### PR TITLE
Azure AKS Collector Skeleton

### DIFF
--- a/cmd/exporter/config/config.go
+++ b/cmd/exporter/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 			Services           StringSliceFlag
 		}
 		Azure struct {
-			// TODO
+			Services StringSliceFlag
 		}
 	}
 	Collector struct {

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -69,6 +69,7 @@ func providerFlags(fs *flag.FlagSet, cfg *config.Config) {
 	// TODO: RENAME THIS TO JUST PROJECTS
 	fs.Var(&cfg.Providers.GCP.Projects, "gcp.bucket-projects", "GCP project(s).")
 	fs.Var(&cfg.Providers.AWS.Services, "aws.services", "AWS service(s).")
+	fs.Var(&cfg.Providers.Azure.Services, "azure.services", "Azure service(s).")
 	fs.Var(&cfg.Providers.GCP.Services, "gcp.services", "GCP service(s).")
 	flag.StringVar(&cfg.Providers.AWS.Region, "aws.region", "", "AWS region")
 	// TODO - PUT PROJECT-ID UNDER GCP
@@ -160,6 +161,7 @@ func selectProvider(ctx context.Context, cfg *config.Config) (provider.Provider,
 	case "azure":
 		return azure.New(ctx, &azure.Config{
 			Logger:           cfg.Logger,
+			Services:         cfg.Providers.Azure.Services,
 			CollectorTimeout: cfg.Collector.Timeout,
 		})
 	case "aws":

--- a/docs/contribute/logging.md
+++ b/docs/contribute/logging.md
@@ -13,7 +13,7 @@ With `slog` being part of Go's stdlib since 1.21, we decided to use it as the lo
 
 1. Every provider _must_ accept a `*slog.Logger` in the constructor
 1. Every collector _must_ accept a `*slog.Logger` in the constructor
-1. Each provider and collector _must_ add a `provider` or `collector` group when initializing using the [slog.WithGroup](https://pkg.go.dev/golang.org/x/exp/slog#Logger.WithGroup) method
+1. Each provider and collector _must_ add a `provider` or `collector` group when initializing using the [slog.Logger.With](https://pkg.go.dev/golang.org/x/exp/slog#Logger.With) method, specifying the collector or provider used
 1. Always prefer to use the `logger.WithAttr(...)` method to add structured data to the log message for both performance and consistency(see [slog blog post](https://go.dev/blog/slog) and search Performance section for more information)
    - NB: If you do not have any additional fields to log out, then you can use the `logger.Info("message")` methods
 

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -189,15 +189,15 @@ func (a *AWS) Collect(ch chan<- prometheus.Metric) {
 		go func(c provider.Collector) {
 			now := time.Now()
 			defer wg.Done()
-			collectorSuccess := 0.0
+			collectorErrors := 0.0
 			if err := c.Collect(ch); err != nil {
-				collectorSuccess = 1.0
+				collectorErrors = 1.0
 				log.Printf("Error collecting metrics from collector %s: %s", c.Name(), err)
 			}
-			ch <- prometheus.MustNewConstMetric(collectorLastScrapeErrorDesc, prometheus.GaugeValue, collectorSuccess, subsystem, c.Name())
+			ch <- prometheus.MustNewConstMetric(collectorLastScrapeErrorDesc, prometheus.GaugeValue, collectorErrors, subsystem, c.Name())
 			ch <- prometheus.MustNewConstMetric(collectorDurationDesc, prometheus.GaugeValue, time.Since(now).Seconds(), subsystem, c.Name())
 			ch <- prometheus.MustNewConstMetric(collectorLastScrapeTime, prometheus.GaugeValue, float64(time.Now().Unix()), subsystem, c.Name())
-			ch <- prometheus.MustNewConstMetric(collectorSuccessDesc, prometheus.GaugeValue, collectorSuccess, c.Name())
+			ch <- prometheus.MustNewConstMetric(collectorSuccessDesc, prometheus.GaugeValue, collectorErrors, c.Name())
 			collectorScrapesTotalCounter.WithLabelValues(subsystem, c.Name()).Inc()
 		}(c)
 	}

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -68,7 +68,7 @@ var (
 	)
 	collectorLastScrapeTime = prometheus.NewDesc(
 		prometheus.BuildFQName(cloudcost_exporter.ExporterName, "collector", "last_scrape_time"),
-		"Time of the last scrape.W",
+		"Time of the last scrape.",
 		[]string{"provider", "collector"},
 		nil,
 	)

--- a/pkg/azure/aks/README.md
+++ b/pkg/azure/aks/README.md
@@ -1,0 +1,3 @@
+# AKS Module
+
+This module is responsible for collecting pricing information for AKS clusters.

--- a/pkg/azure/aks/aks.go
+++ b/pkg/azure/aks/aks.go
@@ -11,7 +11,6 @@ import (
 
 const (
 	subsystem = "azure_aks"
-	// maxResults = 1000
 )
 
 // Errors
@@ -32,6 +31,14 @@ type Collector struct {
 
 type Config struct {
 	Logger *slog.Logger
+}
+
+func New(ctx context.Context, cfg *Config) *Collector {
+	logger := cfg.Logger.With("collector", subsystem)
+
+	return &Collector{
+		Logger: logger,
+	}
 }
 
 // CollectMetrics is a no-op function that satisfies the provider.Collector interface.
@@ -57,15 +64,7 @@ func (c *Collector) Name() string {
 	return subsystem
 }
 
-func New(ctx context.Context, cfg *Config) *Collector {
-	collectorGroup := cfg.Logger.WithGroup(subsystem)
-
-	return &Collector{
-		Logger: collectorGroup,
-	}
-}
-
 func (c *Collector) Register(_ provider.Registry) error {
-	c.Logger.LogAttrs(c.Context, slog.LevelInfo, "registering aks collector")
+	c.Logger.LogAttrs(c.Context, slog.LevelInfo, "registering collector")
 	return nil
 }

--- a/pkg/azure/aks/aks.go
+++ b/pkg/azure/aks/aks.go
@@ -25,8 +25,8 @@ var (
 
 // Collector is a prometheus collector that collects metrics from AKS clusters.
 type Collector struct {
-	Context context.Context
-	Logger  *slog.Logger
+	context context.Context
+	logger  *slog.Logger
 }
 
 type Config struct {
@@ -37,7 +37,7 @@ func New(ctx context.Context, cfg *Config) *Collector {
 	logger := cfg.Logger.With("collector", subsystem)
 
 	return &Collector{
-		Logger: logger,
+		logger: logger,
 	}
 }
 
@@ -50,13 +50,14 @@ func (c *Collector) CollectMetrics(_ chan<- prometheus.Metric) float64 {
 // Collect satisfies the provider.Collector interface.
 func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 	// TODO - implement
-	c.Logger.LogAttrs(c.Context, slog.LevelInfo, "TODO - implement AKS collector Collect method")
+
+	c.logger.LogAttrs(c.context, slog.LevelInfo, "TODO - implement AKS collector Collect method")
 	return nil
 }
 
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
 	// TODO - implement
-	c.Logger.LogAttrs(c.Context, slog.LevelInfo, "TODO - implement AKS collector Describe method")
+	c.logger.LogAttrs(c.context, slog.LevelInfo, "TODO - implement AKS collector Describe method")
 	return nil
 }
 
@@ -65,6 +66,6 @@ func (c *Collector) Name() string {
 }
 
 func (c *Collector) Register(_ provider.Registry) error {
-	c.Logger.LogAttrs(c.Context, slog.LevelInfo, "registering collector")
+	c.logger.LogAttrs(c.context, slog.LevelInfo, "registering collector")
 	return nil
 }

--- a/pkg/azure/aks/aks.go
+++ b/pkg/azure/aks/aks.go
@@ -1,0 +1,71 @@
+package aks
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grafana/cloudcost-exporter/pkg/provider"
+)
+
+const (
+	subsystem = "azure_aks"
+	// maxResults = 1000
+)
+
+// Errors
+var (
+// TODO - define Errors
+)
+
+// Prometheus Metrics
+var (
+// TODO - define Prometheus Metrics
+)
+
+// Collector is a prometheus collector that collects metrics from AKS clusters.
+type Collector struct {
+	Context context.Context
+	Logger  *slog.Logger
+}
+
+type Config struct {
+	Logger *slog.Logger
+}
+
+// CollectMetrics is a no-op function that satisfies the provider.Collector interface.
+// Deprecated: CollectMetrics is deprecated and will be removed in a future release.
+func (c *Collector) CollectMetrics(_ chan<- prometheus.Metric) float64 {
+	return 0
+}
+
+// Collect satisfies the provider.Collector interface.
+func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
+	// TODO - implement
+	c.Logger.LogAttrs(c.Context, slog.LevelInfo, "TODO - implement AKS collector Collect method")
+	return nil
+}
+
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
+	// TODO - implement
+	c.Logger.LogAttrs(c.Context, slog.LevelInfo, "TODO - implement AKS collector Describe method")
+	return nil
+}
+
+func (c *Collector) Name() string {
+	return subsystem
+}
+
+func New(ctx context.Context, cfg *Config) *Collector {
+	collectorGroup := cfg.Logger.WithGroup(subsystem)
+
+	return &Collector{
+		Logger: collectorGroup,
+	}
+}
+
+func (c *Collector) Register(_ provider.Registry) error {
+	c.Logger.LogAttrs(c.Context, slog.LevelInfo, "registering aks collector")
+	return nil
+}

--- a/pkg/azure/aks/aks_test.go
+++ b/pkg/azure/aks/aks_test.go
@@ -1,0 +1,33 @@
+package aks
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	parentCtx  context.Context = context.TODO()
+	testLogger *slog.Logger    = slog.New(slog.NewTextHandler(os.Stdout, nil))
+)
+
+func Test_New(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		expectedError error
+	}{
+		{
+			name: "no error",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := New(parentCtx, &Config{
+				Logger: testLogger,
+			})
+			require.NotNil(t, c)
+		})
+	}
+}

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -31,11 +31,11 @@ var (
 )
 
 type Azure struct {
-	Context context.Context
-	Logger  *slog.Logger
+	context          context.Context
+	logger           *slog.Logger
+	collectorTimeout time.Duration
 
-	Collectors       []provider.Collector
-	CollectorTimeout time.Duration
+	Collectors []provider.Collector
 }
 
 type Config struct {
@@ -66,17 +66,17 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 	}
 
 	return &Azure{
-		Context: ctx,
-		Logger:  logger,
+		context: ctx,
+		logger:  logger,
 
-		CollectorTimeout: config.CollectorTimeout,
+		collectorTimeout: config.CollectorTimeout,
 		Collectors:       collectors,
 	}, nil
 }
 
 // RegisterCollectors is a TODO
 func (a *Azure) RegisterCollectors(registry provider.Registry) error {
-	a.Logger.LogAttrs(a.Context, slog.LevelInfo, "registering collectors", slog.Int("NumOfCollectors", len(a.Collectors)))
+	a.logger.LogAttrs(a.context, slog.LevelInfo, "registering collectors", slog.Int("NumOfCollectors", len(a.Collectors)))
 
 	registry.MustRegister(collectorScrapesTotalCounter)
 	for _, c := range a.Collectors {
@@ -96,6 +96,6 @@ func (a *Azure) Describe(ch chan<- *prometheus.Desc) {
 // Collect is a TODO
 func (a *Azure) Collect(ch chan<- prometheus.Metric) {
 	// TODO - implement collector context
-	_, cancel := context.WithTimeout(a.Context, a.CollectorTimeout)
+	_, cancel := context.WithTimeout(a.context, a.collectorTimeout)
 	defer cancel()
 }

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -93,7 +93,6 @@ type Config struct {
 	Services         []string
 }
 
-// New is a TODO
 func New(ctx context.Context, config *Config) (*Azure, error) {
 	logger := config.Logger.With("provider", subsystem)
 	collectors := []provider.Collector{}

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -47,7 +47,7 @@ type Config struct {
 
 // New is a TODO
 func New(ctx context.Context, config *Config) (*Azure, error) {
-	providerGroup := config.Logger.WithGroup(subsystem)
+	logger := config.Logger.With("provider", subsystem)
 	collectors := []provider.Collector{}
 
 	// Collector Registration
@@ -57,17 +57,17 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 		case "AKS":
 			// TODO - Init azure client
 			collector := aks.New(ctx, &aks.Config{
-				Logger: providerGroup,
+				Logger: logger,
 			})
 			collectors = append(collectors, collector)
 		default:
-			providerGroup.LogAttrs(ctx, slog.LevelInfo, "unknown service", slog.String("service", svc))
+			logger.LogAttrs(ctx, slog.LevelInfo, "unknown service", slog.String("service", svc))
 		}
 	}
 
 	return &Azure{
 		Context: ctx,
-		Logger:  providerGroup,
+		Logger:  logger,
 
 		CollectorTimeout: config.CollectorTimeout,
 		Collectors:       collectors,
@@ -76,7 +76,7 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 
 // RegisterCollectors is a TODO
 func (a *Azure) RegisterCollectors(registry provider.Registry) error {
-	a.Logger.LogAttrs(a.Context, slog.LevelInfo, "registering collectors for azure", slog.Int("NumOfCollectors", len(a.Collectors)))
+	a.Logger.LogAttrs(a.Context, slog.LevelInfo, "registering collectors", slog.Int("NumOfCollectors", len(a.Collectors)))
 
 	registry.MustRegister(collectorScrapesTotalCounter)
 	for _, c := range a.Collectors {

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -19,6 +20,24 @@ const (
 )
 
 var (
+	collectorDurationDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(cloudcost_exporter.ExporterName, "collector", "last_scrape_duration_seconds"),
+		"Duration of the last scrape in seconds.",
+		[]string{"provider", "collector"},
+		nil,
+	)
+	collectorLastScrapeErrorDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(cloudcost_exporter.ExporterName, "collector", "last_scrape_error"),
+		"Was the last scrape an error. 1 indicates an error.",
+		[]string{"provider", "collector"},
+		nil,
+	)
+	collectorLastScrapeTime = prometheus.NewDesc(
+		prometheus.BuildFQName(cloudcost_exporter.ExporterName, "collector", "last_scrape_time"),
+		"Time of the last scrape.",
+		[]string{"provider", "collector"},
+		nil,
+	)
 	collectorScrapesTotalCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: prometheus.BuildFQName(cloudcost_exporter.ExporterName, "collector", "scrapes_total"),
@@ -26,8 +45,37 @@ var (
 		},
 		[]string{"provider", "collector"},
 	)
-
-// TODO - add prometheus metrics here
+	collectorSuccessDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(cloudcost_exporter.ExporterName, subsystem, "collector_success"),
+		"Was the last scrape of the Azure metrics successful.",
+		[]string{"collector"},
+		nil,
+	)
+	providerLastScrapeDurationDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(cloudcost_exporter.ExporterName, "", "last_scrape_duration_seconds"),
+		"Duration of the last scrape in seconds.",
+		[]string{"provider"},
+		nil,
+	)
+	providerLastScrapeErrorDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(cloudcost_exporter.ExporterName, "", "last_scrape_error"),
+		"Was the last scrape an error. 1 indicates an error.",
+		[]string{"provider"},
+		nil,
+	)
+	providerLastScrapeTime = prometheus.NewDesc(
+		prometheus.BuildFQName(cloudcost_exporter.ExporterName, "", "last_scrape_time"),
+		"Time of the last scrape.",
+		[]string{"provider"},
+		nil,
+	)
+	providerScrapesTotalCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: prometheus.BuildFQName(cloudcost_exporter.ExporterName, "", "scrapes_total"),
+			Help: "Total number of scrapes.",
+		},
+		[]string{"provider"},
+	)
 )
 
 type Azure struct {
@@ -35,7 +83,7 @@ type Azure struct {
 	logger           *slog.Logger
 	collectorTimeout time.Duration
 
-	Collectors []provider.Collector
+	collectors []provider.Collector
 }
 
 type Config struct {
@@ -70,16 +118,15 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 		logger:  logger,
 
 		collectorTimeout: config.CollectorTimeout,
-		Collectors:       collectors,
+		collectors:       collectors,
 	}, nil
 }
 
-// RegisterCollectors is a TODO
 func (a *Azure) RegisterCollectors(registry provider.Registry) error {
-	a.logger.LogAttrs(a.context, slog.LevelInfo, "registering collectors", slog.Int("NumOfCollectors", len(a.Collectors)))
+	a.logger.LogAttrs(a.context, slog.LevelInfo, "registering collectors", slog.Int("NumOfCollectors", len(a.collectors)))
 
 	registry.MustRegister(collectorScrapesTotalCounter)
-	for _, c := range a.Collectors {
+	for _, c := range a.collectors {
 		err := c.Register(registry)
 		if err != nil {
 			return err
@@ -89,13 +136,51 @@ func (a *Azure) RegisterCollectors(registry provider.Registry) error {
 	return nil
 }
 
-// Describe is a TODO
 func (a *Azure) Describe(ch chan<- *prometheus.Desc) {
+	ch <- collectorLastScrapeErrorDesc
+	ch <- collectorDurationDesc
+	ch <- providerLastScrapeErrorDesc
+	ch <- providerLastScrapeDurationDesc
+	ch <- collectorLastScrapeTime
+	ch <- providerLastScrapeTime
+	ch <- collectorSuccessDesc
+	for _, c := range a.collectors {
+		if err := c.Describe(ch); err != nil {
+			a.logger.LogAttrs(a.context, slog.LevelInfo, "error describing collector", slog.String("collector", c.Name()), slog.String("error", err.Error()))
+		}
+	}
 }
 
-// Collect is a TODO
 func (a *Azure) Collect(ch chan<- prometheus.Metric) {
 	// TODO - implement collector context
 	_, cancel := context.WithTimeout(a.context, a.collectorTimeout)
 	defer cancel()
+
+	providerStart := time.Now()
+	wg := &sync.WaitGroup{}
+	wg.Add(len(a.collectors))
+
+	for _, c := range a.collectors {
+		go func(c provider.Collector) {
+			collectorStart := time.Now()
+			defer wg.Done()
+			collectorErrors := 0.0
+			if err := c.Collect(ch); err != nil {
+				collectorErrors = 1.0
+				a.logger.LogAttrs(a.context, slog.LevelInfo, "error collecting metrics from collector", slog.String("collector", c.Name()), slog.String("error", err.Error()))
+			}
+			ch <- prometheus.MustNewConstMetric(collectorLastScrapeErrorDesc, prometheus.GaugeValue, collectorErrors, subsystem, c.Name())
+			ch <- prometheus.MustNewConstMetric(collectorDurationDesc, prometheus.GaugeValue, time.Since(collectorStart).Seconds(), subsystem, c.Name())
+			ch <- prometheus.MustNewConstMetric(collectorLastScrapeTime, prometheus.GaugeValue, float64(time.Now().Unix()), subsystem, c.Name())
+			ch <- prometheus.MustNewConstMetric(collectorSuccessDesc, prometheus.GaugeValue, collectorErrors, c.Name())
+			collectorScrapesTotalCounter.WithLabelValues(subsystem, c.Name()).Inc()
+		}(c)
+
+	}
+	wg.Wait()
+
+	ch <- prometheus.MustNewConstMetric(providerLastScrapeErrorDesc, prometheus.GaugeValue, 0.0, subsystem)
+	ch <- prometheus.MustNewConstMetric(providerLastScrapeDurationDesc, prometheus.GaugeValue, time.Since(providerStart).Seconds(), subsystem)
+	ch <- prometheus.MustNewConstMetric(providerLastScrapeTime, prometheus.GaugeValue, float64(time.Now().Unix()), subsystem)
+	providerScrapesTotalCounter.WithLabelValues(subsystem).Inc()
 }

--- a/pkg/google/gcp.go
+++ b/pkg/google/gcp.go
@@ -193,13 +193,13 @@ func (g *GCP) Collect(ch chan<- prometheus.Metric) {
 		go func(c provider.Collector) {
 			now := time.Now()
 			defer wg.Done()
-			collectorSuccess := 0.0
+			collectorErrors := 0.0
 			if err := c.Collect(ch); err != nil {
 				log.Printf("Error collecting metrics from collector %s: %s", c.Name(), err)
-				collectorSuccess = 1.0
+				collectorErrors = 1.0
 			}
-			log.Printf("Collector(%s) collect respose=%.2f", c.Name(), collectorSuccess)
-			ch <- prometheus.MustNewConstMetric(collectorLastScrapeErrorDesc, prometheus.GaugeValue, collectorSuccess, subsystem, c.Name())
+			log.Printf("Collector(%s) collect respose=%.2f", c.Name(), collectorErrors)
+			ch <- prometheus.MustNewConstMetric(collectorLastScrapeErrorDesc, prometheus.GaugeValue, collectorErrors, subsystem, c.Name())
 			ch <- prometheus.MustNewConstMetric(collectorDurationDesc, prometheus.GaugeValue, time.Since(now).Seconds(), subsystem, c.Name())
 			ch <- prometheus.MustNewConstMetric(collectorLastScrapeTime, prometheus.GaugeValue, float64(time.Now().Unix()), subsystem, c.Name())
 			collectorScrapesTotalCounter.WithLabelValues(subsystem, c.Name()).Inc()


### PR DESCRIPTION
Implementing the scaffolding for the AKS collector.

Important points:
- added `azure.services` CLI Flag
- Bare bones implementation of the AKS Collector module
- Added the init function (without any functionality) to the `New()` constructor in Azure

```sh
❯ ./cloudcost-exporter --provider azure --server.address "127.0.0.1:8080" --azure.services "aks"
time=2024-06-24T13:55:09.194-04:00 level=INFO msg="Starting cloudcost-exporter" version="(version=v0.1.4-2-g041dd70-dirty, branch=logyball/azure-implement-aks-collector-skeleton, revision=041dd70)" build_context="(go=go1.22.0, platform=darwin/arm64, user=loganballard@Logans-Laptop.local, date=2024-06-24T17:46:52Z, tags=unknown)"
time=2024-06-24T13:55:09.195-04:00 level=INFO msg="registering collectors for azure" azure.NumOfCollectors=1
time=2024-06-24T13:55:09.195-04:00 level=INFO msg="registering aks collector"
time=2024-06-24T13:55:09.195-04:00 level=INFO msg="Starting server" address=127.0.0.1:8080 path=/metrics
```