### PR TITLE
Azure: Update locking mechanism

### DIFF
--- a/pkg/aws/ec2/pricing_map.go
+++ b/pkg/aws/ec2/pricing_map.go
@@ -198,7 +198,8 @@ func (spm *StructuredPricingMap) GetPriceForInstanceType(region string, instance
 }
 
 func (spm *StructuredPricingMap) CheckReadiness() bool {
-	return spm.m.TryRLock()
+	// TODO - implement
+	return true
 }
 
 // Attributes represents ec2 instance attributes that are pulled from AWS api's describing instances.

--- a/pkg/aws/s3/s3.go
+++ b/pkg/aws/s3/s3.go
@@ -277,7 +277,8 @@ func (s *BillingData) AddMetricGroup(region string, component string, group type
 }
 
 func (c *Collector) CheckReadiness() bool {
-	return c.m.TryRLock()
+	// TODO - implement
+	return true
 }
 
 // getBillingData is responsible for making the API call to the AWS Cost Explorer API and parsing the response

--- a/pkg/azure/aks/machine_store.go
+++ b/pkg/azure/aks/machine_store.go
@@ -277,7 +277,9 @@ func (m *MachineStore) getMachineTypesByLocation(ctx context.Context, location s
 }
 
 func (m *MachineStore) CheckReadiness() bool {
-	return m.machineSizeMapLock.TryRLock() && m.machineMapLock.TryRLock()
+	// TODO - come up with better way to check readiness,
+	// this seems very error-prone
+	return !m.currentlyPopulating
 }
 
 func (m *MachineStore) PopulateMachineStore(ctx context.Context) error {

--- a/pkg/azure/aks/price_store.go
+++ b/pkg/azure/aks/price_store.go
@@ -105,7 +105,7 @@ func NewPricingStore(parentContext context.Context, parentLogger *slog.Logger, s
 }
 
 func (p *PriceStore) CheckReadiness() bool {
-	return p.regionMapLock.TryRLock()
+	return !p.currentlyPopulating
 }
 
 func (p *PriceStore) getPriceBreakdownFromVmInfo(vmInfo *VirtualMachineInfo, price float64) *MachinePrices {

--- a/pkg/google/gcs/gcs.go
+++ b/pkg/google/gcs/gcs.go
@@ -178,7 +178,8 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
 }
 
 func (c *Collector) CheckReadiness() bool {
-	return c.CachedBuckets.m.TryRLock()
+	// TODO - implement
+	return true
 }
 
 func (c *Collector) Collect(ch chan<- prometheus.Metric) error {


### PR DESCRIPTION
In some initial testing, we've discovered that the combination of the readiness probe, machine store population, and prometheus scrape can cause a deadlocking situation.  This PR does a couple things:

- creates a temporary band-aid fix that moves the locking responsibility from the AKS collector to the individual machine and price stores
- removes the TryLock method of readiness probes from all other providers, as it cannot be trusted at the moment.