### PR TITLE
feat(logger): Convert to using slog

### DIFF
--- a/cmd/exporter/config/config.go
+++ b/cmd/exporter/config/config.go
@@ -29,4 +29,9 @@ type Config struct {
 		Path    string
 		Timeout time.Duration
 	}
+	Logger struct {
+		Level  string // debug, info, warn, error
+		Output string // stdout, stderr
+		Type   string // json, text
+	}
 }

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -100,6 +100,7 @@ const (
 )
 
 func New(config *Config, logger *slog.Logger) (*AWS, error) {
+	logger = logger.With("provider", subsystem)
 	var collectors []provider.Collector
 	// There are two scenarios:
 	// 1. Running locally, the user must pass in a region and profile to use

--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"fmt"
+	"log/slog"
+	"os"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -10,6 +12,7 @@ import (
 
 	"github.com/grafana/cloudcost-exporter/pkg/provider"
 	mock_provider "github.com/grafana/cloudcost-exporter/pkg/provider/mocks"
+	"github.com/grafana/cloudcost-exporter/pkg/utils"
 )
 
 func Test_New(t *testing.T) {
@@ -25,7 +28,7 @@ func Test_New(t *testing.T) {
 			// TODO refactor New()
 			t.SkipNow()
 
-			a, err := New(&Config{})
+			a, err := New(&Config{}, nil)
 			if tc.expectedError != nil {
 				require.EqualError(t, err, tc.expectedError.Error())
 				return
@@ -37,6 +40,9 @@ func Test_New(t *testing.T) {
 }
 
 func Test_RegisterCollectors(t *testing.T) {
+	h := slog.NewTextHandler(os.Stdout, nil)
+	handler := utils.NewLevelHandler(slog.LevelError, h)
+	logger := slog.New(handler)
 	for _, tc := range []struct {
 		name          string
 		numCollectors int
@@ -72,6 +78,7 @@ func Test_RegisterCollectors(t *testing.T) {
 			a := AWS{
 				Config:     nil,
 				collectors: []provider.Collector{},
+				logger:     logger,
 			}
 			for i := 0; i < tc.numCollectors; i++ {
 				a.collectors = append(a.collectors, c)

--- a/pkg/aws/eks/eks_test.go
+++ b/pkg/aws/eks/eks_test.go
@@ -2,6 +2,7 @@ package eks
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"os"
 	"testing"
@@ -360,17 +361,21 @@ func TestNewCollector(t *testing.T) {
 			ec2s:           nil,
 		},
 	}
+	hanlder := utils.NewLevelHandler(slog.LevelError, slog.NewTextHandler(io.Discard, nil))
+	logger := slog.New(hanlder)
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			collector := New(tt.region, tt.profile, tt.scrapeInternal, tt.ps, tt.ec2s, nil, nil, nil)
+			collector := New(tt.region, tt.profile, tt.scrapeInternal, tt.ps, tt.ec2s, nil, nil, logger)
 			assert.NotNil(t, collector)
 		})
 	}
 }
 
 func TestCollector_Name(t *testing.T) {
+	hanlder := utils.NewLevelHandler(slog.LevelError, slog.NewTextHandler(io.Discard, nil))
+	logger := slog.New(hanlder)
 	t.Run("Name should return the same name as the subsystem const", func(t *testing.T) {
-		collector := New("", "", 0, nil, nil, nil, nil, nil)
+		collector := New("", "", 0, nil, nil, nil, nil, logger)
 		assert.Equal(t, subsystem, collector.Name())
 	})
 }

--- a/pkg/aws/s3/s3.go
+++ b/pkg/aws/s3/s3.go
@@ -148,6 +148,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 
 // New creates a new Collector with a client and scrape interval defined.
 func New(scrapeInterval time.Duration, client costexplorer.CostExplorer, logger *slog.Logger) *Collector {
+	logger = logger.With("collector", "s3")
 	return &Collector{
 		client:   client,
 		interval: scrapeInterval,

--- a/pkg/aws/s3/s3_test.go
+++ b/pkg/aws/s3/s3_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/csv"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"strings"
@@ -177,11 +178,13 @@ func TestNewCollector(t *testing.T) {
 			want: &Collector{},
 		},
 	}
+	hanlder := utils.NewLevelHandler(slog.LevelError, slog.NewTextHandler(io.Discard, nil))
+	logger := slog.New(hanlder)
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			c := mockcostexplorer.NewCostExplorer(t)
 
-			got := New(tt.args.interval, c, nil)
+			got := New(tt.args.interval, c, logger)
 			assert.NotNil(t, got)
 			assert.Equal(t, tt.args.interval, got.interval)
 		})

--- a/pkg/google/billing/billing.go
+++ b/pkg/google/billing/billing.go
@@ -3,7 +3,8 @@ package billing
 import (
 	"context"
 	"errors"
-	"log"
+	"log/slog"
+	"os"
 
 	billingv1 "cloud.google.com/go/billing/apiv1"
 	"cloud.google.com/go/billing/apiv1/billingpb"
@@ -11,6 +12,8 @@ import (
 )
 
 var ServiceNotFound = errors.New("service not found")
+
+var logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 // GetServiceName will search for a service by the display name and return the full name.
 // The full name is need by the GetPricing method to collect all the pricing information for a given service.
@@ -41,7 +44,7 @@ func GetPricing(ctx context.Context, billingService *billingv1.CloudCatalogClien
 			if errors.Is(err, iterator.Done) {
 				break
 			}
-			log.Println(err) // keep going if we get an error
+			logger.Warn("error iterating over billing data", "error", err) // keep going if we get an error
 		}
 		skus = append(skus, sku)
 	}

--- a/pkg/google/compute/compute.go
+++ b/pkg/google/compute/compute.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
@@ -60,6 +61,7 @@ type Collector struct {
 	config         *Config
 	Projects       []string
 	NextScrape     time.Time
+	logger         *slog.Logger
 }
 
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
@@ -78,13 +80,15 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 }
 
 // New is a helper method to properly set up a compute.Collector struct.
-func New(config *Config, computeService *compute.Service, billingService *billingv1.CloudCatalogClient) *Collector {
+func New(config *Config, computeService *compute.Service, billingService *billingv1.CloudCatalogClient, logger *slog.Logger) *Collector {
+	logger = logger.With("collector", "compute")
 	projects := strings.Split(config.Projects, ",")
 	return &Collector{
 		computeService: computeService,
 		billingService: billingService,
 		config:         config,
 		Projects:       projects,
+		logger:         logger,
 	}
 }
 

--- a/pkg/google/gcs/gcs.go
+++ b/pkg/google/gcs/gcs.go
@@ -266,7 +266,7 @@ func (c *Collector) CollectMetrics(ch chan<- prometheus.Metric) float64 {
 		c.logger.LogAttrs(context.TODO(),
 			slog.LevelError,
 			"Error exporting regional discounts",
-			slog.String("message", err.Error())
+			slog.String("message", err.Error()),
 		)
 	}
 	err = ExportBucketInfo(c.ctx, c.bucketClient, c.Projects, c.CachedBuckets, c.metrics)

--- a/pkg/google/gke/disk.go
+++ b/pkg/google/gke/disk.go
@@ -32,6 +32,9 @@ type Disk struct {
 
 func NewDisk(disk *compute.Disk, project string) *Disk {
 	clusterName := disk.Labels[gcpCompute.GkeClusterLabel]
+	if clusterName == "" {
+		log.Printf("disk(%s) is not associated with a GKE cluster", disk.Name)
+	}
 	d := &Disk{
 		Cluster:     clusterName,
 		Project:     project,

--- a/pkg/google/gke/gke.go
+++ b/pkg/google/gke/gke.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
@@ -59,6 +60,7 @@ type Collector struct {
 	Projects          []string
 	ComputePricingMap *gcpCompute.StructuredPricingMap
 	NextScrape        time.Time
+	logger            *slog.Logger
 }
 
 func (c *Collector) Register(_ provider.Registry) error {
@@ -202,13 +204,15 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 	return nil
 }
 
-func New(config *Config, computeService *compute.Service, billingService *billingv1.CloudCatalogClient) *Collector {
+func New(config *Config, computeService *compute.Service, billingService *billingv1.CloudCatalogClient, logger *slog.Logger) *Collector {
+	logger = logger.With("collector", "eks")
 	projects := strings.Split(config.Projects, ",")
 	return &Collector{
 		computeService: computeService,
 		billingService: billingService,
 		config:         config,
 		Projects:       projects,
+		logger:         logger,
 	}
 }
 

--- a/pkg/utils/logger.go
+++ b/pkg/utils/logger.go
@@ -52,6 +52,7 @@ func (h *LevelHandler) Handler() slog.Handler {
 	return h.handler
 }
 
+// GetLogLevel parses a string and returns the corresponding slog.Leveler. Returns slog.LevelInfo if the string is not recognized.
 func GetLogLevel(level string) slog.Leveler {
 	switch level {
 	case "debug":
@@ -67,16 +68,19 @@ func GetLogLevel(level string) slog.Leveler {
 	}
 }
 
+// WriterForOutput returns an io.Writer based on the output string. Returns os.Stdout if the string is not recognized.
 func WriterForOutput(output string) io.Writer {
 	switch output {
 	case "stdout":
 		return os.Stdout
 	case "stderr":
 		return os.Stderr
+	default:
+		return os.Stdout
 	}
-	return os.Stdout
 }
 
+// HandlerForOutput returns a slog.Handler based on the output string. Returns a slog.NewTextHandler if the string is not recognized.
 func HandlerForOutput(output string, w io.Writer) slog.Handler {
 	switch output {
 	case "json":

--- a/pkg/utils/logger.go
+++ b/pkg/utils/logger.go
@@ -1,0 +1,87 @@
+package utils
+
+// This was copied from the Go standard library (log/level_handler.go) and modified to fit the project's needs.
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+)
+
+// A LevelHandler wraps a Handler with an Enabled method
+// that returns false for levels below a minimum.
+type LevelHandler struct {
+	level   slog.Leveler
+	handler slog.Handler
+}
+
+// NewLevelHandler returns a LevelHandler with the given level.
+// All methods except Enabled delegate to h.
+func NewLevelHandler(level slog.Leveler, h slog.Handler) *LevelHandler {
+	// Optimization: avoid chains of LevelHandlers.
+	if lh, ok := h.(*LevelHandler); ok {
+		h = lh.Handler()
+	}
+	return &LevelHandler{level, h}
+}
+
+// Enabled implements Handler.Enabled by reporting whether
+// level is at least as large as h's level.
+func (h *LevelHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.level.Level()
+}
+
+// Handle implements Handler.Handle.
+func (h *LevelHandler) Handle(ctx context.Context, r slog.Record) error {
+	return h.handler.Handle(ctx, r)
+}
+
+// WithAttrs implements Handler.WithAttrs.
+func (h *LevelHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return NewLevelHandler(h.level, h.handler.WithAttrs(attrs))
+}
+
+// WithGroup implements Handler.WithGroup.
+func (h *LevelHandler) WithGroup(name string) slog.Handler {
+	return NewLevelHandler(h.level, h.handler.WithGroup(name))
+}
+
+// Handler returns the Handler wrapped by h.
+func (h *LevelHandler) Handler() slog.Handler {
+	return h.handler
+}
+
+func GetLogLevel(level string) slog.Leveler {
+	switch level {
+	case "debug":
+		return slog.LevelDebug
+	case "info":
+		return slog.LevelInfo
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+func WriterForOutput(output string) io.Writer {
+	switch output {
+	case "stdout":
+		return os.Stdout
+	case "stderr":
+		return os.Stderr
+	}
+	return os.Stdout
+}
+
+func HandlerForOutput(output string, w io.Writer) slog.Handler {
+	switch output {
+	case "json":
+		return slog.NewJSONHandler(w, nil)
+	default:
+		return slog.NewTextHandler(w, nil)
+	}
+}


### PR DESCRIPTION
This introduces using slog as a structured logger for the project. Created a `LevelHandler` struct that is responsible for only logging out messages below a configured log level.
Extended the config object to have a Log configuration to set
- Level
- Output
- Type

Added the following command flags:
- `log.level` (debug, **info**, warn, error)
- `log.output` (**stdout**, stderr)
- `log.type` (json, **text**)

Updated the csp and collector entrypoints to have accept a `*slog.Logger` parameter.
Started updating existing log.Printf statements to use appropriate logging.

TODO:
- [ ] Update all collectors to accept a logger parameter
- [ ] Determine best way to pass logger to helper methods that current log out via `log.Printf`

- relates #32