### PR TITLE
fix(gcp): Remove GB to GiB conversation on disk size

### DIFF
--- a/pkg/google/gke/README.md
+++ b/pkg/google/gke/README.md
@@ -34,7 +34,7 @@ For simplicity, `cloudcost-exporter` has implemented the following disk types:
 - Local SSD
 
 According to the [documentation](https://cloud.google.com/compute/disks-image-pricing#disk-and-image-pricing), pricing for storage is for [JEDEC Binary GB or IEC gibibytes(GiB)](https://en.wikipedia.org/wiki/Gigabyte).
-One of the more confusing bits is that the Documentation for disk implies that the size is in GB, but doesn't specify if it's in GB or GiB.
-The initial assumption was to convert the size to GiB, however after collecting data for a month and comparing against billing, we were off by just about ~7%.
-Coincidentally, the conversion from GB to GiB is ~7%, so we removed the code to convert from GB to GiB.
+One of the more confusing bits is that the documentation for [disk](https://pkg.go.dev/google.golang.org/api/compute/v1#Disk) implies that the size is in GB, but doesn't specify if it's a [decimal GB or Binary GB](https://en.wikipedia.org/wiki/Gigabyte).
+`cloudcost-exporter` is assuming that the size is in binary GB which aligns with the pricing documentation.
+
 

--- a/pkg/google/gke/README.md
+++ b/pkg/google/gke/README.md
@@ -18,3 +18,23 @@ The primary motivation for this module was to ensure we could support the follow
 
 See the [Design Doc](https://docs.google.com/document/d/1nCU1SVsuJ4HpV6R-N-AFBaDI5AJmSS3q9jH8_h-_Y8s/edit) for the rationale for a separate module.
 TL;DR; We do not want to emit metrics with a `exporter_cluster` label that is empty or make the setup process more complex needed.
+
+## Disk Pricing
+
+Running the `gke` module also collects costs associated with Persistent Volumes.
+Persistent Volumes are attached to GKE instances and are billed as [disks](https://cloud.google.com/compute/disks-image-pricing).
+The price is based off of a combination of the following attributes:
+- region
+- disk type
+- disk size
+
+For simplicity, `cloudcost-exporter` has implemented the following disk types:
+- Standard(hard disk drives)
+- SSD(solid state drives)
+- Local SSD
+
+According to the [documentation](https://cloud.google.com/compute/disks-image-pricing#disk-and-image-pricing), pricing for storage is for [JEDEC Binary GB or IEC gibibytes(GiB)](https://en.wikipedia.org/wiki/Gigabyte).
+One of the more confusing bits is that the Documentation for disk implies that the size is in GB, but doesn't specify if it's in GB or GiB.
+The initial assumption was to convert the size to GiB, however after collecting data for a month and comparing against billing, we were off by just about ~7%.
+Coincidentally, the conversion from GB to GiB is ~7%, so we removed the code to convert from GB to GiB.
+

--- a/pkg/google/gke/disk.go
+++ b/pkg/google/gke/disk.go
@@ -126,14 +126,3 @@ func (d Disk) DiskType() string {
 	}
 	return "persistent_volume"
 }
-
-// GBPerGIB is a helper const to convert from GB to GiB
-// 1 << 30 is the number of bytes in a GiB
-// 1e9 is the number of bytes in a GB
-const GBPerGIB = 1e9 / (1 << 30)
-
-// SizeInGib is used to convert the size of the disk from GigaBytes to GibiBytes. This is particularly important when
-// calculating the cost of the disk since the pricing is in GiB.
-func (d Disk) SizeInGib() float64 {
-	return float64(d.Size) * GBPerGIB
-}

--- a/pkg/google/gke/disk_test.go
+++ b/pkg/google/gke/disk_test.go
@@ -242,30 +242,3 @@ func Test_DiskType(t *testing.T) {
 		})
 	}
 }
-
-func TestDisk_SizeInGib(t *testing.T) {
-	tests := map[string]struct {
-		disk *Disk
-		want float64
-	}{
-		"Disk with size 0 should return 0": {
-			disk: NewDisk(&computev1.Disk{
-				SizeGb: 0,
-			}, ""),
-			want: 0,
-		},
-		"Disk with size 1GB should return 1GiB": {
-			disk: NewDisk(&computev1.Disk{
-				SizeGb: 1,
-			}, ""),
-			want: 0.9313225746154785,
-		},
-	}
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			if got := tt.disk.SizeInGib(); got != tt.want {
-				t.Errorf("SizeInGib() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}

--- a/pkg/google/gke/gke.go
+++ b/pkg/google/gke/gke.go
@@ -193,7 +193,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 				ch <- prometheus.MustNewConstMetric(
 					persistentVolumeHourlyCostDesc,
 					prometheus.GaugeValue,
-					d.SizeInGib()*price,
+					float64(d.Size)*price,
 					labelValues...,
 				)
 			}

--- a/pkg/google/gke/gke_test.go
+++ b/pkg/google/gke/gke_test.go
@@ -186,7 +186,7 @@ func TestCollector_Collect(t *testing.T) {
 						"storage_class":    "pd-ssd",
 						"disk_type":        "persistent_volume",
 					},
-					Value:      0.14304502788755194,
+					Value:      0.15359342915811086,
 					MetricType: prometheus.GaugeValue,
 				},
 				{


### PR DESCRIPTION
I believe the documentation for GCP's api is misleading and that we do not need to convert from GB to GiB when calculating the cost of a disk. This was observed by comparing the measured costs vs our bill over a period of a month and found that we were off by ~7%.

Removes the methods to convert disk.Size to GiB.