### PR TITLE
feat(gcp): Sloggify our gcp provider

### DIFF
--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -177,6 +177,7 @@ func selectProvider(ctx context.Context, cfg *config.Config) (provider.Provider,
 
 	case "gcp":
 		return google.New(&google.Config{
+			Logger:          cfg.Logger,
 			ProjectId:       cfg.ProjectID,
 			Region:          cfg.Providers.GCP.Region,
 			Projects:        cfg.Providers.GCP.Projects.String(),

--- a/pkg/google/gcp.go
+++ b/pkg/google/gcp.go
@@ -136,7 +136,7 @@ func New(config *Config) (*GCP, error) {
 				DefaultDiscount: config.DefaultDiscount,
 			}, cloudCatalogClient, regionsClient, storageClient)
 			if err != nil {
-				logger.LogAttrs(ctx, slog.LevelWarn, "Error creating collector",
+				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
 					slog.String("service", service),
 					slog.String("message", err.Error()))
 				continue
@@ -152,8 +152,7 @@ func New(config *Config) (*GCP, error) {
 				ScrapeInterval: config.ScrapeInterval,
 			}, computeService, cloudCatalogClient)
 		default:
-
-			logger.LogAttrs(ctx, slog.LevelWarn, "Error creating service, does not exist",
+			logger.LogAttrs(ctx, slog.LevelError, "Error creating service, does not exist",
 				slog.String("service", service))
 			continue
 		}

--- a/pkg/google/gcp_test.go
+++ b/pkg/google/gcp_test.go
@@ -2,6 +2,8 @@ package google
 
 import (
 	"fmt"
+	"log/slog"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -14,6 +16,8 @@ import (
 	mock_provider "github.com/grafana/cloudcost-exporter/pkg/provider/mocks"
 	"github.com/grafana/cloudcost-exporter/pkg/utils"
 )
+
+var logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 func Test_RegisterCollectors(t *testing.T) {
 	tests := map[string]struct {
@@ -47,6 +51,7 @@ func Test_RegisterCollectors(t *testing.T) {
 			gcp := &GCP{
 				config:     &Config{},
 				collectors: []provider.Collector{},
+				logger:     logger,
 			}
 			for i := 0; i < tt.numCollectors; i++ {
 				gcp.collectors = append(gcp.collectors, c)
@@ -174,6 +179,7 @@ func TestGCP_CollectMetrics(t *testing.T) {
 			gcp := &GCP{
 				config:     &Config{},
 				collectors: []provider.Collector{},
+				logger:     logger,
 			}
 
 			for i := 0; i < tt.numCollectors; i++ {


### PR DESCRIPTION
This is a multipart refactor to sloggify the gcp provider and collectors. I'll break each commit up into implementing functionality for GCP as a provider then GCS, GKE, Compute.