### PR TITLE
compute: use "node" instead of "instance" label name

### DIFF
--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -33,19 +33,19 @@ var (
 	InstanceCPUHourlyCostDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(cloudcostexporter.MetricPrefix, subsystem, "instance_cpu_usd_per_core_hour"),
 		"The cpu cost a ec2 instance in USD/(core*h)",
-		[]string{"instance", "region", "family", "machine_type", "cluster_name", "price_tier"},
+		[]string{"node", "region", "family", "machine_type", "cluster_name", "price_tier"},
 		nil,
 	)
 	InstanceMemoryHourlyCostDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(cloudcostexporter.MetricPrefix, subsystem, "instance_memory_usd_per_gib_hour"),
 		"The memory cost of a ec2 instance in USD/(GiB*h)",
-		[]string{"instance", "region", "family", "machine_type", "cluster_name", "price_tier"},
+		[]string{"node", "region", "family", "machine_type", "cluster_name", "price_tier"},
 		nil,
 	)
 	InstanceTotalHourlyCostDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(cloudcostexporter.MetricPrefix, subsystem, "instance_total_usd_per_hour"),
 		"The total cost of the ec2 instance in USD/h",
-		[]string{"instance", "region", "family", "machine_type", "cluster_name", "price_tier"},
+		[]string{"node", "region", "family", "machine_type", "cluster_name", "price_tier"},
 		nil,
 	)
 )

--- a/pkg/azure/aks/aks.go
+++ b/pkg/azure/aks/aks.go
@@ -59,19 +59,19 @@ var (
 	InstanceCPUHourlyCostDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(cloudcost_exporter.MetricPrefix, subsystem, "instance_cpu_usd_per_core_hour"),
 		"The cpu cost a compute instance in USD/(core*h)",
-		[]string{"instance", "region", "machine_type", "family", "cluster_name", "price_tier", "operating_system"},
+		[]string{"node", "region", "machine_type", "family", "cluster_name", "price_tier", "operating_system"},
 		nil,
 	)
 	InstanceMemoryHourlyCostDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(cloudcost_exporter.MetricPrefix, subsystem, "instance_memory_usd_per_gib_hour"),
 		"The memory cost of a compute instance in USD/(GiB*h)",
-		[]string{"instance", "region", "machine_type", "family", "cluster_name", "price_tier", "operating_system"},
+		[]string{"node", "region", "machine_type", "family", "cluster_name", "price_tier", "operating_system"},
 		nil,
 	)
 	InstanceTotalHourlyCostDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(cloudcost_exporter.MetricPrefix, subsystem, "instance_total_usd_per_hour"),
 		"The total cost of an compute instance in USD/h",
-		[]string{"instance", "region", "machine_type", "family", "cluster_name", "price_tier", "operating_system"},
+		[]string{"node", "region", "machine_type", "family", "cluster_name", "price_tier", "operating_system"},
 		nil,
 	)
 )

--- a/pkg/google/compute/compute.go
+++ b/pkg/google/compute/compute.go
@@ -36,13 +36,13 @@ var (
 	InstanceCPUHourlyCostDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(cloudcost_exporter.MetricPrefix, subsystem, "instance_cpu_usd_per_core_hour"),
 		"The cpu cost a GCP Compute Instance in USD/(core*h)",
-		[]string{"instance", "region", "family", "machine_type", "project", "price_tier"},
+		[]string{"node", "region", "family", "machine_type", "project", "price_tier"},
 		nil,
 	)
 	InstanceMemoryHourlyCostDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(cloudcost_exporter.MetricPrefix, subsystem, "instance_ram_usd_per_gib_hour"),
 		"The memory cost of a GCP Compute Instance in USD/(GiB*h)",
-		[]string{"instance", "region", "family", "machine_type", "project", "price_tier"},
+		[]string{"node", "region", "family", "machine_type", "project", "price_tier"},
 		nil,
 	)
 )

--- a/pkg/google/compute/compute_test.go
+++ b/pkg/google/compute/compute_test.go
@@ -56,7 +56,7 @@ func TestNewMachineSpec(t *testing.T) {
 		instance *compute.Instance
 		want     *MachineSpec
 	}{
-		"basic instance": {
+		"basic node": {
 			instance: &compute.Instance{
 				Name:        "test",
 				MachineType: "abc/abc-def",
@@ -94,7 +94,7 @@ func TestNewMachineSpec(t *testing.T) {
 				PriceTier:    "ondemand",
 			},
 		},
-		"spot instance": {
+		"spot node": {
 			instance: &compute.Instance{
 				Name:        "test",
 				MachineType: "abc/abc-def",
@@ -151,7 +151,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_compute_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1",
+						"node":         "test-n1",
 						"machine_type": "n1-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing",
@@ -164,7 +164,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_compute_instance_ram_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1",
+						"node":         "test-n1",
 						"machine_type": "n1-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing",
@@ -177,7 +177,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_compute_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2",
+						"node":         "test-n2",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing",
@@ -190,7 +190,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_compute_instance_ram_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2",
+						"node":         "test-n2",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing",
@@ -203,7 +203,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_compute_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1-spot",
+						"node":         "test-n1-spot",
 						"machine_type": "n1-slim",
 						"price_tier":   "spot",
 						"project":      "testing",
@@ -216,7 +216,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_compute_instance_ram_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1-spot",
+						"node":         "test-n1-spot",
 						"machine_type": "n1-slim",
 						"price_tier":   "spot",
 						"project":      "testing",
@@ -229,7 +229,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_compute_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2-us-east1",
+						"node":         "test-n2-us-east1",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing",
@@ -242,7 +242,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_compute_instance_ram_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2-us-east1",
+						"node":         "test-n2-us-east1",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing",
@@ -255,7 +255,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_compute_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1",
+						"node":         "test-n1",
 						"machine_type": "n1-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing-1",
@@ -268,7 +268,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_compute_instance_ram_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1",
+						"node":         "test-n1",
 						"machine_type": "n1-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing-1",
@@ -281,7 +281,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_compute_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2",
+						"node":         "test-n2",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing-1",
@@ -294,7 +294,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_compute_instance_ram_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2",
+						"node":         "test-n2",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing-1",
@@ -307,7 +307,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_compute_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1-spot",
+						"node":         "test-n1-spot",
 						"machine_type": "n1-slim",
 						"price_tier":   "spot",
 						"project":      "testing-1",
@@ -320,7 +320,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_compute_instance_ram_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1-spot",
+						"node":         "test-n1-spot",
 						"machine_type": "n1-slim",
 						"price_tier":   "spot",
 						"project":      "testing-1",
@@ -333,7 +333,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_compute_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2-us-east1",
+						"node":         "test-n2-us-east1",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing-1",
@@ -346,7 +346,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_compute_instance_ram_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2-us-east1",
+						"node":         "test-n2-us-east1",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing-1",

--- a/pkg/google/gke/gke.go
+++ b/pkg/google/gke/gke.go
@@ -29,14 +29,14 @@ var (
 
 		"The cpu cost a GKE Instance in USD/(core*h)",
 		// Cannot simply do cluster because many metric scrapers will add a label for cluster and would interfere with the label we want to add
-		[]string{"cluster_name", "instance", "region", "family", "machine_type", "project", "price_tier"},
+		[]string{"cluster_name", "node", "region", "family", "machine_type", "project", "price_tier"},
 		nil,
 	)
 	gkeNodeCPUHourlyCostDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(cloudcostexporter.MetricPrefix, subsystem, "instance_cpu_usd_per_core_hour"),
 		"The memory cost of a GKE Instance in USD/(GiB*h)",
 		// Cannot simply do cluster because many metric scrapers will add a label for cluster and would interfere with the label we want to add
-		[]string{"cluster_name", "instance", "region", "family", "machine_type", "project", "price_tier"},
+		[]string{"cluster_name", "node", "region", "family", "machine_type", "project", "price_tier"},
 		nil,
 	)
 	persistentVolumeHourlyCostDesc = prometheus.NewDesc(

--- a/pkg/google/gke/gke_test.go
+++ b/pkg/google/gke/gke_test.go
@@ -53,7 +53,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1",
+						"node":         "test-n1",
 						"machine_type": "n1-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing",
@@ -67,7 +67,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_memory_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1",
+						"node":         "test-n1",
 						"machine_type": "n1-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing",
@@ -81,7 +81,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2",
+						"node":         "test-n2",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing",
@@ -95,7 +95,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_memory_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2",
+						"node":         "test-n2",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing",
@@ -109,7 +109,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1-spot",
+						"node":         "test-n1-spot",
 						"machine_type": "n1-slim",
 						"price_tier":   "spot",
 						"project":      "testing",
@@ -123,7 +123,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_memory_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1-spot",
+						"node":         "test-n1-spot",
 						"machine_type": "n1-slim",
 						"price_tier":   "spot",
 						"project":      "testing",
@@ -137,7 +137,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2-us-east1",
+						"node":         "test-n2-us-east1",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing",
@@ -151,7 +151,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_memory_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2-us-east1",
+						"node":         "test-n2-us-east1",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing",
@@ -194,7 +194,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1",
+						"node":         "test-n1",
 						"machine_type": "n1-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing-1",
@@ -208,7 +208,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_memory_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1",
+						"node":         "test-n1",
 						"machine_type": "n1-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing-1",
@@ -222,7 +222,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2",
+						"node":         "test-n2",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing-1",
@@ -236,7 +236,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_memory_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2",
+						"node":         "test-n2",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing-1",
@@ -250,7 +250,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1-spot",
+						"node":         "test-n1-spot",
 						"machine_type": "n1-slim",
 						"price_tier":   "spot",
 						"project":      "testing-1",
@@ -264,7 +264,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_memory_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1-spot",
+						"node":         "test-n1-spot",
 						"machine_type": "n1-slim",
 						"price_tier":   "spot",
 						"project":      "testing-1",
@@ -278,7 +278,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2-us-east1",
+						"node":         "test-n2-us-east1",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing-1",
@@ -292,7 +292,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_memory_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2-us-east1",
+						"node":         "test-n2-us-east1",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing-1",


### PR DESCRIPTION
Ref: #262.

See #262 for the rationale, this PR implements straightfwd
`s/instance/node/`, alternatively we could consider this to be
optionally behind a flag, although increasing complexity for main to
CSP modules coupling and test cases.

Signed-off-by: JuanJo Ciarlante <juanjosec@gmail.com>
