### PR TITLE
fix(aws): Slog implementation

### DIFF
--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -3,6 +3,8 @@ package aws
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"os"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -12,6 +14,8 @@ import (
 	"github.com/grafana/cloudcost-exporter/pkg/provider"
 	mock_provider "github.com/grafana/cloudcost-exporter/pkg/provider/mocks"
 )
+
+var logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 func Test_New(t *testing.T) {
 	for _, tc := range []struct {
@@ -73,6 +77,7 @@ func Test_RegisterCollectors(t *testing.T) {
 			a := AWS{
 				Config:     nil,
 				collectors: []provider.Collector{},
+				logger:     logger,
 			}
 			for i := 0; i < tc.numCollectors; i++ {
 				a.collectors = append(a.collectors, c)
@@ -127,6 +132,7 @@ func Test_CollectMetrics(t *testing.T) {
 			a := AWS{
 				Config:     nil,
 				collectors: []provider.Collector{},
+				logger:     logger,
 			}
 			for i := 0; i < tc.numCollectors; i++ {
 				a.collectors = append(a.collectors, c)


### PR DESCRIPTION
It looks like in the previous PR to add ec2 module(https://github.com/grafana/cloudcost-exporter/pull/202/files), the slogger wasn't wired up to be used by the aws package. This updates all function calls to `aws.go` to use slog and sets the log levels appropriately.