### PR TITLE
feat(gcs): Create unit tests + benchmarks

### DIFF
--- a/pkg/google/gcs/bucket_cache.go
+++ b/pkg/google/gcs/bucket_cache.go
@@ -13,14 +13,15 @@ type BucketCache struct {
 
 func (c *BucketCache) Get(project string) []*storage.BucketAttrs {
 	c.m.RLock()
-	defer c.m.RUnlock()
-	return c.Buckets[project]
+	buckets := c.Buckets[project]
+	c.m.RUnlock()
+	return buckets
 }
 
 func (c *BucketCache) Set(project string, buckets []*storage.BucketAttrs) {
 	c.m.Lock()
-	defer c.m.Unlock()
 	c.Buckets[project] = buckets
+	c.m.Unlock()
 }
 
 func NewBucketCache() *BucketCache {

--- a/pkg/google/gcs/bucket_cache_test.go
+++ b/pkg/google/gcs/bucket_cache_test.go
@@ -1,0 +1,93 @@
+package gcs
+
+import (
+	"strconv"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBucketCache_Get(t *testing.T) {
+	tests := map[string]struct {
+		want     int
+		error    assert.ErrorAssertionFunc
+		projects []string
+		buckets  []*storage.BucketAttrs
+	}{
+		"empty": {
+			want:  0,
+			error: assert.Error,
+		},
+		"one": {
+			want:     1,
+			projects: []string{"test"},
+			buckets:  generateNBuckets(1),
+		},
+		"ten": {
+			want:     10,
+			projects: []string{"test"},
+			buckets:  generateNBuckets(10),
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			bucketCache := NewBucketCache()
+			for _, project := range tt.projects {
+				bucketCache.Set(project, tt.buckets)
+			}
+			for _, project := range tt.projects {
+				buckets := bucketCache.Get(project)
+				assert.Equal(t, tt.want, len(buckets))
+			}
+		})
+	}
+}
+
+func BenchmarkBucketCache_Get(b *testing.B) {
+	bucketCache := NewBucketCache()
+	buckets := generateNBuckets(1000)
+	bucketCache.Set("test", buckets)
+	for i := 0; i < b.N; i++ {
+		bucketCache.Get("test")
+	}
+}
+
+func BenchmarkBucketCache_GetParallel(b *testing.B) {
+	bucketCache := NewBucketCache()
+	buckets := generateNBuckets(1000)
+	bucketCache.Set("test", buckets)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			bucketCache.Get("test")
+		}
+	})
+}
+
+func BenchmarkBucketCache_Set(b *testing.B) {
+	bucketCache := NewBucketCache()
+	buckets := generateNBuckets(1000)
+	for i := 0; i < b.N; i++ {
+		bucketCache.Set(strconv.Itoa(i), buckets)
+	}
+}
+
+func BenchmarkBucketCache_SetParallel(b *testing.B) {
+	bucketCache := NewBucketCache()
+	buckets := generateNBuckets(1000)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			bucketCache.Set("test", buckets)
+		}
+	})
+}
+
+func generateNBuckets(n int) []*storage.BucketAttrs {
+	buckets := make([]*storage.BucketAttrs, n)
+	for i := 0; i < n; i++ {
+		buckets[i] = &storage.BucketAttrs{
+			Name: "test",
+		}
+	}
+	return buckets
+}

--- a/pkg/google/gcs/gcs_test.go
+++ b/pkg/google/gcs/gcs_test.go
@@ -467,7 +467,6 @@ func (s *fakeCloudBillingServer) ListSkus(_ context.Context, _ *billingpb.ListSk
 }
 
 func TestGetServiceNameByReadableName(t *testing.T) {
-
 	// We can't follow AWS's example as the CloudCatalogClient returns an iterator that has private fields that we can't easily override
 	// Let's try to see if we can use an httptest server to mock the response
 	tests := map[string]struct {


### PR DESCRIPTION
Introduces unit tests and benchmarks for the bucket_cache.go file. It was raised during implementation that using `defer` has a performance penalty, but I wanted to use benchmarks to measure it. By removing defers, we end up with roughly 5% performance gains. In practice though, this should be minor and have negligible impact on overall performance.