### PR TITLE
docs(README): Add a pkg.go.dev badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cloud Cost Exporter
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/grafana/cloudcost-exporter.svg)](https://pkg.go.dev/github.com/grafana/cloudcost-exporter)
+
 Cloud Cost exporter is a designed to collect cost data from cloud providers and export the data in Prometheus format.
 The cost data can then be combined with usage data from tools such as stackdriver, yace, and promitor to measure the spend of resources at a granular level.
 


### PR DESCRIPTION
Updates README.md to add a [pkg.dev.go](https://pkg.go.dev/about#best-practices) badge to the readme. The badge links out to
https://pkg.go.dev/github.com/grafana/cloudcost-exporter, which hosts a parsed out version of all of the comments in go files.