### PR TITLE
docs(developer-guide): Explicitly list external dependencies

### DIFF
--- a/docs/contribute/developer-guide.md
+++ b/docs/contribute/developer-guide.md
@@ -2,6 +2,15 @@
 
 This guide will help you get started with the development environment and how to contribute to the project.
 
+## External Dependencies
+
+There are two tools that we use to generate mocks for testing that need to be installed independently:
+1. [mockery](https://vektra.github.io/mockery/latest/installation/): See the note about _not_ using go tools to install
+2. [mockgen](https://github.com/uber-go/mock?tab=readme-ov-file#installation)
+
+Use the latest version available for both. 
+The tools are used by `make generate-mocks` in the [Makefile](https://github.com/grafana/cloudcost-exporter/blob/66b83baacf9ad4408f0ad7c7b1738ac3b2c179b2/Makefile#L28)
+
 ## Running Locally
 
 Prior to running the exporter, you will need to ensure you have the appropriate credentials for the cloud provider you are trying to export data for.


### PR DESCRIPTION
There are two external tools used by the project that are not defined by `go.mod`:
1. mockery
2. mockgen

This adds documentation on where to look for installation instructures and specifies to use the latest version. The primary reason why I suggest latest instead of the current version used is because PR's generated by the latest tools can serve as a reminder for others to upgrade their tooling. I don't know of a way we can automate the upgrade of those tools.