### PR TITLE
Speed up Docker Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ COPY ["go.mod", "go.sum", "./"]
 RUN go mod download
 
 COPY . .
-RUN make build-binary
+
+ENV GOCACHE=/go/pkg/mod/
+RUN  --mount=type=cache,target="/go/pkg/mod/" make build-binary
 
 # Build Image
 FROM scratch


### PR DESCRIPTION
I was getting a little frustrated re-building the docker image after minor code changes, as it frequently took 30-60s to build.  After reading up a bit on the [mounting of caches](https://docs.docker.com/build/guide/mounts/) within Docker Build, I was able to speed up re-builds of the image by a fair amount.

**Without the cache**:
- first build: ~1m
- second build after a minor code change: 32s

**With the cache**:
- first build: ~1:04
- second build after a minor code change: 6s

This likely won't help our github action too much (unless we re-run it several times on the same agent), but it can speed up local dev a little bit.

```sh
# Clear out any lingering cached image layers
❯ docker system prune -f > /dev/null

# First build with original Dockerfile
❯ time docker build -q .            
sha256:e4359d6931ea87510378251645061989a9b84a7e14aafabe05a56945db915628
docker build -q .  0.88s user 0.89s system 2% cpu 1:00.85 total

# NOTE: here I made a no-op code change to force re-building of the binary inside the dockerfile
❯ time docker build -q .
sha256:4302ffce67e3286a6d2236c24394a8d29dabcfc52108540791cf9d0f9efcca53
docker build -q .  0.54s user 0.46s system 3% cpu 32.354 total

# Clear out any lingering cached image layers
❯ docker system prune -f > /dev/null

# First build with modified Dockerfile, including the cache
❯ time docker build -q .            
sha256:6cbedc0e12bdca250bcdb7774c06f1cace36fb2834c301066e281dcf17fbd735
docker build -q .  0.90s user 0.98s system 2% cpu 1:04.64 total

# NOTE: here I made a no-op code change to force re-building of the binary inside the dockerfile
❯ time docker build -q .
sha256:3ab8991727b724bd844bca31affe80fff22eda937973bedcb95dac343fda516d
docker build -q .  0.31s user 0.24s system 9% cpu 6.099 total
```