### PR TITLE
ci(CODEOWNERS): Add default CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default all reviews to be Grafana's Capacity squad
+* @grafana/platform-capacity


### PR DESCRIPTION
Create a CODEOWNERS that defaults all reviews to the platform capacity squad from Grafana Labs. This ensures no PR's go without someone getting notified that there is a PR to review.