### PR TITLE
poc(compute): Add cluster label to instance costs

### DIFF
--- a/pkg/google/gke/gke.go
+++ b/pkg/google/gke/gke.go
@@ -1,0 +1,1 @@
+package gke


### PR DESCRIPTION
⚠️ This is only a PoC! Not meant to be merged in until we decide on which approach to take ⚠️ 

Add a cluster attribute to the machineType struct and associated cost metrics.
Cluster name is derived from the instance label `goog-k8s-cluster-name`. Cluster name is set to an empty string if no value xists for the key.

- Closes #68

## Thoughts

The nice part of this approach is it's relatively straight forward to implement and get values for the clusters. There is one _major_ draw back: We need to add a `cluster` label to all metrics emitted, even if they're not part of a GKE cluster. Everything I've gathered is that this will have an impact on queries, dashboards, alerts, and other rules. 