### PR TITLE
Azure: modify priority to be lowercase

### DIFF
--- a/pkg/azure/aks/aks.go
+++ b/pkg/azure/aks/aks.go
@@ -39,7 +39,7 @@ const (
 	Spot
 )
 
-var machinePriorityNames [2]string = [2]string{"OnDemand", "Spot"}
+var machinePriorityNames [2]string = [2]string{"ondemand", "spot"}
 
 func (mp MachinePriority) String() string {
 	return machinePriorityNames[mp]

--- a/pkg/azure/aks/machine_store_test.go
+++ b/pkg/azure/aks/machine_store_test.go
@@ -61,7 +61,7 @@ func TestGetVmInfoByName(t *testing.T) {
 func TestGetMachineScaleSetPriority(t *testing.T) {
 	testTable := map[string]struct {
 		vmssObject       *armcompute.VirtualMachineScaleSet
-		expectedPriority MachinePriority
+		expectedPriority string
 	}{
 		"spot": {
 			vmssObject: &armcompute.VirtualMachineScaleSet{
@@ -71,7 +71,7 @@ func TestGetMachineScaleSetPriority(t *testing.T) {
 					},
 				},
 			},
-			expectedPriority: Spot,
+			expectedPriority: "spot",
 		},
 		"on demand": {
 			vmssObject: &armcompute.VirtualMachineScaleSet{
@@ -81,14 +81,14 @@ func TestGetMachineScaleSetPriority(t *testing.T) {
 					},
 				},
 			},
-			expectedPriority: OnDemand,
+			expectedPriority: "ondemand",
 		},
 	}
 
 	for name, tc := range testTable {
 		t.Run(name, func(t *testing.T) {
 			priority := getMachineScaleSetPriority(tc.vmssObject)
-			assert.Equal(t, tc.expectedPriority, priority)
+			assert.Equal(t, tc.expectedPriority, priority.String())
 		})
 	}
 }


### PR DESCRIPTION
All other compute collectors use lowercase for their priority, Azure shouldn't be any different.

EC2

```sh
cloudcost_aws_ec2_instance_total_usd_per_hour{cluster_name="<redacted>",family="Memory optimized",instance="<redacted>",machine_type="r4.4xlarge",price_tier="ondemand",region="<redacted>"} 1.064

...

cloudcost_aws_ec2_instance_cpu_usd_per_core_hour{cluster_name="<redacted>",family="Memory optimized",instance="<redacted>",machine_type="r7g.xlarge",price_tier="spot",region="<redacted>"} 0.008759999999999999
```

GCP Compute
```sh
cloudcost_gcp_gke_instance_memory_usd_per_gib_hour{cluster_name="<redacted>",family="n2",instance="<redacted>",machine_type="n2-standard-16",price_tier="spot",project="<redacted>",region="<redacted>"} 0.001196

...

cloudcost_gcp_gke_instance_memory_usd_per_gib_hour{cluster_name="<redacted>",family="n2",instance="<redacted>",machine_type="n2-highmem-4",price_tier="ondemand",project="<redacted>",region="<redacted>"} 0.004237
```
