### PR TITLE
Feat/ec2 instance exporter

### DIFF
--- a/pkg/aws/compute/ec2/README.md
+++ b/pkg/aws/compute/ec2/README.md
@@ -1,0 +1,81 @@
+# ec2 cost module
+
+This module is responsible for collecting pricing information for EC2 instances.
+See [metrics](/docs/metrics.md) for more information on the metrics that are collected.
+
+## Overview
+
+ec2 has a fairly large overlap with [eks]() for the pricing map and collecting of instances.
+The primary reason to have two dedicated implementations is that they emit two distinct sets of metrics.
+There are two differences in the ec2 implementation:
+- filters out instances associated with eks clusters
+- emits the __total__ price of a machine
+
+The primary use case for this metric is to associate an ec2 instance to a team, by environment.
+A major assumption made for the module is that each machine has one distinct owner. 
+
+## Pricing Map
+
+The pricing map is generated based on the machine type and the region where the instance is running.
+
+Here's how the data structure looks like:
+
+```
+--> root
+    --> region
+        --> machine type
+           --> reservation type(on-demand, spot)
+              --> price
+```
+
+Regions are populated by making an [api call]() to find the regions enabled for the account.
+The [price]() instance has an attribute for the __total__ hourly cost of a machine.
+
+The following attributes must be available to make the lookup:
+- region
+- machine type
+- reservation type
+- operating system
+
+## Collect
+
+## Cost Calculations
+
+Here's some example PromQL queries that can be used to calculate the costs of ec2 instances:
+
+```PromQL
+// Calculate the total houlry cost of all ec2 instances
+sum(cloudcost_aws_ec2_instance_hourly_cost)
+// Calculate the total hourly cost by region
+sum by (region) (cloudcost_aws_ec2_instance_hourly_cost)
+// Calculate the total hourly cost by machine type
+sum by (machine_type) (cloudcost_aws_ec2_instance_hourly_cost)
+// Calculate the total hourly cost by reservation type
+sum by (reservation) (cloudcost_aws_ec2_instance_hourly_cost)
+```
+
+You can do more interesting queries if you run [yace]() and export the following metrics:
+- `aws_ec2_info`
+
+All of these examples assume that you have created the tag name referenced in the examples.
+
+```PromQL
+// Calculate the total hourly cost by team
+// Assumes a tag called `Team` has been created on the ec2 instances
+sum by (team) (
+    cloudcost_aws_ec2_instance_hourly_cost
+    * on (instance_id) group_right()
+    label_join(aws_ec2_info, "team", "tag_Team")
+)
+
+// Calculate the total hourly cost by team and environment
+// Assumes a tag called `Team` has been created on the ec2 instances
+// Assumes a tag called `Environment` has been created on the ec2 instances
+sum by (team, environment) (
+    cloudcost_aws_ec2_instance_hourly_cost
+    * on (instance_id) group_right()
+    label_join(
+        label_join(aws_ec2_info, "environment", "tag_Environment")
+    "team", "tag_Team")
+)
+```

--- a/pkg/aws/compute/ec2/ec2.go
+++ b/pkg/aws/compute/ec2/ec2.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sync/errgroup"
 
+	cloudcostexporter "github.com/grafana/cloudcost-exporter"
 	"github.com/grafana/cloudcost-exporter/pkg/aws/compute"
 	ec2client "github.com/grafana/cloudcost-exporter/pkg/aws/services/ec2"
 	pricingClient "github.com/grafana/cloudcost-exporter/pkg/aws/services/pricing"
@@ -26,6 +27,15 @@ var (
 	ErrClientNotFound = errors.New("no client found")
 
 	ErrGeneratePricingMap = errors.New("error generating pricing map")
+)
+
+var (
+	totalHourlyCostDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(cloudcostexporter.MetricPrefix, subsystem, "instance_total_hourly_cost_per_hour"),
+		"The total hourly cost of the instance in USD/h",
+		[]string{"instance", "region", "family", "machine_type", "price_tier"},
+		nil,
+	)
 )
 
 // Collector is a prometheus collector that collects metrics from AWS EKS clusters.
@@ -56,7 +66,8 @@ func (c *Collector) CollectMetrics(_ chan<- prometheus.Metric) float64 {
 }
 
 // Collect satisfies the provider.Collector interface.
-func (c *Collector) Collect(_ chan<- prometheus.Metric) error {
+func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
+	now := time.Now()
 	c.logger.LogAttrs(c.context, slog.LevelInfo, "Collecting Metrics")
 	if c.pricingMap == nil || time.Now().After(c.NextScrape) {
 		now := time.Now()
@@ -104,11 +115,97 @@ func (c *Collector) Collect(_ chan<- prometheus.Metric) error {
 			slog.Duration("duration", time.Since(now)),
 		)
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	wg := sync.WaitGroup{}
+	wg.Add(len(c.Regions))
+	reservationsCh := make(chan []ec2Types.Reservation, len(c.Regions))
+
+	for _, region := range c.Regions {
+		go func(region ec2Types.Region) {
+			defer wg.Done()
+			c.logger.LogAttrs(ctx, slog.LevelInfo, "Fetching instances for region",
+				slog.String("region", *region.RegionName),
+			)
+
+			if _, ok := c.ec2RegionClient[*region.RegionName]; !ok {
+				c.logger.LogAttrs(ctx, slog.LevelError, "could not find client for region",
+					slog.String("region", *region.RegionName),
+				)
+				return
+			}
+			client := c.ec2RegionClient[*region.RegionName]
+			reservations, err := compute.ListComputeInstances(context.TODO(), client)
+			if err != nil {
+				c.logger.LogAttrs(ctx, slog.LevelError, "could not list instances",
+					slog.String("message", err.Error()),
+				)
+				return
+			}
+			reservationsCh <- reservations
+		}(region)
+	}
+	go func() {
+		wg.Wait()
+		close(reservationsCh)
+	}()
+
+	c.emitMetrics(reservationsCh, ch)
+
+	c.logger.LogAttrs(c.context, slog.LevelInfo, "Finished Collecting metrics",
+		slog.Duration("duration", time.Since(now)),
+	)
+
 	return nil
 }
 
-func (c *Collector) Describe(_ chan<- *prometheus.Desc) error {
-	c.logger.LogAttrs(c.context, slog.LevelInfo, "TODO - Implement ec2.Describe")
+func (c *Collector) emitMetrics(reservationsCh chan []ec2Types.Reservation, ch chan<- prometheus.Metric) {
+	for reservations := range reservationsCh {
+		for _, reservation := range reservations {
+			for _, instance := range reservation.Instances {
+				clusterName := compute.ClusterNameFromInstance(instance)
+				if clusterName != "" {
+					c.logger.LogAttrs(c.context, slog.LevelDebug, "filtering out instance that's associated with an eks cluster",
+						slog.String("instance", *instance.InstanceId))
+					continue
+				}
+				c.logger.LogAttrs(c.context, slog.LevelDebug, "instance found",
+					slog.String("instance", *instance.InstanceId))
+				region := *instance.Placement.AvailabilityZone
+
+				pricetier := "spot"
+				if instance.InstanceLifecycle != ec2Types.InstanceLifecycleTypeSpot {
+					pricetier = "ondemand"
+					// Ondemand instances are keyed based upon their region, so we need to remove the availability zone
+					region = region[:len(region)-1]
+				}
+				price, err := c.pricingMap.GetPriceForInstanceType(region, string(instance.InstanceType))
+				if err != nil {
+					c.logger.LogAttrs(c.context, slog.LevelError, "could not get price for instance type",
+						slog.String("instance_type", string(instance.InstanceType)),
+						slog.String("region", region),
+						slog.String("message", err.Error()),
+					)
+					continue
+				}
+
+				labelValues := []string{
+					*instance.PrivateDnsName,
+					region,
+					c.pricingMap.InstanceDetails[string(instance.InstanceType)].InstanceFamily,
+					string(instance.InstanceType),
+					pricetier,
+				}
+				ch <- prometheus.MustNewConstMetric(totalHourlyCostDesc, prometheus.GaugeValue, price.Total, labelValues...)
+			}
+		}
+	}
+}
+
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
+	c.logger.LogAttrs(c.context, slog.LevelInfo, "Calling describe")
+	ch <- totalHourlyCostDesc
 	return nil
 }
 


### PR DESCRIPTION
This PR ties together the https://github.com/grafana/cloudcost-exporter/pull/211 and lists out instances for a specific AWS profile. The code checks for instances that are not associated with a cluster and then emits a metric for the total hourly cost.

Adds documentation for how the collector is created and provides some basic PromQL queries that _could_ be used.