### PR TITLE
fix(s3): Fix flaky tests

### DIFF
--- a/pkg/aws/s3/s3.go
+++ b/pkg/aws/s3/s3.go
@@ -394,10 +394,16 @@ func exportMetrics(s3BillingData S3BillingData, m Metrics) {
 // unitCostForComponent will calculate the unit cost for a given component. This is necessary because the
 // unit cost will depend on the type of component.
 func unitCostForComponent(component string, pricing *Pricing) float64 {
+	// If the usage is 0, we don't want to divide by 0 which would result in NaN metrics _or_ +Inf
+	// TODO: Assess if we should return the pricing.Cost instead
+	if pricing.Usage == 0 {
+		log.Printf("Usage is 0 for component: %s\n", component)
+		return 0
+	}
+
 	switch component {
 	case "Requests-Tier1", "Requests-Tier2":
-		unitCost := pricing.Cost / (pricing.Usage / 1000)
-		return unitCost
+		return pricing.Cost / (pricing.Usage / 1000)
 	case "TimedStorage":
 		return (pricing.Cost / HoursInMonth) / pricing.Usage
 	default:


### PR DESCRIPTION
We were calling unitCostForComponent on every iteration of metrics, which potentially was causing a flaky test. This moves the call to unitCostForComponent to after generating the entire componentsMap, and has not resulted in a single failed test(100's of runs).

- fixes #51