### PR TITLE
Fix/gcp tests

### DIFF
--- a/pkg/google/gcp_test.go
+++ b/pkg/google/gcp_test.go
@@ -75,6 +75,14 @@ func TestGCP_CollectMetrics(t *testing.T) {
 	}{
 		"no error if no collectors": {
 			numCollectors: 0,
+			expectedMetrics: []*utils.MetricResult{
+				{
+					FqName:     "cloudcost_exporter_last_scrape_error",
+					Labels:     utils.LabelMap{"provider": "gcp"},
+					Value:      0,
+					MetricType: prometheus.GaugeValue,
+				},
+			},
 		},
 		"bubble-up single collector error": {
 			numCollectors: 1,
@@ -86,6 +94,12 @@ func TestGCP_CollectMetrics(t *testing.T) {
 					FqName:     "cloudcost_exporter_collector_last_scrape_error",
 					Labels:     utils.LabelMap{"provider": "gcp", "collector": "test"},
 					Value:      1,
+					MetricType: prometheus.GaugeValue,
+				},
+				{
+					FqName:     "cloudcost_exporter_last_scrape_error",
+					Labels:     utils.LabelMap{"provider": "gcp"},
+					Value:      0,
 					MetricType: prometheus.GaugeValue,
 				},
 			},
@@ -100,7 +114,18 @@ func TestGCP_CollectMetrics(t *testing.T) {
 					Value:      0,
 					MetricType: prometheus.GaugeValue,
 				},
-			},
+				{
+					FqName:     "cloudcost_exporter_collector_last_scrape_error",
+					Labels:     utils.LabelMap{"provider": "gcp", "collector": "test"},
+					Value:      0,
+					MetricType: prometheus.GaugeValue,
+				},
+				{
+					FqName:     "cloudcost_exporter_last_scrape_error",
+					Labels:     utils.LabelMap{"provider": "gcp"},
+					Value:      0,
+					MetricType: prometheus.GaugeValue,
+				}},
 		},
 	}
 	for name, tt := range tests {

--- a/pkg/google/gke/gke_test.go
+++ b/pkg/google/gke/gke_test.go
@@ -14,6 +14,7 @@ import (
 	billingv1 "cloud.google.com/go/billing/apiv1"
 	"cloud.google.com/go/billing/apiv1/billingpb"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	computev1 "google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
@@ -193,6 +194,34 @@ func TestCollector_Collect(t *testing.T) {
 						"disk_type":        "persistent_volume",
 					},
 					Value:      0.15359342915811086,
+					MetricType: prometheus.GaugeValue,
+				},
+				{
+					FqName: "cloudcost_gcp_gke_persistent_volume_usd_per_hour",
+					Labels: map[string]string{
+						"cluster_name":     "test",
+						"namespace":        "cloudcost-exporter",
+						"persistentvolume": "test-ssd-disk",
+						"region":           "us-east4",
+						"project":          "testing-1",
+						"storage_class":    "pd-ssd",
+						"disk_type":        "persistent_volume",
+					},
+					Value:      0.15359342915811086,
+					MetricType: prometheus.GaugeValue,
+				},
+				{
+					FqName: "cloudcost_gcp_gke_persistent_volume_usd_per_hour",
+					Labels: map[string]string{
+						"cluster_name":     "test",
+						"namespace":        "cloudcost-exporter",
+						"persistentvolume": "test-disk",
+						"region":           "us-central1",
+						"project":          "testing-1",
+						"storage_class":    "pd-standard",
+						"disk_type":        "boot_disk",
+					},
+					Value:      0,
 					MetricType: prometheus.GaugeValue,
 				},
 				{
@@ -450,10 +479,7 @@ func TestCollector_Collect(t *testing.T) {
 			if len(metrics) == 0 {
 				return
 			}
-
-			for i, expectedMetric := range test.expectedMetrics {
-				require.Equal(t, expectedMetric, metrics[i])
-			}
+			assert.ElementsMatch(t, metrics, test.expectedMetrics)
 		})
 	}
 }


### PR DESCRIPTION
- fixes #201 

This builds upon the solution @logyball had used in Azure where we use `assert.MatchElements` that compares two lists/slices and ensures the members match. Coupled with #317, this should resolve the flakiness that GCP's test suite has. To test it I created a franken-branch and pulled all the changes in:

```
git checkout -b franken-branch
 git cherry-pick ae8a23ed38cf3f5dde3f7be1c3c47ad97f58c0d1
git cherry-pick 7e62a674c0a536eaece285492104ea231fbe15dd
git cherry-pick 7cef6d21f61f42f819cffa7894d6fb6ea0d9e1e0
```

Then I ran ~1000 tests:

```
go test ./... -count=1000
```

I did this a few times and there was no flaky tests 🎉 
