### PR TITLE
AKS - convert machine names to lowercase

### DIFF
--- a/pkg/azure/aks/machine_store.go
+++ b/pkg/azure/aks/machine_store.go
@@ -396,7 +396,7 @@ func (m *MachineStore) getMachineName(vm *armcompute.VirtualMachineScaleSetVM) (
 		return "", fmt.Errorf("unable to determine machine name: %+v", vm)
 	}
 
-	return computerName, nil
+	return strings.ToLower(computerName), nil
 }
 
 // Based on this logic https://learn.microsoft.com/en-us/azure/virtual-machines/vm-naming-conventions

--- a/pkg/azure/aks/machine_store_test.go
+++ b/pkg/azure/aks/machine_store_test.go
@@ -265,7 +265,7 @@ func TestPopulateMachineStore(t *testing.T) {
 
 			expectedMachineMap: map[string]*VirtualMachineInfo{
 				"vmId": {
-					Name:           "vmName",
+					Name:           "vmname",
 					Id:             "vmId",
 					Region:         "centralus",
 					OwningVMSS:     "vmssName",
@@ -478,6 +478,17 @@ func TestGetMachineName(t *testing.T) {
 				Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 					InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
 						ComputerName: to.StringPtr("aks-vmss-machine"),
+					},
+				},
+			},
+			expectedName: "aks-vmss-machine",
+			expectedErr:  false,
+		},
+		"name is uppercase": {
+			vmObject: &armcompute.VirtualMachineScaleSetVM{
+				Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+					InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+						ComputerName: to.StringPtr("AKS-VMSS-machine"),
 					},
 				},
 			},


### PR DESCRIPTION
Machine names are returned from Azure in mixed case, but kubernetes expects them to be in lowercase.  Modifying the machine name functions to return only lowercase versions of Azure VMs.