### PR TITLE
Implement image pipeline

### DIFF
--- a/.github/actions/setup-goversion/action.yml
+++ b/.github/actions/setup-goversion/action.yml
@@ -1,3 +1,4 @@
+# This action extracts the go version from Dockerfile and uses this version setup go
 name: setup-goversion
 runs:
   using: composite

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -36,6 +37,7 @@ jobs:
       # Setup buildx
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,6 @@ on:
     branches: [ "main" ]
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
ref: #80 

The PR implements the image pipeline for cloudcost-exporter. It will not build the images pre merge, as the arm64 build takes 12 minutes currently. Instead we will execute all steps on merge and produce an image with every merged PR.

Small drive-by: I toke @zerok solution to detect the go version from the Dockerfile to build the tests.