### PR TITLE
fix(google): Deduplicate disks to export

### DIFF
--- a/pkg/google/gke/gke.go
+++ b/pkg/google/gke/gke.go
@@ -169,6 +169,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 				)
 			}
 		}
+		seenDisks := make(map[string]bool)
 		for group := range disks {
 			for _, disk := range group {
 				clusterName := disk.Labels[gcpCompute.GkeClusterLabel]
@@ -176,6 +177,10 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 
 				namespace := getNamespaceFromDisk(disk)
 				name := getNameFromDisk(disk)
+				if _, ok := seenDisks[name]; ok {
+					continue
+				}
+				seenDisks[name] = true
 				diskType := strings.Split(disk.Type, "/")
 				storageClass := diskType[len(diskType)-1]
 				labelValues := []string{

--- a/pkg/google/gke/gke_test.go
+++ b/pkg/google/gke/gke_test.go
@@ -382,6 +382,17 @@ func TestCollector_Collect(t *testing.T) {
 								Type:        "pd-ssd",
 								SizeGb:      600,
 							},
+							{
+								// Introduce a duplicated disk to ensure the duplicate doesn't cause an issue emitting metrics
+								Name: "test-ssd-disk",
+								Zone: "testing/us-east4",
+								Labels: map[string]string{
+									compute.GkeClusterLabel: "test",
+								},
+								Description: `{"kubernetes.io/created-for/pvc/namespace":"cloudcost-exporter"}`,
+								Type:        "pd-ssd",
+								SizeGb:      600,
+							},
 						},
 					}
 				default:


### PR DESCRIPTION
Introduce a simple map to keep track of seen disks to ensure we do not emit metrics for disks already seen.

- closes #143
- refs #5