### PR TITLE
fix(gke): Update collect method to gracefully fail

### DIFF
--- a/pkg/google/gke/gke.go
+++ b/pkg/google/gke/gke.go
@@ -223,8 +223,6 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 						slog.String("cluster_name", d.Cluster),
 						slog.String("storage_class", d.StorageClass()),
 					)
-
-					fmt.Printf("%s error getting cost of storage: %v\n", disk.Name, err)
 					continue
 				}
 				ch <- prometheus.MustNewConstMetric(

--- a/pkg/google/gke/gke_test.go
+++ b/pkg/google/gke/gke_test.go
@@ -382,6 +382,19 @@ func TestCollector_Collect(t *testing.T) {
 								},
 							},
 							{
+								// Add in an instance that does not have a machine type that would exist in the pricing map.
+								// This test replicates and fixes https://github.com/grafana/cloudcost-exporter/issues/335
+								Name:        "test-n1-spot",
+								MachineType: "abc/n8-slim",
+								Zone:        "testing/us-central1-a",
+								Scheduling: &computev1.Scheduling{
+									ProvisioningModel: "SPOT",
+								},
+								Labels: map[string]string{
+									GkeClusterLabel: "test",
+								},
+							},
+							{
 								Name:        "test-n2-us-east1",
 								MachineType: "abc/n2-slim",
 								Zone:        "testing/us-east1-a",


### PR DESCRIPTION
There is a condition where a failure to find a machine type in the price map was causing the `Collect` method to return instead of continuing. Instead, this changes the logic to log out the message within `Collect` and continue operating.
Adds a unit test to reproduce the error and then validates it is resolved.

A future improvement here would be to
1. Export a metric
2. Set a sane default value(if provided?)

- closes #335