### PR TITLE
Chore/remove readiness check probes

### DIFF
--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -102,15 +102,8 @@ func setupLogger(level string, output string, logtype string) *slog.Logger {
 func runServer(ctx context.Context, cfg *config.Config, csp provider.Provider, log *slog.Logger) error {
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/", web.HomePageHandler(cfg.Server.Path))                // landing page
-	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) { // readiness probe
-		if !csp.CheckReadiness() {
-			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprint(w, "not ready to serve traffic")
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-	})
+	mux.HandleFunc("/", web.HomePageHandler(cfg.Server.Path)) // landing page
+
 	registryHandler, err := createPromRegistryHandler(csp) // prom metrics handler
 	if err != nil {
 		return err

--- a/mocks/pkg/azure/azureClientWrapper/azureClientWrapper.go
+++ b/mocks/pkg/azure/azureClientWrapper/azureClientWrapper.go
@@ -5,7 +5,6 @@
 //
 //	mockgen -source=pkg/azure/azureClientWrapper/azureClientWrapper.go -destination mocks/pkg/azure/azureClientWrapper/azureClientWrapper.go
 //
-
 // Package mock_azureClientWrapper is a generated GoMock package.
 package mock_azureClientWrapper
 

--- a/mocks/pkg/provider/Collector.go
+++ b/mocks/pkg/provider/Collector.go
@@ -20,51 +20,6 @@ func (_m *Collector) EXPECT() *Collector_Expecter {
 	return &Collector_Expecter{mock: &_m.Mock}
 }
 
-// CheckReadiness provides a mock function with given fields:
-func (_m *Collector) CheckReadiness() bool {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for CheckReadiness")
-	}
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
-// Collector_CheckReadiness_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CheckReadiness'
-type Collector_CheckReadiness_Call struct {
-	*mock.Call
-}
-
-// CheckReadiness is a helper method to define mock.On call
-func (_e *Collector_Expecter) CheckReadiness() *Collector_CheckReadiness_Call {
-	return &Collector_CheckReadiness_Call{Call: _e.mock.On("CheckReadiness")}
-}
-
-func (_c *Collector_CheckReadiness_Call) Run(run func()) *Collector_CheckReadiness_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *Collector_CheckReadiness_Call) Return(_a0 bool) *Collector_CheckReadiness_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *Collector_CheckReadiness_Call) RunAndReturn(run func() bool) *Collector_CheckReadiness_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Collect provides a mock function with given fields: _a0
 func (_m *Collector) Collect(_a0 chan<- prometheus.Metric) error {
 	ret := _m.Called(_a0)

--- a/mocks/pkg/provider/Provider.go
+++ b/mocks/pkg/provider/Provider.go
@@ -20,51 +20,6 @@ func (_m *Provider) EXPECT() *Provider_Expecter {
 	return &Provider_Expecter{mock: &_m.Mock}
 }
 
-// CheckReadiness provides a mock function with given fields:
-func (_m *Provider) CheckReadiness() bool {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for CheckReadiness")
-	}
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
-// Provider_CheckReadiness_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CheckReadiness'
-type Provider_CheckReadiness_Call struct {
-	*mock.Call
-}
-
-// CheckReadiness is a helper method to define mock.On call
-func (_e *Provider_Expecter) CheckReadiness() *Provider_CheckReadiness_Call {
-	return &Provider_CheckReadiness_Call{Call: _e.mock.On("CheckReadiness")}
-}
-
-func (_c *Provider_CheckReadiness_Call) Run(run func()) *Provider_CheckReadiness_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *Provider_CheckReadiness_Call) Return(_a0 bool) *Provider_CheckReadiness_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *Provider_CheckReadiness_Call) RunAndReturn(run func() bool) *Provider_CheckReadiness_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Collect provides a mock function with given fields: _a0
 func (_m *Provider) Collect(_a0 chan<- prometheus.Metric) {
 	_m.Called(_a0)

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -227,15 +227,6 @@ func (a *AWS) Collect(ch chan<- prometheus.Metric) {
 	providerScrapesTotalCounter.WithLabelValues(subsystem).Inc()
 }
 
-func (a *AWS) CheckReadiness() bool {
-	for _, c := range a.collectors {
-		if !c.CheckReadiness() {
-			return false
-		}
-	}
-	return true
-}
-
 func newEc2Client(region, profile string) (*ec2.Client, error) {
 	options := []func(*awsconfig.LoadOptions) error{awsconfig.WithEC2IMDSRegion()}
 	options = append(options, awsconfig.WithRegion(region))

--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -364,11 +364,6 @@ func (c *Collector) emitMetricsFromVolumesChannel(volumesCh chan []ec2Types.Volu
 	}
 }
 
-func (c *Collector) CheckReadiness() bool {
-	// TODO add storagePricingMap to the readiness check
-	return c.computePricingMap.CheckReadiness()
-}
-
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
 	ch <- InstanceCPUHourlyCostDesc
 	ch <- InstanceMemoryHourlyCostDesc

--- a/pkg/aws/ec2/pricing_map.go
+++ b/pkg/aws/ec2/pricing_map.go
@@ -276,16 +276,6 @@ func (spm *StoragePricingMap) GetPriceForVolumeType(region string, volumeType st
 	return spm.Regions[region].Storage[volumeType] * float64(size) / 30 / 24, nil
 }
 
-func (cpm *ComputePricingMap) CheckReadiness() bool {
-	// TODO - implement
-	return true
-}
-
-func (spm *StoragePricingMap) CheckReadiness() bool {
-	// TODO - implement
-	return true
-}
-
 // InstanceAttributes represents ec2 instance attributes that are pulled from AWS api's describing instances.
 // It's specifically pulled out of productTerm to enable usage during tests.
 type InstanceAttributes struct {

--- a/pkg/aws/s3/s3.go
+++ b/pkg/aws/s3/s3.go
@@ -276,11 +276,6 @@ func (s *BillingData) AddMetricGroup(region string, component string, group type
 	componentsMap.UnitCost = unitCostForComponent(component, componentsMap)
 }
 
-func (c *Collector) CheckReadiness() bool {
-	// TODO - implement
-	return true
-}
-
 // getBillingData is responsible for making the API call to the AWS Cost Explorer API and parsing the response
 // into a S3BillingData struct
 func getBillingData(client costexplorer.CostExplorer, startDate time.Time, endDate time.Time, m Metrics) (*BillingData, error) {

--- a/pkg/azure/aks/aks.go
+++ b/pkg/azure/aks/aks.go
@@ -141,10 +141,6 @@ func (c *Collector) CollectMetrics(_ chan<- prometheus.Metric) float64 {
 	return 0
 }
 
-func (c *Collector) CheckReadiness() bool {
-	return c.PriceStore.CheckReadiness() && c.MachineStore.CheckReadiness()
-}
-
 func (c *Collector) getMachinePrices(vmId string) (*MachineSku, error) {
 	vmInfo, err := c.MachineStore.getVmInfoByVmId(vmId)
 	if err != nil {

--- a/pkg/azure/aks/machine_store.go
+++ b/pkg/azure/aks/machine_store.go
@@ -11,8 +11,9 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v5"
-	"github.com/grafana/cloudcost-exporter/pkg/azure/azureClientWrapper"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/grafana/cloudcost-exporter/pkg/azure/azureClientWrapper"
 
 	"github.com/Azure/go-autorest/autorest/to"
 )
@@ -258,11 +259,6 @@ func (m *MachineStore) getMachineTypesByLocation(ctx context.Context, location s
 	}
 
 	return nil
-}
-
-func (m *MachineStore) CheckReadiness() bool {
-	// TODO - implement
-	return true
 }
 
 func (m *MachineStore) GetListOfVmsForSubscription() []*VirtualMachineInfo {

--- a/pkg/azure/aks/price_store.go
+++ b/pkg/azure/aks/price_store.go
@@ -10,8 +10,9 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/grafana/cloudcost-exporter/pkg/azure/azureClientWrapper"
 	retailPriceSdk "gomodules.xyz/azure-retail-prices-sdk-for-go/sdk"
+
+	"github.com/grafana/cloudcost-exporter/pkg/azure/azureClientWrapper"
 
 	"gopkg.in/matryer/try.v1"
 )
@@ -89,11 +90,6 @@ func NewPricingStore(ctx context.Context, parentLogger *slog.Logger, azClientWra
 	go p.PopulatePriceStore(ctx)
 
 	return p
-}
-
-func (p *PriceStore) CheckReadiness() bool {
-	// TODO - implement
-	return true
 }
 
 func (p *PriceStore) getPriceBreakdownFromVmInfo(vmInfo *VirtualMachineInfo, price float64) *MachinePrices {

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -184,15 +184,6 @@ func (a *Azure) Describe(ch chan<- *prometheus.Desc) {
 	}
 }
 
-func (a *Azure) CheckReadiness() bool {
-	for _, c := range a.collectors {
-		if !c.CheckReadiness() {
-			return false
-		}
-	}
-	return true
-}
-
 func (a *Azure) Collect(ch chan<- prometheus.Metric) {
 	// TODO - implement collector context
 	_, cancel := context.WithTimeout(a.context, a.collectorTimeout)

--- a/pkg/google/gcp.go
+++ b/pkg/google/gcp.go
@@ -195,15 +195,6 @@ func (g *GCP) Describe(ch chan<- *prometheus.Desc) {
 	}
 }
 
-func (g *GCP) CheckReadiness() bool {
-	for _, c := range g.collectors {
-		if !c.CheckReadiness() {
-			return false
-		}
-	}
-	return true
-}
-
 // Collect implements the prometheus.Collector interface and will iterate over all the collectors instantiated during New and collect their metrics.
 func (g *GCP) Collect(ch chan<- prometheus.Metric) {
 	wg := sync.WaitGroup{}

--- a/pkg/google/gcs/gcs.go
+++ b/pkg/google/gcs/gcs.go
@@ -177,11 +177,6 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
 	return nil
 }
 
-func (c *Collector) CheckReadiness() bool {
-	// TODO - implement
-	return true
-}
-
 func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 	c.CollectMetrics(ch)
 	return nil

--- a/pkg/google/gke/gke.go
+++ b/pkg/google/gke/gke.go
@@ -69,11 +69,6 @@ func (c *Collector) Register(_ provider.Registry) error {
 	return nil
 }
 
-func (c *Collector) CheckReadiness() bool {
-	// TODO - implement
-	return true
-}
-
 func (c *Collector) CollectMetrics(ch chan<- prometheus.Metric) float64 {
 	err := c.Collect(ch)
 	if err != nil {

--- a/pkg/google/gke/pricing_map.go
+++ b/pkg/google/gke/pricing_map.go
@@ -132,11 +132,6 @@ func NewComputePricingMap() *PricingMap {
 	}
 }
 
-func (pm *PricingMap) CheckReadiness() bool {
-	// TODO - implement locking on the pricing map
-	return true
-}
-
 // FamilyPricing is a map where the key is the family and the value is the price tiers
 type FamilyPricing struct {
 	Family map[string]*PriceTiers

--- a/pkg/provider/mocks/provider.go
+++ b/pkg/provider/mocks/provider.go
@@ -5,7 +5,6 @@
 //
 //	mockgen -source=pkg/provider/provider.go -destination pkg/provider/mocks/provider.go
 //
-
 // Package mock_provider is a generated GoMock package.
 package mock_provider
 
@@ -147,20 +146,6 @@ func (m *MockCollector) EXPECT() *MockCollectorMockRecorder {
 	return m.recorder
 }
 
-// CheckReadiness mocks base method.
-func (m *MockCollector) CheckReadiness() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckReadiness")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// CheckReadiness indicates an expected call of CheckReadiness.
-func (mr *MockCollectorMockRecorder) CheckReadiness() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckReadiness", reflect.TypeOf((*MockCollector)(nil).CheckReadiness))
-}
-
 // Collect mocks base method.
 func (m *MockCollector) Collect(arg0 chan<- prometheus.Metric) error {
 	m.ctrl.T.Helper()
@@ -252,20 +237,6 @@ func NewMockProvider(ctrl *gomock.Controller) *MockProvider {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 	return m.recorder
-}
-
-// CheckReadiness mocks base method.
-func (m *MockProvider) CheckReadiness() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckReadiness")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// CheckReadiness indicates an expected call of CheckReadiness.
-func (mr *MockProviderMockRecorder) CheckReadiness() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckReadiness", reflect.TypeOf((*MockProvider)(nil).CheckReadiness))
 }
 
 // Collect mocks base method.

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -14,7 +14,6 @@ type Registry interface {
 
 type Collector interface {
 	Register(r Registry) error
-	CheckReadiness() bool
 	CollectMetrics(chan<- prometheus.Metric) float64
 	Collect(chan<- prometheus.Metric) error
 	Describe(chan<- *prometheus.Desc) error
@@ -23,6 +22,5 @@ type Collector interface {
 
 type Provider interface {
 	prometheus.Collector
-	CheckReadiness() bool
 	RegisterCollectors(r Registry) error
 }


### PR DESCRIPTION
I've introduced two atomic commits to resolve #323. The first pass removes `CheckReadiness` from the providers interfaces. The second removes `CheckReadiness` from all of the associated collectors.

- fixes #323 