### PR TITLE
AZ AKS Collector: Update Machine Store order of operations

### DIFF
--- a/pkg/azure/aks/price_store.go
+++ b/pkg/azure/aks/price_store.go
@@ -209,8 +209,6 @@ func (p *PriceStore) PopulatePriceStore(ctx context.Context) {
 			return
 		}
 
-		p.logger.Debug("new page")
-
 		for _, v := range page.Items {
 			regionName := v.ArmRegionName
 			if regionName == "" {


### PR DESCRIPTION
Previously, the Machine Store was populating both the **machine sizes** and the **machine instances** in parallel.  Unfortunately, [machine instances is _dependent_ on machine sizes](https://github.com/grafana/cloudcost-exporter/blob/5f9e474dbe535e11fe8a22f5386e72badfed9824/pkg/azure/aks/machine_store.go#L174):

```go
        vmSizeInfo, ok := m.MachineSizeMap[vmRegion][vmSku]
	if !ok {
		m.logger.LogAttrs(ctx, slog.LevelDebug, "no VM sizing info found",
			slog.String("machineName", vmName),
			slog.String("region", vmRegion),
			slog.String("sku", vmSku),
		)
		continue
	}
```

Meaning that we would often run into a situation where sizing info was not found for machines because it hadn't populated yet.  

To fix, I've separated out the parallelization into:
- in parallel, region's machine sizes are fetched from the AZ API 
- AFTER, machine instances are fetched from the AZ API

In addition, I've added a bunch of debugging logs to assist the user.