### PR TITLE
Feat/add leveled logger interface

### DIFF
--- a/cmd/exporter/config/config.go
+++ b/cmd/exporter/config/config.go
@@ -29,4 +29,9 @@ type Config struct {
 		Path    string
 		Timeout time.Duration
 	}
+	Logger struct {
+		Level  string // Maps to slog levels: debug, info, warn, error
+		Output string // io.Writer interface to write out to: stdout, stderr, file
+		Type   string // How to write out the logs: json, text
+	}
 }

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"log/slog"
 	"net/http"
 	"os/signal"
 	"strings"
@@ -23,9 +24,38 @@ import (
 	"github.com/grafana/cloudcost-exporter/cmd/exporter/web"
 	"github.com/grafana/cloudcost-exporter/pkg/aws"
 	"github.com/grafana/cloudcost-exporter/pkg/google"
+	"github.com/grafana/cloudcost-exporter/pkg/logger"
 	"github.com/grafana/cloudcost-exporter/pkg/provider"
 )
 
+func main() {
+	var cfg config.Config
+	providerFlags(flag.CommandLine, &cfg)
+	operationalFlags(&cfg)
+	flag.Parse()
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	logs := setupLogger(cfg.Logger.Level, cfg.Logger.Output, cfg.Logger.Type)
+	logs.LogAttrs(ctx, slog.LevelInfo, "Starting cloudcost-exporter",
+		slog.String("version", cversion.Info()),
+		slog.String("build_context", cversion.BuildContext()),
+	)
+
+	csp, err := selectProvider(&cfg)
+	if err != nil {
+		log.Fatalf("Error setting up provider %s: %s", cfg.Provider, err)
+	}
+
+	err = runServer(ctx, &cfg, csp, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// providerFlags is a helper method that is responsible for setting up the flags that are used to configure the provider.
+// TODO: This should probably be moved over to the config package.
 func providerFlags(fs *flag.FlagSet, cfg *config.Config) {
 	flag.StringVar(&cfg.Provider, "provider", "aws", "aws or gcp")
 	fs.StringVar(&cfg.Providers.AWS.Profile, "aws.profile", "", "AWS Profile to authenticate with.")
@@ -39,6 +69,8 @@ func providerFlags(fs *flag.FlagSet, cfg *config.Config) {
 	flag.IntVar(&cfg.Providers.GCP.DefaultGCSDiscount, "gcp.default-discount", 19, "GCP default discount")
 }
 
+// operationalFlags is a helper method that is responsible for setting up the flags that are used to configure the operational aspects of the application.
+// TODO: This should probably be moved over to the config package.
 func operationalFlags(cfg *config.Config) {
 	flag.DurationVar(&cfg.Collector.ScrapeInterval, "scrape-interval", 1*time.Hour, "Scrape interval")
 	flag.DurationVar(&cfg.Server.Timeout, "server-timeout", 30*time.Second, "Server timeout")
@@ -47,6 +79,68 @@ func operationalFlags(cfg *config.Config) {
 	flag.StringVar(&cfg.Logger.Level, "log.level", "info", "Log level")
 	flag.StringVar(&cfg.Logger.Output, "log.output", "stdout", "Log output")
 	flag.StringVar(&cfg.Logger.Type, "log.type", "text", "Log type")
+}
+
+// setupLogger is a helper method that is responsible for creating a structured logger that is used throughout the application.
+// It sets the log level, output, and type of log.
+func setupLogger(level string, output string, logtype string) *slog.Logger {
+	handler := logger.NewLevelHandler(logger.GetLogLevel(level), logger.HandlerForOutput(logtype, logger.WriterForOutput(output)))
+	return slog.New(handler)
+}
+
+// runServer is a helper method that is responsible for starting the metrics server and handling shutdown signals.
+func runServer(ctx context.Context, cfg *config.Config, csp provider.Provider, log *slog.Logger) error {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", web.HomePageHandler(cfg.Server.Path))   // landing page
+	mux.Handle(cfg.Server.Path, createPromRegistryHandler(csp)) // prom metrics handler
+
+	server := &http.Server{Addr: cfg.Server.Address, Handler: mux}
+	errChan := make(chan error)
+
+	go func() {
+		log.LogAttrs(ctx, slog.LevelInfo, "Starting server",
+			slog.String("address", cfg.Server.Address),
+			slog.String("path", cfg.Server.Path))
+		errChan <- server.ListenAndServe()
+	}()
+
+	select {
+	case <-ctx.Done():
+		log.LogAttrs(ctx, slog.LevelInfo, "Shutting down server")
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.Server.Timeout)
+		defer cancel()
+
+		err := server.Shutdown(ctx)
+		if err != nil {
+			return fmt.Errorf("error shutting down server: %w", err)
+		}
+	case err := <-errChan:
+		if !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("error running server: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func createPromRegistryHandler(csp provider.Provider) http.Handler {
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(
+		collectors.NewBuildInfoCollector(),
+		collectors.NewGoCollector(),
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+		version.NewCollector(cloudcost_exporter.ExporterName),
+		csp,
+	)
+	err := csp.RegisterCollectors(registry)
+	if err != nil {
+		log.Fatalf("Error registering collectors: %s", err)
+	}
+	// CollectMetrics http server for prometheus
+	return promhttp.HandlerFor(registry, promhttp.HandlerOpts{
+		EnableOpenMetrics: true,
+	})
 }
 
 func selectProvider(cfg *config.Config) (provider.Provider, error) {
@@ -71,80 +165,5 @@ func selectProvider(cfg *config.Config) (provider.Provider, error) {
 
 	default:
 		return nil, fmt.Errorf("unknown provider")
-	}
-}
-
-func createPromRegistryHandler(csp provider.Provider) http.Handler {
-	registry := prometheus.NewRegistry()
-	registry.MustRegister(
-		collectors.NewBuildInfoCollector(),
-		collectors.NewGoCollector(),
-		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
-		version.NewCollector(cloudcost_exporter.ExporterName),
-		csp,
-	)
-	err := csp.RegisterCollectors(registry)
-	if err != nil {
-		log.Fatalf("Error registering collectors: %s", err)
-	}
-	// CollectMetrics http server for prometheus
-	return promhttp.HandlerFor(registry, promhttp.HandlerOpts{
-		EnableOpenMetrics: true,
-	})
-}
-
-func runServer(ctx context.Context, cfg *config.Config, csp provider.Provider) error {
-	mux := http.NewServeMux()
-
-	mux.HandleFunc("/", web.HomePageHandler(cfg.Server.Path))   // landing page
-	mux.Handle(cfg.Server.Path, createPromRegistryHandler(csp)) // prom metrics handler
-
-	server := &http.Server{Addr: cfg.Server.Address, Handler: mux}
-	errChan := make(chan error)
-
-	go func() {
-		log.Printf("Listening on %s%s", cfg.Server.Address, cfg.Server.Path)
-		errChan <- server.ListenAndServe()
-	}()
-
-	select {
-	case <-ctx.Done():
-		log.Print("shutting down server")
-		ctx, cancel := context.WithTimeout(context.Background(), cfg.Server.Timeout)
-		defer cancel()
-
-		err := server.Shutdown(ctx)
-		if err != nil {
-			return fmt.Errorf("error shutting down server: %w", err)
-		}
-	case err := <-errChan:
-		if !errors.Is(err, http.ErrServerClosed) {
-			return fmt.Errorf("error running server: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func main() {
-	var cfg config.Config
-	providerFlags(flag.CommandLine, &cfg)
-	operationalFlags(&cfg)
-	flag.Parse()
-
-	log.Printf("Version %s", cversion.Info())
-	log.Printf("Build Context %s", cversion.BuildContext())
-
-	csp, err := selectProvider(&cfg)
-	if err != nil {
-		log.Fatalf("Error setting up provider %s: %s", cfg.Provider, err)
-	}
-
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer cancel()
-
-	err = runServer(ctx, &cfg, csp)
-	if err != nil {
-		log.Fatal(err)
 	}
 }

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -44,6 +44,9 @@ func operationalFlags(cfg *config.Config) {
 	flag.DurationVar(&cfg.Server.Timeout, "server-timeout", 30*time.Second, "Server timeout")
 	flag.StringVar(&cfg.Server.Address, "server.address", ":8080", "Default address for the server to listen on.")
 	flag.StringVar(&cfg.Server.Path, "server.path", "/metrics", "Default path for the server to listen on.")
+	flag.StringVar(&cfg.Logger.Level, "log.level", "info", "Log level")
+	flag.StringVar(&cfg.Logger.Output, "log.output", "stdout", "Log output")
+	flag.StringVar(&cfg.Logger.Type, "log.type", "text", "Log type")
 }
 
 func selectProvider(cfg *config.Config) (provider.Provider, error) {

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -116,7 +116,6 @@ func runServer(ctx context.Context, cfg *config.Config, csp provider.Provider, l
 
 	select {
 	case <-ctx.Done():
-		log.Info("Context done", slog.String("test", "this"))
 		log.LogAttrs(ctx, slog.LevelInfo, "Shutting down server")
 		ctx, cancel := context.WithTimeout(context.Background(), cfg.Server.Timeout)
 		defer cancel()

--- a/docs/contribute/logging.md
+++ b/docs/contribute/logging.md
@@ -14,7 +14,7 @@ With `slog` being part of Go's stdlib since 1.21, we decided to use it as the lo
 1. Every provider _must_ accept a `*slog.Logger` in the constructor
 1. Every collector _must_ accept a `*slog.Logger` in the constructor
 1. Each provider and collector _must_ add a `provider` or `collector` group when initializing using the [slog.WithGroup](https://pkg.go.dev/golang.org/x/exp/slog#Logger.WithGroup) method
-1. Always prefer to use the `logger.WithAttr(...)` method to add structured data to the log message for both performance and consistency
+1. Always prefer to use the `logger.WithAttr(...)` method to add structured data to the log message for both performance and consistency(see [slog blog post](https://go.dev/blog/slog) and search Performance section for more information)
 
 ## Expanding the logging
 

--- a/docs/contribute/logging.md
+++ b/docs/contribute/logging.md
@@ -15,6 +15,7 @@ With `slog` being part of Go's stdlib since 1.21, we decided to use it as the lo
 1. Every collector _must_ accept a `*slog.Logger` in the constructor
 1. Each provider and collector _must_ add a `provider` or `collector` group when initializing using the [slog.WithGroup](https://pkg.go.dev/golang.org/x/exp/slog#Logger.WithGroup) method
 1. Always prefer to use the `logger.WithAttr(...)` method to add structured data to the log message for both performance and consistency(see [slog blog post](https://go.dev/blog/slog) and search Performance section for more information)
+   - NB: If you do not have any additional fields to log out, then you can use the `logger.Info("message")` methods
 
 ## Expanding the logging
 

--- a/docs/contribute/logging.md
+++ b/docs/contribute/logging.md
@@ -13,7 +13,7 @@ With `slog` being part of Go's stdlib since 1.21, we decided to use it as the lo
 
 1. Every provider _must_ accept a `*slog.Logger` in the constructor
 1. Every collector _must_ accept a `*slog.Logger` in the constructor
-1. Each provider and collect _must_ add a `provider` or `collector` group when initializing using the [slog.WithGroup](https://pkg.go.dev/golang.org/x/exp/slog#Logger.WithGroup) method
+1. Each provider and collector _must_ add a `provider` or `collector` group when initializing using the [slog.WithGroup](https://pkg.go.dev/golang.org/x/exp/slog#Logger.WithGroup) method
 1. Always prefer to use the `logger.WithAttr(...)` method to add structured data to the log message for both performance and consistency
 
 ## Expanding the logging

--- a/docs/contribute/logging.md
+++ b/docs/contribute/logging.md
@@ -1,0 +1,22 @@
+# Logging
+
+`cloudcost-exporter` codebase has grown to the point where we need to have some form of structured logging. 
+The initial commit was introduced `db82ae9ccdfddc010492f4739724c8e67ef40851` with a fairly detailed messaged on the requirements and the approach.
+The very short is we needed:
+
+1. Structured logging with consistent labels across providers and collectors
+2. Ability to define a log level and runtime that limits the logs emitted
+
+With `slog` being part of Go's stdlib since 1.21, we decided to use it as the logging library with a wrapper so that we can get log levels as well.
+
+## Guidelines
+
+1. Every provider _must_ accept a `*slog.Logger` in the constructor
+1. Every collector _must_ accept a `*slog.Logger` in the constructor
+1. Each provider and collect _must_ add a `provider` or `collector` group when initializing using the [slog.WithGroup](https://pkg.go.dev/golang.org/x/exp/slog#Logger.WithGroup) method
+1. Always prefer to use the `logger.WithAttr(...)` method to add structured data to the log message for both performance and consistency
+
+## Expanding the logging
+
+If you need more flexibility or need to expand the logger, please file an [issue](https://github.com/grafana/cloudcost-exporter/issues/new) with the requirements and we can discuss the best way to implement it.
+

--- a/docs/contribute/logging.md
+++ b/docs/contribute/logging.md
@@ -18,5 +18,5 @@ With `slog` being part of Go's stdlib since 1.21, we decided to use it as the lo
 
 ## Expanding the logging
 
-If you need more flexibility or need to expand the logger, please file an [issue](https://github.com/grafana/cloudcost-exporter/issues/new) with the requirements and we can discuss the best way to implement it.
+If you need more flexibility or need to expand the logger, please file an [issue](https://github.com/grafana/cloudcost-exporter/issues/new) with the requirements, and we can discuss the best way to implement it.
 

--- a/pkg/logger/level.go
+++ b/pkg/logger/level.go
@@ -1,0 +1,89 @@
+package logger
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+)
+
+// A LevelHandler wraps a Handler with an Enabled method
+// that returns false for levels below a minimum.
+type LevelHandler struct {
+	level   slog.Leveler
+	handler slog.Handler
+}
+
+// NewHandler returns a LevelHandler with the given level.
+// All methods except Enabled delegate to h.
+func NewHandler(level slog.Leveler, h slog.Handler) *LevelHandler {
+	// Optimization: avoid chains of LevelHandlers.
+	if lh, ok := h.(*LevelHandler); ok {
+		h = lh.Handler()
+	}
+	return &LevelHandler{level, h}
+}
+
+// Enabled implements Handler.Enabled by reporting whether
+// level is at least as large as h's level.
+func (h *LevelHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.level.Level()
+}
+
+// Handle implements Handler.Handle.
+func (h *LevelHandler) Handle(ctx context.Context, r slog.Record) error {
+	return h.handler.Handle(ctx, r)
+}
+
+// WithAttrs implements Handler.WithAttrs.
+func (h *LevelHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return NewHandler(h.level, h.handler.WithAttrs(attrs))
+}
+
+// WithGroup implements Handler.WithGroup.
+func (h *LevelHandler) WithGroup(name string) slog.Handler {
+	return NewHandler(h.level, h.handler.WithGroup(name))
+}
+
+// Handler returns the Handler wrapped by h.
+func (h *LevelHandler) Handler() slog.Handler {
+	return h.handler
+}
+
+// GetLogLevel parses a string and returns the corresponding slog.Leveler. Returns slog.LevelInfo if the string is not recognized.
+func GetLogLevel(level string) slog.Leveler {
+	switch level {
+	case "debug":
+		return slog.LevelDebug
+	case "info":
+		return slog.LevelInfo
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+// WriterForOutput returns an io.Writer based on the output string. Returns os.Stdout if the string is not recognized.
+func WriterForOutput(output string) io.Writer {
+	switch output {
+	case "stdout":
+		return os.Stdout
+	case "stderr":
+		return os.Stderr
+	default:
+		return os.Stdout
+	}
+}
+
+// HandlerForOutput returns a slog.Handler based on the output string. Returns a slog.NewTextHandler if the string is not recognized.
+func HandlerForOutput(output string, w io.Writer) slog.Handler {
+	switch output {
+	case "json":
+		return slog.NewJSONHandler(w, nil)
+	default:
+		return slog.NewTextHandler(w, nil)
+	}
+}

--- a/pkg/logger/level.go
+++ b/pkg/logger/level.go
@@ -14,9 +14,9 @@ type LevelHandler struct {
 	handler slog.Handler
 }
 
-// NewHandler returns a LevelHandler with the given level.
+// NewLevelHandler returns a LevelHandler with the given level.
 // All methods except Enabled delegate to h.
-func NewHandler(level slog.Leveler, h slog.Handler) *LevelHandler {
+func NewLevelHandler(level slog.Leveler, h slog.Handler) *LevelHandler {
 	// Optimization: avoid chains of LevelHandlers.
 	if lh, ok := h.(*LevelHandler); ok {
 		h = lh.Handler()
@@ -37,12 +37,12 @@ func (h *LevelHandler) Handle(ctx context.Context, r slog.Record) error {
 
 // WithAttrs implements Handler.WithAttrs.
 func (h *LevelHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return NewHandler(h.level, h.handler.WithAttrs(attrs))
+	return NewLevelHandler(h.level, h.handler.WithAttrs(attrs))
 }
 
 // WithGroup implements Handler.WithGroup.
 func (h *LevelHandler) WithGroup(name string) slog.Handler {
-	return NewHandler(h.level, h.handler.WithGroup(name))
+	return NewLevelHandler(h.level, h.handler.WithGroup(name))
 }
 
 // Handler returns the Handler wrapped by h.


### PR DESCRIPTION
Add base level log 
There are two main requirements for improving the logging of cloudcost-exporter:
1. Structured logging with consistent labels across providers and collectors
2. Ability to define a log level and runtime that limits the logs
       
There are no shortage of existing Go packages that could have been to meet the first requirement, such that:
- [logrus](https://pkg.go.dev/github.com/sirupsen/
- [zap](https://github.com/uber-go/zap)
- [zerolog](https://github.com/

However each of these comes with tradeoffs and then yet dependency to maintain. The go team released [slog](https://go.dev/blog/slog) officially in go 1.21, which provides a structured logging implemention as part of the standard library. This makes it a prime candidate to immediate meet the first requirement.
    
The second requirement(levels) is a bit more nuanced since the slog is  thin implementation. The go team provides a reference example to use: https://pkg.go.dev/log/slog@master#example-Handler-LevelHandler. 
This PR aims to meet both requirements by:
1. Adding `slog` as a common logging library to use
2. Creating a levels implementation that allows us to toggle the emitted level

    

There are two three methods added as well:
- `GetLogLevel` to convert a string to the log level
- `WriterForOutput` to convert a string to an `io.Writer`
- `HandlerForOutput` that takes a string and returns a slog handler for json or text
