### PR TITLE
Azure: adding ability to get CPU, Memory, disk size per machine

### DIFF
--- a/pkg/azure/aks/aks.go
+++ b/pkg/azure/aks/aks.go
@@ -132,8 +132,8 @@ func (c *Collector) CollectMetrics(_ chan<- prometheus.Metric) float64 {
 }
 
 // TODO - BREAK INTO CPU AND RAM
-func (c *Collector) getMachinePrices(vmName string) (float64, error) {
-	vmInfo, err := c.MachineStore.getVmInfoByVmName(vmName)
+func (c *Collector) getMachinePrices(vmId string) (float64, error) {
+	vmInfo, err := c.MachineStore.getVmInfoByVmId(vmId)
 	if err != nil {
 		return 0.0, err
 	}
@@ -185,14 +185,14 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 
 	c.MachineStore.machineMapLock.RLock()
 	defer c.MachineStore.machineMapLock.RUnlock()
-	for vmName, vmInfo := range c.MachineStore.MachineMap {
-		price, err := c.getMachinePrices(vmName)
+	for vmId, vmInfo := range c.MachineStore.MachineMap {
+		price, err := c.getMachinePrices(vmId)
 		if err != nil {
 			return err
 		}
 
 		labelValues := []string{
-			vmName,
+			vmInfo.Name,
 			vmInfo.Region,
 			vmInfo.MachineTypeSku,
 			vmInfo.OwningCluster,

--- a/pkg/azure/aks/machine_store.go
+++ b/pkg/azure/aks/machine_store.go
@@ -187,6 +187,7 @@ func (m *MachineStore) getVmInfoFromVmss(ctx context.Context, rgName, vmssName, 
 			vmSizeInfo, ok := m.MachineSizeMap[vmRegion][vmSku]
 			if !ok {
 				m.logger.LogAttrs(ctx, slog.LevelDebug, "no VM sizing info found", slog.String("machineName", vmName))
+				continue
 			}
 
 			m.logger.LogAttrs(ctx, slog.LevelDebug, "found machine information", slog.String("machineName", vmName))

--- a/pkg/azure/aks/machine_store.go
+++ b/pkg/azure/aks/machine_store.go
@@ -57,7 +57,7 @@ type VirtualMachineInfo struct {
 	Priority        MachinePriority
 
 	NumOfCores     int32
-	MemoryInMB     int32
+	MemoryInMiB    int32
 	OsDiskSizeInMB int32
 }
 
@@ -197,7 +197,7 @@ func (m *MachineStore) getVmInfoFromVmss(ctx context.Context, rgName, vmssName, 
 					OperatingSystem: osInfo,
 
 					NumOfCores:     to.Int32(vmSizeInfo.NumberOfCores),
-					MemoryInMB:     to.Int32(vmSizeInfo.MemoryInMB),
+					MemoryInMiB:    to.Int32(vmSizeInfo.MemoryInMB),
 					OsDiskSizeInMB: to.Int32(vmSizeInfo.OSDiskSizeInMB),
 				}
 				m.logger.LogAttrs(ctx, slog.LevelDebug, "found machine information", slog.String("machineName", vmName))

--- a/pkg/azure/aks/machine_store.go
+++ b/pkg/azure/aks/machine_store.go
@@ -184,27 +184,27 @@ func (m *MachineStore) getVmInfoFromVmss(ctx context.Context, rgName, vmssName, 
 			}
 			vmId := to.String(v.Properties.VMID)
 
-			if vmSizeInfo, ok := m.MachineSizeMap[vmRegion][vmSku]; ok {
-				vmInfo[vmId] = &VirtualMachineInfo{
-					Name:            vmName,
-					Id:              vmId,
-					Region:          vmRegion,
-					OwningVMSS:      vmssName,
-					OwningCluster:   cluster,
-					MachineTypeSku:  vmSku,
-					MachineFamily:   vmFamily,
-					Priority:        priority,
-					OperatingSystem: osInfo,
-
-					NumOfCores:     to.Int32(vmSizeInfo.NumberOfCores),
-					MemoryInMiB:    to.Int32(vmSizeInfo.MemoryInMB),
-					OsDiskSizeInMB: to.Int32(vmSizeInfo.OSDiskSizeInMB),
-				}
-				m.logger.LogAttrs(ctx, slog.LevelDebug, "found machine information", slog.String("machineName", vmName))
-				continue
+			vmSizeInfo, ok := m.MachineSizeMap[vmRegion][vmSku]
+			if !ok {
+				m.logger.LogAttrs(ctx, slog.LevelDebug, "no VM sizing info found", slog.String("machineName", vmName))
 			}
 
-			m.logger.LogAttrs(ctx, slog.LevelDebug, "no VM sizing info found", slog.String("machineName", vmName))
+			m.logger.LogAttrs(ctx, slog.LevelDebug, "found machine information", slog.String("machineName", vmName))
+			vmInfo[vmId] = &VirtualMachineInfo{
+				Name:            vmName,
+				Id:              vmId,
+				Region:          vmRegion,
+				OwningVMSS:      vmssName,
+				OwningCluster:   cluster,
+				MachineTypeSku:  vmSku,
+				MachineFamily:   vmFamily,
+				Priority:        priority,
+				OperatingSystem: osInfo,
+
+				NumOfCores:     to.Int32(vmSizeInfo.NumberOfCores),
+				MemoryInMiB:    to.Int32(vmSizeInfo.MemoryInMB),
+				OsDiskSizeInMB: to.Int32(vmSizeInfo.OSDiskSizeInMB),
+			}
 		}
 	}
 

--- a/pkg/azure/aks/machine_store_test.go
+++ b/pkg/azure/aks/machine_store_test.go
@@ -43,7 +43,7 @@ func TestGetVmInfoByName(t *testing.T) {
 
 	for name, tc := range testTable {
 		t.Run(name, func(t *testing.T) {
-			machine, err := fakeMachineStore.getVmInfoByVmName(tc.machineName)
+			machine, err := fakeMachineStore.getVmInfoByVmId(tc.machineName)
 
 			if tc.expectedNil {
 				assert.Nil(t, machine)

--- a/pkg/azure/aks/machine_store_test.go
+++ b/pkg/azure/aks/machine_store_test.go
@@ -184,3 +184,46 @@ func TestGetMachineName(t *testing.T) {
 		})
 	}
 }
+
+func TestGetMachineFamily(t *testing.T) {
+	fakeMachineStore := &MachineStore{
+		logger: slog.Default(),
+	}
+	testTable := map[string]struct {
+		skuName        string
+		expectedFamily string
+		expectedErr    bool
+	}{
+		"General Purpose": {
+			skuName:        "D5v2",
+			expectedFamily: "GeneralPurpose",
+			expectedErr:    false,
+		},
+		"General Purpose - standard": {
+			skuName:        "Standard_D16_v3",
+			expectedFamily: "GeneralPurpose",
+			expectedErr:    false,
+		},
+		"Memory Optimized": {
+			skuName:        "M416ms_v2",
+			expectedFamily: "MemoryOptimized",
+			expectedErr:    false,
+		},
+		"GPU Accelerated": {
+			skuName:        "NC4as_T4_v3",
+			expectedFamily: "GPUAccelerated",
+			expectedErr:    false,
+		},
+	}
+
+	for name, tc := range testTable {
+		t.Run(name, func(t *testing.T) {
+			machineFamily, err := fakeMachineStore.getMachineFamilyFromSku(tc.skuName)
+			if tc.expectedErr {
+				assert.NotNil(t, err)
+			}
+
+			assert.Equal(t, tc.expectedFamily, machineFamily)
+		})
+	}
+}


### PR DESCRIPTION
Two changes:

### Add machine information
- Create a call to the `VirtualMachineSizes` client to get the different sizes of machines that are relevant for a particular subscription
- Add the Number of CPUs to a particular machines information
- Add the MB of RAM for a particular machine's information
- Add the size of the OS Boot Disk (not sure if this will every be relevant)
- Added a Machine Family classification system based on product SKU

### Index by Machine ID

The names of VMs as _nodes_ from a AKS cluster could not be globally unique.  VM IDs are.  Changing the identifier in the map to one that is globally unique.