### PR TITLE
fix(persistentvolues): Properly handle searching for storage classes

### DIFF
--- a/pkg/google/billing/billing_test_helpers.go
+++ b/pkg/google/billing/billing_test_helpers.go
@@ -198,6 +198,23 @@ func (s *FakeCloudCatalogServer) ListSkus(_ context.Context, req *billingpb.List
 					},
 				}},
 			},
+			{
+				Name:           "SSD Storage",
+				Description:    "SSD backed PD Capacity",
+				ServiceRegions: []string{"us-east4"},
+				Category: &billingpb.Category{
+					ResourceFamily: "Storage",
+				},
+				PricingInfo: []*billingpb.PricingInfo{{
+					PricingExpression: &billingpb.PricingExpression{
+						TieredRates: []*billingpb.PricingExpression_TierRate{{
+							UnitPrice: &money.Money{
+								Nanos: 187000000,
+							},
+						}},
+					},
+				}},
+			},
 		},
 	}, nil
 }

--- a/pkg/google/compute/pricing_map_test.go
+++ b/pkg/google/compute/pricing_map_test.go
@@ -371,6 +371,19 @@ func TestGeneratePricingMap(t *testing.T) {
 						}},
 					},
 				}},
+			}, {
+				Description:    "Regional Balanced PD Capacity",
+				Category:       &billingpb.Category{ResourceFamily: "Storage"},
+				ServiceRegions: []string{"europe-west1"},
+				PricingInfo: []*billingpb.PricingInfo{{
+					PricingExpression: &billingpb.PricingExpression{
+						TieredRates: []*billingpb.PricingExpression_TierRate{{
+							UnitPrice: &money.Money{
+								Nanos: 1e9 * 2,
+							},
+						}},
+					},
+				}},
 			}},
 			expectedPricingMap: &StructuredPricingMap{
 				Storage: map[string]*StoragePricing{
@@ -404,6 +417,48 @@ func TestGeneratePricingMap(t *testing.T) {
 					"europe-west1": {
 						Storage: map[string]float64{
 							"pd-extreme": 1.0 / utils.HoursInMonth,
+						},
+					},
+				},
+				Compute: map[string]*FamilyPricing{},
+			},
+		},
+		{
+			name: "us-east-4 region with many skus",
+			skus: []*billingpb.Sku{{
+				Description:    "SSD backed PD Capacity",
+				Category:       &billingpb.Category{ResourceFamily: "Storage"},
+				ServiceRegions: []string{"us-east4"},
+				PricingInfo: []*billingpb.PricingInfo{{
+					PricingExpression: &billingpb.PricingExpression{
+						TieredRates: []*billingpb.PricingExpression_TierRate{{
+							UnitPrice: &money.Money{
+								Nanos: 187000000,
+							},
+						}},
+					},
+				}},
+			},
+				{
+					Description:    "Regional SSD backed PD Capacity",
+					Category:       &billingpb.Category{ResourceFamily: "Storage"},
+					ServiceRegions: []string{"us-east4"},
+					PricingInfo: []*billingpb.PricingInfo{{
+						PricingExpression: &billingpb.PricingExpression{
+							TieredRates: []*billingpb.PricingExpression_TierRate{{
+								UnitPrice: &money.Money{
+									Nanos: 187000000 * 2,
+								},
+							}},
+						},
+					}},
+				},
+			},
+			expectedPricingMap: &StructuredPricingMap{
+				Storage: map[string]*StoragePricing{
+					"us-east4": {
+						Storage: map[string]float64{
+							"pd-ssd": 187000000 * 1e-9 / utils.HoursInMonth,
 						},
 					},
 				},

--- a/pkg/google/gke/gke.go
+++ b/pkg/google/gke/gke.go
@@ -185,8 +185,10 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 					project,
 					storageClass,
 				}
+
 				price, err := c.ComputePricingMap.GetCostOfStorage(region, storageClass)
 				if err != nil {
+
 					fmt.Printf("%s error getting cost of storage: %v\n", disk.Name, err)
 					continue
 				}

--- a/pkg/google/gke/gke_test.go
+++ b/pkg/google/gke/gke_test.go
@@ -175,6 +175,20 @@ func TestCollector_Collect(t *testing.T) {
 					MetricType: prometheus.GaugeValue,
 				},
 				{
+					FqName: "cloudcost_gcp_gke_persistent_volume_usd_per_gib_hour",
+					Labels: map[string]string{
+						"cluster_name":     "test",
+						"namespace":        "cloudcost-exporter",
+						"persistentvolume": "test-ssd-disk",
+						"region":           "us-east4",
+						"project":          "testing",
+						"storage_class":    "pd-ssd",
+					},
+					Value:      0.15359342915811086,
+					MetricType: prometheus.GaugeValue,
+				},
+				{
+
 					FqName: "cloudcost_gcp_gke_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n1",
@@ -357,6 +371,16 @@ func TestCollector_Collect(t *testing.T) {
 								},
 								Description: `{"kubernetes.io/created-for/pvc/namespace":"cloudcost-exporter"}`,
 								Type:        "pd-standard",
+							},
+							{
+								Name: "test-ssd-disk",
+								Zone: "testing/us-east4",
+								Labels: map[string]string{
+									compute.GkeClusterLabel: "test",
+								},
+								Description: `{"kubernetes.io/created-for/pvc/namespace":"cloudcost-exporter"}`,
+								Type:        "pd-ssd",
+								SizeGb:      600,
 							},
 						},
 					}


### PR DESCRIPTION
This adds tests to validate that regional sku's were overwriting standard, ssd, and balanced disks costs which effectively was doubling the cost per persistent volume.

The fix is to check if the description starts with the storage class as opposed to simply checking if it Contains. Typically what you would see is a Description like `Regional Storage backed PD Capacity` which would return true when checking if it contains `Storage backed PD Capacity`.

- fixes #137