### PR TITLE
compute: allow "instance" label name to be set (behind a flag)

### DIFF
--- a/cmd/exporter/config/config.go
+++ b/cmd/exporter/config/config.go
@@ -5,10 +5,15 @@ import (
 	"time"
 )
 
+type CommonConfig struct {
+	ComputeInstanceLabel string
+}
+
 type Config struct {
-	Provider  string
-	ProjectID string
-	Providers struct {
+	Provider     string
+	ProjectID    string
+	CommonConfig CommonConfig
+	Providers    struct {
 		AWS struct {
 			Profile  string
 			Region   string

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -31,6 +31,7 @@ import (
 
 func main() {
 	var cfg config.Config
+	commonFlags(&cfg)
 	providerFlags(flag.CommandLine, &cfg)
 	operationalFlags(&cfg)
 	flag.Parse()
@@ -76,6 +77,10 @@ func providerFlags(fs *flag.FlagSet, cfg *config.Config) {
 	flag.StringVar(&cfg.ProjectID, "project-id", "ops-tools-1203", "Project ID to target.")
 	flag.StringVar(&cfg.Providers.Azure.SubscriptionId, "azure.subscription-id", "", "Azure subscription ID to pull data from.")
 	flag.IntVar(&cfg.Providers.GCP.DefaultGCSDiscount, "gcp.default-discount", 19, "GCP default discount")
+}
+
+func commonFlags(cfg *config.Config) {
+	flag.StringVar(&cfg.CommonConfig.ComputeInstanceLabel, "compute.instance-label", "instance", "instance label name")
 }
 
 // operationalFlags is a helper method that is responsible for setting up the flags that are used to configure the operational aspects of the application.
@@ -169,6 +174,7 @@ func selectProvider(ctx context.Context, cfg *config.Config) (provider.Provider,
 	switch cfg.Provider {
 	case "azure":
 		return azure.New(ctx, &azure.Config{
+			CommonConfig:     &cfg.CommonConfig,
 			Logger:           cfg.Logger,
 			SubscriptionId:   cfg.Providers.Azure.SubscriptionId,
 			Services:         cfg.Providers.Azure.Services,
@@ -176,6 +182,7 @@ func selectProvider(ctx context.Context, cfg *config.Config) (provider.Provider,
 		})
 	case "aws":
 		return aws.New(ctx, &aws.Config{
+			CommonConfig:   &cfg.CommonConfig,
 			Logger:         cfg.Logger,
 			Region:         cfg.Providers.AWS.Region,
 			Profile:        cfg.Providers.AWS.Profile,
@@ -185,6 +192,7 @@ func selectProvider(ctx context.Context, cfg *config.Config) (provider.Provider,
 
 	case "gcp":
 		return google.New(&google.Config{
+			CommonConfig:    &cfg.CommonConfig,
 			Logger:          cfg.Logger,
 			ProjectId:       cfg.ProjectID,
 			Region:          cfg.Providers.GCP.Region,

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/pricing"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/grafana/cloudcost-exporter/cmd/exporter/config"
 	ec2Collector "github.com/grafana/cloudcost-exporter/pkg/aws/ec2"
 
 	cloudcost_exporter "github.com/grafana/cloudcost-exporter"
@@ -28,6 +29,7 @@ type Config struct {
 	Region         string
 	Profile        string
 	ScrapeInterval time.Duration
+	CommonConfig   *config.CommonConfig
 	Logger         *slog.Logger
 }
 
@@ -144,6 +146,7 @@ func New(ctx context.Context, config *Config) (*AWS, error) {
 				regionClientMap[*r.RegionName] = client
 			}
 			collector := ec2Collector.New(&ec2Collector.Config{
+				CommonConfig:   config.CommonConfig,
 				Regions:        regions.Regions,
 				RegionClients:  regionClientMap,
 				Logger:         logger,

--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -30,7 +30,7 @@ var (
 	ErrGeneratePricingMap = errors.New("error generating pricing map")
 )
 
-type CollectorMetrics struct {
+type collectorMetrics struct {
 	InstanceCPUHourlyCostDesc    *prometheus.Desc
 	InstanceMemoryHourlyCostDesc *prometheus.Desc
 	InstanceTotalHourlyCostDesc  *prometheus.Desc
@@ -44,7 +44,7 @@ type Collector struct {
 	pricingService   pricingClient.Pricing
 	NextScrape       time.Time
 	ec2RegionClients map[string]ec2client.EC2
-	metrics          *CollectorMetrics
+	metrics          *collectorMetrics
 	logger           *slog.Logger
 }
 
@@ -56,8 +56,8 @@ type Config struct {
 	Logger         *slog.Logger
 }
 
-func newCollectorMetrics(instanceLabel string) *CollectorMetrics {
-	return &CollectorMetrics{
+func newCollectorMetrics(instanceLabel string) *collectorMetrics {
+	return &collectorMetrics{
 		InstanceCPUHourlyCostDesc: prometheus.NewDesc(
 			prometheus.BuildFQName(cloudcostexporter.MetricPrefix, subsystem, "instance_cpu_usd_per_core_hour"),
 			"The cpu cost a ec2 instance in USD/(core*h)",

--- a/pkg/azure/aks/aks.go
+++ b/pkg/azure/aks/aks.go
@@ -57,14 +57,14 @@ var (
 
 // Prometheus Metrics
 
-type CollectorMetrics struct {
+type collectorMetrics struct {
 	InstanceCPUHourlyCostDesc    *prometheus.Desc
 	InstanceMemoryHourlyCostDesc *prometheus.Desc
 	InstanceTotalHourlyCostDesc  *prometheus.Desc
 }
 
-func newCollectorMetrics(instanceLabel string) *CollectorMetrics {
-	return &CollectorMetrics{
+func newCollectorMetrics(instanceLabel string) *collectorMetrics {
+	return &collectorMetrics{
 		InstanceCPUHourlyCostDesc: prometheus.NewDesc(
 			prometheus.BuildFQName(cloudcost_exporter.MetricPrefix, subsystem, "instance_cpu_usd_per_core_hour"),
 			"The cpu cost a compute instance in USD/(core*h)",
@@ -90,7 +90,7 @@ func newCollectorMetrics(instanceLabel string) *CollectorMetrics {
 type Collector struct {
 	context context.Context
 	logger  *slog.Logger
-	metrics *CollectorMetrics
+	metrics *collectorMetrics
 
 	PriceStore   *PriceStore
 	MachineStore *MachineStore

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/grafana/cloudcost-exporter/cmd/exporter/config"
 	"github.com/grafana/cloudcost-exporter/pkg/azure/aks"
 	"github.com/grafana/cloudcost-exporter/pkg/provider"
 
@@ -96,7 +97,8 @@ type Azure struct {
 }
 
 type Config struct {
-	Logger *slog.Logger
+	Logger       *slog.Logger
+	CommonConfig *config.CommonConfig
 
 	SubscriptionId string
 
@@ -126,6 +128,7 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 			collector, err := aks.New(ctx, &aks.Config{
 				Credentials:    creds,
 				SubscriptionId: config.SubscriptionId,
+				CommonConfig:   config.CommonConfig,
 				Logger:         logger,
 			})
 			if err != nil {

--- a/pkg/azure/azure_test.go
+++ b/pkg/azure/azure_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/grafana/cloudcost-exporter/cmd/exporter/config"
 	mock_provider "github.com/grafana/cloudcost-exporter/pkg/provider/mocks"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
@@ -19,6 +20,7 @@ var (
 )
 
 func Test_New(t *testing.T) {
+	commonConfig := &config.CommonConfig{ComputeInstanceLabel: "instance"}
 	for _, tc := range []struct {
 		name           string
 		expectedError  error
@@ -32,6 +34,7 @@ func Test_New(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			a, err := New(parentCtx, &Config{
 				Logger:         testLogger,
+				CommonConfig:   commonConfig,
 				SubscriptionId: tc.subscriptionId,
 			})
 			if tc.expectedError != nil {

--- a/pkg/google/compute/compute.go
+++ b/pkg/google/compute/compute.go
@@ -33,7 +33,7 @@ type Config struct {
 	ScrapeInterval time.Duration
 }
 
-type CollectorMetrics struct {
+type collectorMetrics struct {
 	NextScrapeDesc               *prometheus.Desc
 	InstanceCPUHourlyCostDesc    *prometheus.Desc
 	InstanceMemoryHourlyCostDesc *prometheus.Desc
@@ -46,12 +46,12 @@ type Collector struct {
 	PricingMap     *StructuredPricingMap
 	config         *Config
 	Projects       []string
-	metrics        *CollectorMetrics
+	metrics        *collectorMetrics
 	NextScrape     time.Time
 }
 
-func newCollectorMetrics(instanceLabel string) *CollectorMetrics {
-	return &CollectorMetrics{
+func newCollectorMetrics(instanceLabel string) *collectorMetrics {
+	return &collectorMetrics{
 		NextScrapeDesc: prometheus.NewDesc(
 			prometheus.BuildFQName(cloudcost_exporter.ExporterName, subsystem, "next_scrape"),
 			"Next time GCP's compute submodule pricing map will be refreshed as unix timestamp",

--- a/pkg/google/gcp.go
+++ b/pkg/google/gcp.go
@@ -15,6 +15,7 @@ import (
 	computev1 "google.golang.org/api/compute/v1"
 
 	cloudcost_exporter "github.com/grafana/cloudcost-exporter"
+	"github.com/grafana/cloudcost-exporter/cmd/exporter/config"
 	"github.com/grafana/cloudcost-exporter/pkg/google/compute"
 	"github.com/grafana/cloudcost-exporter/pkg/google/gcs"
 	"github.com/grafana/cloudcost-exporter/pkg/google/gke"
@@ -91,6 +92,7 @@ type Config struct {
 	Services        []string
 	ScrapeInterval  time.Duration
 	DefaultDiscount int
+	CommonConfig    *config.CommonConfig
 	Logger          *slog.Logger
 }
 
@@ -143,11 +145,13 @@ func New(config *Config) (*GCP, error) {
 			}
 		case "COMPUTE":
 			collector = compute.New(&compute.Config{
+				CommonConfig:   config.CommonConfig,
 				Projects:       config.Projects,
 				ScrapeInterval: config.ScrapeInterval,
 			}, computeService, cloudCatalogClient)
 		case "GKE":
 			collector = gke.New(&gke.Config{
+				CommonConfig:   config.CommonConfig,
 				Projects:       config.Projects,
 				ScrapeInterval: config.ScrapeInterval,
 			}, computeService, cloudCatalogClient)

--- a/pkg/google/gke/gke.go
+++ b/pkg/google/gke/gke.go
@@ -24,7 +24,7 @@ const (
 	subsystem = "gcp_gke"
 )
 
-type CollectorMetrics struct {
+type collectorMetrics struct {
 	gkeNodeMemoryHourlyCostDesc    *prometheus.Desc
 	gkeNodeCPUHourlyCostDesc       *prometheus.Desc
 	persistentVolumeHourlyCostDesc *prometheus.Desc
@@ -42,12 +42,12 @@ type Collector struct {
 	config            *Config
 	Projects          []string
 	ComputePricingMap *gcpCompute.StructuredPricingMap
-	metrics           *CollectorMetrics
+	metrics           *collectorMetrics
 	NextScrape        time.Time
 }
 
-func newCollectorMetrics(instanceLabel string) *CollectorMetrics {
-	return &CollectorMetrics{
+func newCollectorMetrics(instanceLabel string) *collectorMetrics {
+	return &collectorMetrics{
 		gkeNodeMemoryHourlyCostDesc: prometheus.NewDesc(
 			prometheus.BuildFQName(cloudcostexporter.MetricPrefix, subsystem, "instance_memory_usd_per_gib_hour"),
 

--- a/pkg/google/gke/gke_test.go
+++ b/pkg/google/gke/gke_test.go
@@ -18,12 +18,15 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/grafana/cloudcost-exporter/cmd/exporter/config"
 	"github.com/grafana/cloudcost-exporter/pkg/google/billing"
 	"github.com/grafana/cloudcost-exporter/pkg/google/compute"
 	"github.com/grafana/cloudcost-exporter/pkg/utils"
 )
 
 func TestCollector_Collect(t *testing.T) {
+	instanceLabel := "node"
+	commonConfig := &config.CommonConfig{ComputeInstanceLabel: instanceLabel}
 	tests := map[string]struct {
 		config          *Config
 		testServer      *httptest.Server
@@ -33,7 +36,8 @@ func TestCollector_Collect(t *testing.T) {
 	}{
 		"Handle http error": {
 			config: &Config{
-				Projects: "testing",
+				CommonConfig: commonConfig,
+				Projects:     "testing",
 			},
 			testServer: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
@@ -44,7 +48,8 @@ func TestCollector_Collect(t *testing.T) {
 		},
 		"Parse our regular response": {
 			config: &Config{
-				Projects: "testing,testing-1",
+				CommonConfig: commonConfig,
+				Projects:     "testing,testing-1",
 			},
 			collectResponse: 1.0,
 			expectedMetrics: []*utils.MetricResult{
@@ -53,7 +58,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1",
+						instanceLabel:  "test-n1",
 						"machine_type": "n1-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing",
@@ -67,7 +72,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_memory_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1",
+						instanceLabel:  "test-n1",
 						"machine_type": "n1-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing",
@@ -81,7 +86,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2",
+						instanceLabel:  "test-n2",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing",
@@ -95,7 +100,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_memory_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2",
+						instanceLabel:  "test-n2",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing",
@@ -109,7 +114,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1-spot",
+						instanceLabel:  "test-n1-spot",
 						"machine_type": "n1-slim",
 						"price_tier":   "spot",
 						"project":      "testing",
@@ -123,7 +128,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_memory_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1-spot",
+						instanceLabel:  "test-n1-spot",
 						"machine_type": "n1-slim",
 						"price_tier":   "spot",
 						"project":      "testing",
@@ -137,7 +142,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2-us-east1",
+						instanceLabel:  "test-n2-us-east1",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing",
@@ -151,7 +156,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_memory_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2-us-east1",
+						instanceLabel:  "test-n2-us-east1",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing",
@@ -194,7 +199,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1",
+						instanceLabel:  "test-n1",
 						"machine_type": "n1-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing-1",
@@ -208,7 +213,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_memory_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1",
+						instanceLabel:  "test-n1",
 						"machine_type": "n1-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing-1",
@@ -222,7 +227,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2",
+						instanceLabel:  "test-n2",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing-1",
@@ -236,7 +241,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_memory_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2",
+						instanceLabel:  "test-n2",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing-1",
@@ -250,7 +255,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1-spot",
+						instanceLabel:  "test-n1-spot",
 						"machine_type": "n1-slim",
 						"price_tier":   "spot",
 						"project":      "testing-1",
@@ -264,7 +269,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_memory_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n1",
-						"instance":     "test-n1-spot",
+						instanceLabel:  "test-n1-spot",
 						"machine_type": "n1-slim",
 						"price_tier":   "spot",
 						"project":      "testing-1",
@@ -278,7 +283,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_cpu_usd_per_core_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2-us-east1",
+						instanceLabel:  "test-n2-us-east1",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing-1",
@@ -292,7 +297,7 @@ func TestCollector_Collect(t *testing.T) {
 					FqName: "cloudcost_gcp_gke_instance_memory_usd_per_gib_hour",
 					Labels: map[string]string{
 						"family":       "n2",
-						"instance":     "test-n2-us-east1",
+						instanceLabel:  "test-n2-us-east1",
 						"machine_type": "n2-slim",
 						"price_tier":   "ondemand",
 						"project":      "testing-1",


### PR DESCRIPTION
Fixes #262.

## What

Allow `instance` label name to be set via new `-compute.instance-label` flag.

## Why

See #262 for the rationale and discussion.

## How

* for each compute `Collector`, create new `collectorMetrics` type
  containing compute metrics (moved from _global var_), to let each
  `Collector` own an allocated instance obtained via
  `newCollectorMetrics(instanceLabel)`

* changing metrics from _global var_ to dynamically allocated object is
  needed for:
  * setting its label at runtime
  * allowing tests to be self-contained, else the 1st test to run would "own" setting `instanceLabel`
  * pave the way to also fixing #263, where we'd also need to (optionally) add a `spot={true,false}` label

* there's a new `config.CommonConfig` type, currently only having a
  single field `ComputeInstanceLabel`, which is passed down from `cmd/`
  to each instantiated _Provider_, then to each compute _Collector_

## Testing

Adapted testing with a couple `ComputeInstanceLabel="node"` changes,
although it should be improved to test changes to the label name.

--
Signed-off-by: JuanJo Ciarlante <juanjosec@gmail.com>
