### PR TITLE
AKS Pricing Map Population

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4 v4.2.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
+	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/aws/aws-sdk-go-v2 v1.30.0
 	github.com/aws/aws-sdk-go-v2/config v1.27.21
 	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.39.1
@@ -36,6 +37,7 @@ require (
 	cloud.google.com/go/iam v1.1.8 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.8.0 // indirect
+	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.21 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,10 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.0.0 
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.0.0/go.mod h1:243D9iHbcQXoFUtgHJwL7gl2zx1aDuDMjvBZVGr2uW0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
+github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
+github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
+github.com/Azure/go-autorest/autorest/to v0.4.0 h1:oXVqrxakqqV1UZdSazDOPOLvOIz+XA683u8EctwboHk=
+github.com/Azure/go-autorest/autorest/to v0.4.0/go.mod h1:fE8iZBn7LQR7zH/9XU2NcPR4o9jEImooCeWJcYV/zLE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/pkg/azure/aks/README.md
+++ b/pkg/azure/aks/README.md
@@ -1,3 +1,42 @@
 # AKS Module
 
 This module is responsible for collecting pricing information for AKS clusters.
+
+
+## Pricing Map
+
+Because Azure has not yet implemented the pricing API into it's SDK :shame:, this packages uses the 3rd party [Azure Retail Prices SDK](https://github.com/gomodules/azure-retail-prices-sdk-for-go) to grab the prices.
+
+This is based on [Azure's pricing model](https://azure.microsoft.com/en-us/pricing/details/virtual-machines/windows/), where different prices are determined by a combination of those factors.
+
+### Price Stratification
+
+The PricingMap is built out with the following structure:
+
+```
+root -> {
+  regionName -> {
+    machinePriority -> {
+      operatingSystem -> {
+        skuName -> information
+      }
+    }
+  }
+}
+```
+
+That way, in order to uniquely identify a price, we will have to have the following attributes of any VM:
+- the region it is deployed into
+- it's priority (spot or on-demand)
+- the operating system it is running
+- it's SKU (e.g. `E8-4as_v4`)
+
+# Future Work 
+
+- (Pricing Map) - implement background job to populate pricing map every 24 hours
+- (Pricing Map) - clear and repopulate Price Map and cache with backgroud job
+- (Pricing Map) - implement retry mechanism to pricing map, crash program if it doesn't populate after 5 tries
+- (Pricing Map) - implement VM lookup by machine ID
+- (VMs) - implement VM list
+- connect VM list with Pricing Map 
+- Prometheus metrics

--- a/pkg/azure/aks/aks.go
+++ b/pkg/azure/aks/aks.go
@@ -35,10 +35,11 @@ type Collector struct {
 	context context.Context
 	logger  *slog.Logger
 
-	priceClient                  *retailPriceSdk.RetailPricesClient
 	resourceGroupClient          *armresources.ResourceGroupsClient
 	virtualMachineClient         *armcompute.VirtualMachineScaleSetVMsClient
 	virtualMachineScaleSetClient *armcompute.VirtualMachineScaleSetsClient
+
+	PriceStore *PriceStore
 }
 
 type Config struct {
@@ -73,10 +74,11 @@ func New(ctx context.Context, cfg *Config) (*Collector, error) {
 		context: ctx,
 		logger:  logger,
 
-		priceClient:                  retailPricesClient,
 		resourceGroupClient:          rgClient,
 		virtualMachineClient:         computeClientFactory.NewVirtualMachineScaleSetVMsClient(),
 		virtualMachineScaleSetClient: computeClientFactory.NewVirtualMachineScaleSetsClient(),
+
+		PriceStore: NewPricingStore(cfg.SubscriptionId, retailPricesClient, logger, ctx),
 	}, nil
 }
 
@@ -89,7 +91,6 @@ func (c *Collector) CollectMetrics(_ chan<- prometheus.Metric) float64 {
 // Collect satisfies the provider.Collector interface.
 func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 	// TODO - implement
-
 	c.logger.LogAttrs(c.context, slog.LevelInfo, "TODO - implement AKS collector Collect method")
 	return nil
 }

--- a/pkg/azure/aks/pricing_map.go
+++ b/pkg/azure/aks/pricing_map.go
@@ -23,8 +23,10 @@ const (
 	Windows
 )
 
+var machineOperatingSystemNames [2]string = [2]string{"Linux", "Windows"}
+
 func (o MachineOperatingSystem) String() string {
-	return [2]string{"Linux", "Windows"}[o-1]
+	return machineOperatingSystemNames[o-1]
 }
 
 type MachinePriority int
@@ -34,8 +36,10 @@ const (
 	Spot
 )
 
+var machinePriorityNames [2]string = [2]string{"OnDemand", "Spot"}
+
 func (v MachinePriority) String() string {
-	return [2]string{"OnDemand", "Spot"}[v-1]
+	return machinePriorityNames[v-1]
 }
 
 type PriceBySku map[string]retailPriceSdk.ResourceSKU
@@ -140,7 +144,7 @@ func (p *PriceStore) PopulatePriceStore(locationList []string) error {
 		for _, v := range page.Items {
 			regionName := v.ArmRegionName
 			if regionName == "" {
-				p.logger.LogAttrs(p.context, slog.LevelInfo, "region name for price not found")
+				p.logger.LogAttrs(p.context, slog.LevelInfo, "region name for price not found", slog.String("sku", v.SkuName))
 				continue
 			}
 

--- a/pkg/azure/aks/pricing_map.go
+++ b/pkg/azure/aks/pricing_map.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/Azure/go-autorest/autorest/to"
 	retailPriceSdk "gomodules.xyz/azure-retail-prices-sdk-for-go/sdk"
@@ -121,6 +122,7 @@ func (p *PriceStore) determineMachinePriority(sku retailPriceSdk.ResourceSKU) Ma
 }
 
 func (p *PriceStore) PopulatePriceStore(locationList []string) error {
+	startTime := time.Now()
 	p.logger.LogAttrs(p.context, slog.LevelInfo, "populating price map")
 
 	p.lock.Lock()
@@ -159,7 +161,7 @@ func (p *PriceStore) PopulatePriceStore(locationList []string) error {
 		}
 	}
 
-	p.logger.LogAttrs(p.context, slog.LevelInfo, "price map populated")
+	p.logger.LogAttrs(p.context, slog.LevelInfo, "price map populated", slog.Duration("duration", time.Since(startTime)))
 	return nil
 }
 

--- a/pkg/azure/aks/pricing_map.go
+++ b/pkg/azure/aks/pricing_map.go
@@ -23,7 +23,7 @@ const (
 )
 
 func (o MachineOperatingSystem) String() string {
-	return [...]string{"Linux", "Windows"}[o-1]
+	return [2]string{"Linux", "Windows"}[o-1]
 }
 
 type MachinePriority int
@@ -34,7 +34,7 @@ const (
 )
 
 func (v MachinePriority) String() string {
-	return [...]string{"OnDemand", "Spot"}[v-1]
+	return [2]string{"OnDemand", "Spot"}[v-1]
 }
 
 type PriceBySku map[string]retailPriceSdk.ResourceSKU
@@ -79,11 +79,11 @@ func NewPricingStore(subId string, priceClient *retailPriceSdk.RetailPricesClien
 }
 
 func (p *PriceStore) buildQueryFilter(locationList []string) string {
-	locationListFilter := []string{}
 	if len(locationList) == 0 {
 		return `serviceName eq 'Virtual Machines' and priceType eq 'Consumption'`
 	}
 
+	locationListFilter := []string{}
 	for _, region := range locationList {
 		locationListFilter = append(locationListFilter, fmt.Sprintf("armRegionName eq '%s'", region))
 	}

--- a/pkg/azure/aks/pricing_map.go
+++ b/pkg/azure/aks/pricing_map.go
@@ -1,0 +1,181 @@
+package aks
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	retailPriceSdk "gomodules.xyz/azure-retail-prices-sdk-for-go/sdk"
+)
+
+const (
+	AZ_API_VERSION string = "2023-01-01-preview" // using latest API Version https://learn.microsoft.com/en-us/rest/api/cost-management/retail-prices/azure-retail-prices
+)
+
+type MachineOperatingSystem int
+
+const (
+	Linux MachineOperatingSystem = iota
+	Windows
+)
+
+func (o MachineOperatingSystem) String() string {
+	return [...]string{"Linux", "Windows"}[o-1]
+}
+
+type MachinePriority int
+
+const (
+	OnDemand MachinePriority = iota
+	Spot
+)
+
+func (v MachinePriority) String() string {
+	return [...]string{"OnDemand", "Spot"}[v-1]
+}
+
+type PriceBySku map[string]retailPriceSdk.ResourceSKU
+
+type PriceByOperatingSystem map[MachineOperatingSystem]PriceBySku
+
+type PriceByPriority map[MachinePriority]PriceByOperatingSystem
+
+type PriceStore struct {
+	lock              *sync.RWMutex
+	subscriptionId    string
+	logger            *slog.Logger
+	context           context.Context
+	retailPriceClient *retailPriceSdk.RetailPricesClient
+
+	RegionMap map[string]PriceByPriority
+	Cache     map[string]*retailPriceSdk.ResourceSKU
+}
+
+func NewPricingStore(subId string, priceClient *retailPriceSdk.RetailPricesClient, parentLogger *slog.Logger, parentContext context.Context) *PriceStore {
+	logger := parentLogger.With("subsystem", "pricingMap")
+
+	p := &PriceStore{
+		lock:              &sync.RWMutex{},
+		logger:            logger,
+		context:           parentContext,
+		subscriptionId:    subId,
+		retailPriceClient: priceClient,
+
+		RegionMap: make(map[string]PriceByPriority),
+		Cache:     make(map[string]*retailPriceSdk.ResourceSKU),
+	}
+
+	go func() {
+		err := p.PopulatePriceStore([]string{})
+		if err != nil {
+			p.logger.LogAttrs(p.context, slog.LevelError, "error populating initial price store", slog.String("error", err.Error()))
+		}
+	}()
+
+	return p
+}
+
+func (p *PriceStore) buildQueryFilter(locationList []string) string {
+	locationListFilter := []string{}
+	if len(locationList) == 0 {
+		return `serviceName eq 'Virtual Machines' and priceType eq 'Consumption'`
+	}
+
+	for _, region := range locationList {
+		locationListFilter = append(locationListFilter, fmt.Sprintf("armRegionName eq '%s'", region))
+	}
+
+	locationListStr := strings.Join(locationListFilter, " or ")
+	return fmt.Sprintf(`serviceName eq 'Virtual Machines' and priceType eq 'Consumption' and (%s)`, locationListStr)
+}
+
+func (p *PriceStore) buildListOptions(locationList []string) *retailPriceSdk.RetailPricesClientListOptions {
+	queryFilter := p.buildQueryFilter(locationList)
+	return &retailPriceSdk.RetailPricesClientListOptions{
+		APIVersion:  to.StringPtr(AZ_API_VERSION),
+		Filter:      to.StringPtr(queryFilter),
+		MeterRegion: to.StringPtr(`'primary'`),
+	}
+}
+
+func (p *PriceStore) determineMachineOperatingSystem(sku retailPriceSdk.ResourceSKU) MachineOperatingSystem {
+	switch {
+	case strings.Contains(sku.ProductName, "Windows"):
+		return Windows
+	default:
+		return Linux
+	}
+}
+
+func (p *PriceStore) determineMachinePriority(sku retailPriceSdk.ResourceSKU) MachinePriority {
+	switch {
+	case strings.Contains(sku.SkuName, "Spot"):
+		return Spot
+	default:
+		return OnDemand
+	}
+
+}
+
+func (p *PriceStore) PopulatePriceStore(locationList []string) error {
+	p.logger.LogAttrs(p.context, slog.LevelInfo, "populating price map")
+
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	pager := p.retailPriceClient.NewListPager(p.buildListOptions(locationList))
+
+	for pager.More() {
+		page, err := pager.NextPage(p.context)
+		if err != nil {
+			p.logger.LogAttrs(p.context, slog.LevelError, "error paging")
+			return ErrPageAdvanceFailure
+		}
+
+		for _, v := range page.Items {
+			regionName := v.ArmRegionName
+			if regionName == "" {
+				p.logger.LogAttrs(p.context, slog.LevelInfo, "region name for price not found")
+				continue
+			}
+
+			if _, ok := p.RegionMap[regionName]; !ok {
+				p.logger.LogAttrs(p.context, slog.LevelInfo, "populating machine prices for region", slog.String("region", regionName))
+				p.RegionMap[regionName] = make(PriceByPriority)
+				p.RegionMap[regionName][Spot] = make(PriceByOperatingSystem)
+				p.RegionMap[regionName][OnDemand] = make(PriceByOperatingSystem)
+			}
+
+			machineOperatingSystem := p.determineMachineOperatingSystem(v)
+			machinePriority := p.determineMachinePriority(v)
+
+			if _, ok := p.RegionMap[regionName][machinePriority][machineOperatingSystem]; !ok {
+				p.RegionMap[regionName][machinePriority][machineOperatingSystem] = make(PriceBySku)
+			}
+			p.RegionMap[regionName][machinePriority][machineOperatingSystem][v.ArmSkuName] = v
+		}
+	}
+
+	p.logger.LogAttrs(p.context, slog.LevelInfo, "price map populated")
+	return nil
+}
+
+// TODO - implement ability to lookup a certain VM's
+// Price by it's ID
+func (p *PriceStore) GetVmPrice() {}
+
+// TODO - use to grab regional prices
+// func (p *PriceStore) getPricesByRegion(region string) (*PriceByPriority, error) {
+// 	p.lock.RLock()
+// 	defer p.lock.RUnlock()
+
+// 	priceByPriority, ok := p.RegionMap[region]
+// 	if !ok {
+// 		return nil, fmt.Errorf("region %s not found", region)
+// 	}
+
+// 	return &priceByPriority, nil
+// }

--- a/pkg/azure/aks/pricing_map_test.go
+++ b/pkg/azure/aks/pricing_map_test.go
@@ -1,0 +1,7 @@
+package aks
+
+import "testing"
+
+func TestMapCreation(t *testing.T) {
+	t.Skip()
+}

--- a/pkg/azure/aks/pricing_map_test.go
+++ b/pkg/azure/aks/pricing_map_test.go
@@ -1,7 +1,82 @@
 package aks
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/stretchr/testify/assert"
+	retailPriceSdk "gomodules.xyz/azure-retail-prices-sdk-for-go/sdk"
+)
 
 func TestMapCreation(t *testing.T) {
+	// TODO - mock
 	t.Skip()
+}
+
+func TestBuildQueryFilter(t *testing.T) {
+	p := PriceStore{}
+	testTable := map[string]struct {
+		locationList   []string
+		expectedFilter string
+	}{
+		"no location list": {
+			locationList:   nil,
+			expectedFilter: `serviceName eq 'Virtual Machines' and priceType eq 'Consumption'`,
+		},
+		"location list with one item": {
+			locationList:   []string{"eastus"},
+			expectedFilter: `serviceName eq 'Virtual Machines' and priceType eq 'Consumption' and (armRegionName eq 'eastus')`,
+		},
+		"location list with many items": {
+			locationList:   []string{"eastus", "asiapacific", "Global"},
+			expectedFilter: `serviceName eq 'Virtual Machines' and priceType eq 'Consumption' and (armRegionName eq 'eastus' or armRegionName eq 'asiapacific' or armRegionName eq 'Global')`,
+		},
+	}
+
+	for name, test := range testTable {
+		t.Run(name, func(t *testing.T) {
+			queryFilter := p.buildQueryFilter(test.locationList)
+			assert.Equal(t, test.expectedFilter, queryFilter)
+		})
+	}
+}
+
+func TestBuildListOptions(t *testing.T) {
+	p := PriceStore{}
+	testTable := map[string]struct {
+		locationList []string
+		expectedOpts *retailPriceSdk.RetailPricesClientListOptions
+	}{
+		"no location list": {
+			locationList: nil,
+			expectedOpts: &retailPriceSdk.RetailPricesClientListOptions{
+				APIVersion:  to.StringPtr("2023-01-01-preview"),
+				Filter:      to.StringPtr(`serviceName eq 'Virtual Machines' and priceType eq 'Consumption'`),
+				MeterRegion: to.StringPtr(`'primary'`),
+			},
+		},
+		"location list with one item": {
+			locationList: []string{"eastus"},
+			expectedOpts: &retailPriceSdk.RetailPricesClientListOptions{
+				APIVersion:  to.StringPtr("2023-01-01-preview"),
+				Filter:      to.StringPtr(`serviceName eq 'Virtual Machines' and priceType eq 'Consumption' and (armRegionName eq 'eastus')`),
+				MeterRegion: to.StringPtr(`'primary'`),
+			},
+		},
+		"location list with many items": {
+			locationList: []string{"eastus", "asiapacific", "Global"},
+			expectedOpts: &retailPriceSdk.RetailPricesClientListOptions{
+				APIVersion:  to.StringPtr("2023-01-01-preview"),
+				Filter:      to.StringPtr(`serviceName eq 'Virtual Machines' and priceType eq 'Consumption' and (armRegionName eq 'eastus' or armRegionName eq 'asiapacific' or armRegionName eq 'Global')`),
+				MeterRegion: to.StringPtr(`'primary'`),
+			},
+		},
+	}
+
+	for name, test := range testTable {
+		t.Run(name, func(t *testing.T) {
+			opts := p.buildListOptions(test.locationList)
+			assert.Equal(t, test.expectedOpts, opts)
+		})
+	}
 }

--- a/pkg/azure/aks/pricing_map_test.go
+++ b/pkg/azure/aks/pricing_map_test.go
@@ -89,13 +89,13 @@ func TestDetermineMachineOperatingSystem(t *testing.T) {
 	}{
 		"Linux": {
 			sku: retailPriceSdk.ResourceSKU{
-				ProductName: "Standard D4",
+				ProductName: "Virtual Machines Esv4 Series",
 			},
 			expectedMachine: Linux,
 		},
 		"Windows": {
 			sku: retailPriceSdk.ResourceSKU{
-				ProductName: "Standard D4 Windows",
+				ProductName: "Virtual Machines D Series Windows",
 			},
 			expectedMachine: Windows,
 		},
@@ -117,13 +117,13 @@ func TestDetermineMachinePriority(t *testing.T) {
 	}{
 		"OnDemand": {
 			sku: retailPriceSdk.ResourceSKU{
-				ProductName: "Standard D4",
+				SkuName: "Standard_E16pds_v5 Low Priority",
 			},
 			expectedPriority: OnDemand,
 		},
 		"Spot": {
 			sku: retailPriceSdk.ResourceSKU{
-				ProductName: "Standard D4 Windows",
+				SkuName: "B4ls v2 Spot",
 			},
 			expectedPriority: Spot,
 		},
@@ -131,7 +131,7 @@ func TestDetermineMachinePriority(t *testing.T) {
 
 	for name, test := range testTable {
 		t.Run(name, func(t *testing.T) {
-			machinePriority := p.determineMachineOperatingSystem(test.sku)
+			machinePriority := p.determineMachinePriority(test.sku)
 			assert.Equal(t, test.expectedPriority, machinePriority)
 		})
 	}

--- a/pkg/azure/aks/pricing_map_test.go
+++ b/pkg/azure/aks/pricing_map_test.go
@@ -80,3 +80,59 @@ func TestBuildListOptions(t *testing.T) {
 		})
 	}
 }
+
+func TestDetermineMachineOperatingSystem(t *testing.T) {
+	p := PriceStore{}
+	testTable := map[string]struct {
+		sku             retailPriceSdk.ResourceSKU
+		expectedMachine MachineOperatingSystem
+	}{
+		"Linux": {
+			sku: retailPriceSdk.ResourceSKU{
+				ProductName: "Standard D4",
+			},
+			expectedMachine: Linux,
+		},
+		"Windows": {
+			sku: retailPriceSdk.ResourceSKU{
+				ProductName: "Standard D4 Windows",
+			},
+			expectedMachine: Windows,
+		},
+	}
+
+	for name, test := range testTable {
+		t.Run(name, func(t *testing.T) {
+			machineOs := p.determineMachineOperatingSystem(test.sku)
+			assert.Equal(t, test.expectedMachine, machineOs)
+		})
+	}
+}
+
+func TestDetermineMachinePriority(t *testing.T) {
+	p := PriceStore{}
+	testTable := map[string]struct {
+		sku              retailPriceSdk.ResourceSKU
+		expectedPriority MachinePriority
+	}{
+		"OnDemand": {
+			sku: retailPriceSdk.ResourceSKU{
+				ProductName: "Standard D4",
+			},
+			expectedPriority: OnDemand,
+		},
+		"Spot": {
+			sku: retailPriceSdk.ResourceSKU{
+				ProductName: "Standard D4 Windows",
+			},
+			expectedPriority: Spot,
+		},
+	}
+
+	for name, test := range testTable {
+		t.Run(name, func(t *testing.T) {
+			machinePriority := p.determineMachineOperatingSystem(test.sku)
+			assert.Equal(t, test.expectedPriority, machinePriority)
+		})
+	}
+}


### PR DESCRIPTION
Continuing on to implementing the AKS functionality.

This PR implements a "PriceStore" object used to hold the prices of different machine types based on region, priority, and operating system.  This is based on [Azure's pricing model](https://azure.microsoft.com/en-us/pricing/details/virtual-machines/windows/), where different prices are determined by a combination of those factors.

# Details

### Price Stratification

The PricingMap is built out with the following structure:

```
root -> {
  regionName -> {
    machinePriority -> {
      operatingSystem -> {
        skuName -> information
      }
    }
  }
}
```

That way, in order to uniquely identify a price, we will have to have the following attributes of any VM:
- the region it is deployed into
- it's priority (spot or on-demand)
- the operating system it is running
- it's SKU (e.g. `E8-4as_v4`)

Fortunately, when listing out VMs, these options are available to us.

### Population Strategy

When the PricingStore object is instantiated upon creating the AKS Collector, the price map is populated in the background.  Is is protected by the `lock`, so that if it is read before it is fully populated, the read will block until population is complete.

In addition, there is a region filter that can be used in combination with future work that will cause the price map to only populate for certain regions.  This is useful for the future, as we can only populate prices for locations where VMs are actually present.

### Future Work

- Tests (this should be covered by mocking in my opinion, once the metrics themselves are actually being populated)
- Caching VM IDs -> prices
  - This will help tremendously with lookup.  Once we have the VMSS and VMs listing functionality, we can store a price for individual machines, so they do not need to do an expensive lookup to find their prices 

# Testing

Currently there isn't a great way to test this without the debugger.  However, you can see the population happening in logging lines, but validating the actual numbers will have to come later:

```sh
❯ ./cloudcost-exporter --provider azure --server.address "127.0.0.1:8080" --azure.services "aks" --azure.subscription-id "<redacted>"          
time=2024-06-25T19:15:58.795-04:00 level=INFO msg="Starting cloudcost-exporter" version="(version=v0.1.5-3-g579964b-dirty, branch=logyball/aks-pricing-map-implementation, revision=579964b)" build_context="(go=go1.22.0, platform=darwin/arm64, user=loganballard@Logans-Laptop.local, date=2024-06-25T23:15:46Z, tags=unknown)"
time=2024-06-25T19:15:58.795-04:00 level=INFO msg="populating price map" provider=azure collector=aks subsystem=pricingMap
time=2024-06-25T19:15:58.795-04:00 level=INFO msg="TODO - implement AKS collector Describe method" provider=azure collector=aks
time=2024-06-25T19:15:58.795-04:00 level=INFO msg="registering collectors" provider=azure NumOfCollectors=1
time=2024-06-25T19:15:58.796-04:00 level=INFO msg="registering collector" provider=azure collector=aks
time=2024-06-25T19:15:58.796-04:00 level=INFO msg="Starting server" address=127.0.0.1:8080 path=/metrics
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=southindia
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=switzerlandnorth
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=francecentral
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=eastasia
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=israelcentral
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=uaenorth
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=westus
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=centralus
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=brazilsoutheast
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=westindia
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=northeurope
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=swedensouth
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=usgovarizona
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=eastus2
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=uksouth
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=koreacentral
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=germanywestcentral
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=norwaywest
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=australiasoutheast
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=westeurope
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=swedencentral
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=brazilsouth
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=southafricanorth
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=southcentralus
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=koreasouth
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=westus2
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=spaincentral
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=japanwest
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=japaneast
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=jioindiawest
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=usgovtexas
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=eastus
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=qatarcentral
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=southafricawest
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=ukwest
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=westus3
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=uaecentral
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=canadaeast
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=westcentralus
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=southeastasia
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=australiaeast
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=italynorth
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=norwayeast
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=canadacentral
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=switzerlandwest
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=australiacentral2
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=jioindiacentral
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=germanynorth
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=polandcentral
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=australiacentral
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=centralindia
time=2024-06-25T19:15:59.189-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=attdallas1
time=2024-06-25T19:15:59.190-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=attdetroit1
time=2024-06-25T19:15:59.190-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=sgxsingapore1
time=2024-06-25T19:15:59.190-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=attatlanta1
time=2024-06-25T19:15:59.190-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=mexicocentral
time=2024-06-25T19:15:59.190-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=northcentralus
time=2024-06-25T19:15:59.190-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=usgovvirginia
time=2024-06-25T19:15:59.190-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=Global
time=2024-06-25T19:15:59.190-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=francesouth
time=2024-06-25T19:15:59.190-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=uksouth2
time=2024-06-25T19:15:59.557-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=attnewyork1
time=2024-06-25T19:15:59.908-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=usgoviowa
time=2024-06-25T19:16:00.940-04:00 level=INFO msg="populating machine prices for region" provider=azure collector=aks subsystem=pricingMap region=uknorth
time=2024-06-25T19:16:06.815-04:00 level=INFO msg="region name for price not found" provider=azure collector=aks subsystem=pricingMap
time=2024-06-25T19:16:13.641-04:00 level=INFO msg="region name for price not found" provider=azure collector=aks subsystem=pricingMap
time=2024-06-25T19:16:41.702-04:00 level=INFO msg="price map populated" provider=azure collector=aks subsystem=pricingMap duration=42.907056542s