### PR TITLE
AZ: Add main interface tests 

### DIFF
--- a/pkg/azure/aks/aks.go
+++ b/pkg/azure/aks/aks.go
@@ -166,10 +166,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 	c.logger.Info("collecting metrics")
 	now := time.Now()
 
-	machineList, err := c.MachineStore.GetListOfVmsForSubscription()
-	if err != nil {
-		return err
-	}
+	machineList := c.MachineStore.GetListOfVmsForSubscription()
 
 	for _, vmInfo := range machineList {
 		vmId := vmInfo.Id

--- a/pkg/azure/aks/machine_store.go
+++ b/pkg/azure/aks/machine_store.go
@@ -313,7 +313,7 @@ func (m *MachineStore) CheckReadiness() bool {
 	return true
 }
 
-func (m *MachineStore) GetListOfVmsForSubscription() ([]*VirtualMachineInfo, error) {
+func (m *MachineStore) GetListOfVmsForSubscription() []*VirtualMachineInfo {
 	m.machineMapLock.RLock()
 	defer m.machineMapLock.RUnlock()
 
@@ -322,7 +322,7 @@ func (m *MachineStore) GetListOfVmsForSubscription() ([]*VirtualMachineInfo, err
 		vmi = append(vmi, vmInfo)
 	}
 
-	return vmi, nil
+	return vmi
 }
 
 func (m *MachineStore) PopulateMachineStore(ctx context.Context) {

--- a/pkg/azure/aks/machine_store_test.go
+++ b/pkg/azure/aks/machine_store_test.go
@@ -15,6 +15,40 @@ func TestMachineStoreMapCreation(t *testing.T) {
 	t.Skip()
 }
 
+func TestGetListOfVmsForSubscription(t *testing.T) {
+	fakeMachineStore := &MachineStore{
+		MachineMap:     make(map[string]*VirtualMachineInfo),
+		machineMapLock: &sync.RWMutex{},
+	}
+	fakeMachineStore.MachineMap["vm1"] = &VirtualMachineInfo{
+		Name: "vm1",
+	}
+	fakeMachineStore.MachineMap["vm2"] = &VirtualMachineInfo{
+		Name: "vm2",
+	}
+
+	testTable := map[string]struct {
+		expectedNames []string
+	}{
+		"base_case": {
+			expectedNames: []string{"vm1", "vm2"},
+		},
+	}
+
+	for name, tc := range testTable {
+		t.Run(name, func(t *testing.T) {
+			vmList := fakeMachineStore.GetListOfVmsForSubscription()
+			var vmNameList []string
+
+			for _, v := range vmList {
+				vmNameList = append(vmNameList, v.Name)
+			}
+
+			assert.ElementsMatch(t, tc.expectedNames, vmNameList)
+		})
+	}
+}
+
 func TestGetVmInfoByName(t *testing.T) {
 	fakeMachineStore := &MachineStore{
 		MachineMap:     make(map[string]*VirtualMachineInfo),

--- a/pkg/azure/azure_test.go
+++ b/pkg/azure/azure_test.go
@@ -6,7 +6,11 @@ import (
 	"os"
 	"testing"
 
+	mock_provider "github.com/grafana/cloudcost-exporter/pkg/provider/mocks"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 var (
@@ -36,6 +40,93 @@ func Test_New(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.NotNil(t, a)
+		})
+	}
+}
+
+func Test_RegisterCollectors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRegistry := mock_provider.NewMockRegistry(ctrl)
+
+	testCases := map[string]struct {
+		mockCollectors []*mock_provider.MockCollector
+		expectedErr    error
+	}{
+		"no collectors": {
+			mockCollectors: []*mock_provider.MockCollector{},
+		},
+		"AKS collector": {
+			mockCollectors: []*mock_provider.MockCollector{
+				mock_provider.NewMockCollector(ctrl),
+			},
+		},
+		"AKS and future storage collector": {
+			mockCollectors: []*mock_provider.MockCollector{
+				mock_provider.NewMockCollector(ctrl),
+				mock_provider.NewMockCollector(ctrl),
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			azProvider := &Azure{
+				logger:  testLogger,
+				context: parentCtx,
+			}
+			for _, c := range tc.mockCollectors {
+				call := c.EXPECT().Register(gomock.Any()).AnyTimes()
+				call.Return(nil)
+
+				azProvider.collectors = append(azProvider.collectors, c)
+			}
+
+			mockRegistry.EXPECT().MustRegister(gomock.Any()).Times(1)
+			err := azProvider.RegisterCollectors(mockRegistry)
+			assert.Equal(t, err, tc.expectedErr)
+		})
+	}
+}
+
+func Test_CollectMetrics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fakePromCh := make(chan prometheus.Metric)
+	testCases := map[string]struct {
+		mockCollectors []*mock_provider.MockCollector
+		expectedErr    error
+	}{
+		"base case": {
+			mockCollectors: []*mock_provider.MockCollector{
+				mock_provider.NewMockCollector(ctrl),
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			go func() {
+				for range fakePromCh {
+					// no metrics are generated here, so loop through to avoid
+					// process hang waiting on metrics that will never come
+				}
+			}()
+
+			azProvider := &Azure{
+				logger:  testLogger,
+				context: parentCtx,
+			}
+			for _, c := range tc.mockCollectors {
+				c.EXPECT().Collect(gomock.Any()).Times(1)
+				c.EXPECT().Name().AnyTimes()
+
+				azProvider.collectors = append(azProvider.collectors, c)
+			}
+
+			azProvider.Collect(fakePromCh)
 		})
 	}
 }

--- a/pkg/azure/azure_test.go
+++ b/pkg/azure/azure_test.go
@@ -94,7 +94,7 @@ func Test_CollectMetrics(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	fakePromCh := make(chan prometheus.Metric)
+	ch := make(chan prometheus.Metric)
 	testCases := map[string]struct {
 		mockCollectors []*mock_provider.MockCollector
 		expectedErr    error
@@ -109,9 +109,9 @@ func Test_CollectMetrics(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			go func() {
-				for range fakePromCh {
-					// no metrics are generated here, so loop through to avoid
-					// process hang waiting on metrics that will never come
+				// no metrics are generated here, so loop through to avoid
+				// process hang waiting on metrics that will never come
+				for range ch {
 				}
 			}()
 
@@ -126,7 +126,7 @@ func Test_CollectMetrics(t *testing.T) {
 				azProvider.collectors = append(azProvider.collectors, c)
 			}
 
-			azProvider.Collect(fakePromCh)
+			azProvider.Collect(ch)
 		})
 	}
 }


### PR DESCRIPTION
Adding some interface tests for the Azure collector using `gomock`.

Ninja add: updating `GetListOfVmsForSubscription` that never returns an error to simply return a machine list.