### PR TITLE
Fix/aws s3 collect multiple profiles

### DIFF
--- a/cmd/exporter/config/config.go
+++ b/cmd/exporter/config/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	ProjectID string
 	Providers struct {
 		AWS struct {
+			Profile  string
 			Profiles StringSliceFlag
 			Region   string
 			Services StringSliceFlag

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -28,7 +28,8 @@ import (
 
 func providerFlags(fs *flag.FlagSet, cfg *config.Config) {
 	flag.StringVar(&cfg.Provider, "provider", "aws", "aws or gcp")
-	fs.Var(&cfg.Providers.AWS.Profiles, "aws.profile", "AWS profile(s).")
+	fs.StringVar(&cfg.Providers.AWS.Profile, "aws.profile", "", "AWS Profile to authenticate with.")
+	fs.Var(&cfg.Providers.AWS.Profiles, "aws.profiles", "AWS Profiles to collect resources from.")
 	// TODO: RENAME THIS TO JUST PROJECTS
 	fs.Var(&cfg.Providers.GCP.Projects, "gcp.bucket-projects", "GCP project(s).")
 	fs.Var(&cfg.Providers.AWS.Services, "aws.services", "AWS service(s).")
@@ -51,7 +52,8 @@ func selectProvider(cfg *config.Config) (provider.Provider, error) {
 	case "aws":
 		return aws.New(&aws.Config{
 			Region:         cfg.Providers.AWS.Region,
-			Profile:        cfg.Providers.AWS.Profiles.String(),
+			Profile:        cfg.Providers.AWS.Profile,
+			Profiles:       strings.Split(cfg.Providers.AWS.Profiles.String(), ","),
 			ScrapeInterval: cfg.Collector.ScrapeInterval,
 			Services:       strings.Split(cfg.Providers.AWS.Services.String(), ","),
 		})

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -118,7 +118,7 @@ func New(config *Config) (*AWS, error) {
 			}
 
 			client := costexplorer.NewFromConfig(ac)
-			collector, err := s3.New(config.ScrapeInterval, client)
+			collector, err := s3.New(config.ScrapeInterval, client, config.Profiles, config.Region)
 			if err != nil {
 				return nil, fmt.Errorf("error creating s3 collector: %w", err)
 			}

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -20,6 +20,7 @@ type Config struct {
 	Services       []string
 	Region         string
 	Profile        string
+	Profiles       []string
 	ScrapeInterval time.Duration
 }
 


### PR DESCRIPTION
- fixes https://github.com/grafana/cloudcost-exporter/issues/173

Cherry picked a change from https://github.com/grafana/cloudcost-exporter/pull/169 to extend the configuration for
AWS to have profiles which represents the profiles you want to pill data
from.

Updated `aws/s3` to become aware of multiple profiles and create a new
costexplorer client per profile when fetching billing data.
Updated `s3.parseBillingData` to return a slice of outputs so that we
can merge them with other profiles before parsing out billing data.