### PR TITLE
Added reusable GenerateDesc function across all providers

### DIFF
--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/grafana/cloudcost-exporter/pkg/utils"
 	"log/slog"
 	"strconv"
 	"sync"
@@ -32,29 +33,33 @@ var (
 )
 
 var (
-	InstanceCPUHourlyCostDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(cloudcostexporter.MetricPrefix, subsystem, "instance_cpu_usd_per_core_hour"),
+	InstanceCPUHourlyCostDesc = utils.GenerateDesc(
+		cloudcostexporter.MetricPrefix,
+		subsystem,
+		utils.InstanceCPUCostSuffix,
 		"The cpu cost a ec2 instance in USD/(core*h)",
 		[]string{"instance", "instance_id", "region", "family", "machine_type", "cluster_name", "price_tier"},
-		nil,
 	)
-	InstanceMemoryHourlyCostDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(cloudcostexporter.MetricPrefix, subsystem, "instance_memory_usd_per_gib_hour"),
+	InstanceMemoryHourlyCostDesc = utils.GenerateDesc(
+		cloudcostexporter.MetricPrefix,
+		subsystem,
+		utils.InstanceMemoryCostSuffix,
 		"The memory cost of a ec2 instance in USD/(GiB*h)",
 		[]string{"instance", "instance_id", "region", "family", "machine_type", "cluster_name", "price_tier"},
-		nil,
 	)
-	InstanceTotalHourlyCostDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(cloudcostexporter.MetricPrefix, subsystem, "instance_total_usd_per_hour"),
+	InstanceTotalHourlyCostDesc = utils.GenerateDesc(
+		cloudcostexporter.MetricPrefix,
+		subsystem,
+		utils.InstanceTotalCostSuffix,
 		"The total cost of the ec2 instance in USD/h",
 		[]string{"instance", "instance_id", "region", "family", "machine_type", "cluster_name", "price_tier"},
-		nil,
 	)
-	PersistentVolumeHourlyCostDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(cloudcostexporter.MetricPrefix, subsystem, "persistent_volume_usd_per_hour"),
+	PersistentVolumeHourlyCostDesc = utils.GenerateDesc(
+		cloudcostexporter.MetricPrefix,
+		subsystem,
+		utils.PersistentVolumeCostSuffix,
 		"The cost of an AWS EBS Volume in USD/h.",
 		[]string{"persistentvolume", "region", "availability_zone", "disk", "type", "size_gib", "state"},
-		nil,
 	)
 )
 

--- a/pkg/azure/aks/aks.go
+++ b/pkg/azure/aks/aks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/grafana/cloudcost-exporter/pkg/utils"
 	"log/slog"
 	"time"
 
@@ -58,23 +59,26 @@ var (
 
 // Prometheus Metrics
 var (
-	InstanceCPUHourlyCostDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(cloudcost_exporter.MetricPrefix, subsystem, "instance_cpu_usd_per_core_hour"),
-		"The cpu cost a compute instance in USD/(core*h)",
+	InstanceCPUHourlyCostDesc = utils.GenerateDesc(
+		cloudcost_exporter.MetricPrefix,
+		subsystem,
+		utils.InstanceCPUCostSuffix,
+		"The cpu cost a a compute instance in USD/(core*h)",
 		[]string{"instance", "region", "machine_type", "family", "cluster_name", "price_tier", "operating_system"},
-		nil,
 	)
-	InstanceMemoryHourlyCostDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(cloudcost_exporter.MetricPrefix, subsystem, "instance_memory_usd_per_gib_hour"),
+	InstanceMemoryHourlyCostDesc = utils.GenerateDesc(
+		cloudcost_exporter.MetricPrefix,
+		subsystem,
+		utils.InstanceMemoryCostSuffix,
 		"The memory cost of a compute instance in USD/(GiB*h)",
 		[]string{"instance", "region", "machine_type", "family", "cluster_name", "price_tier", "operating_system"},
-		nil,
 	)
-	InstanceTotalHourlyCostDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(cloudcost_exporter.MetricPrefix, subsystem, "instance_total_usd_per_hour"),
-		"The total cost of an compute instance in USD/h",
+	InstanceTotalHourlyCostDesc = utils.GenerateDesc(
+		cloudcost_exporter.MetricPrefix,
+		subsystem,
+		utils.InstanceTotalCostSuffix,
+		"The total cost of a compute instance in USD/h",
 		[]string{"instance", "region", "machine_type", "family", "cluster_name", "price_tier", "operating_system"},
-		nil,
 	)
 )
 

--- a/pkg/google/gke/gke.go
+++ b/pkg/google/gke/gke.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/grafana/cloudcost-exporter/pkg/utils"
 	"log/slog"
 	"strings"
 	"sync"
@@ -22,26 +23,28 @@ const (
 )
 
 var (
-	gkeNodeMemoryHourlyCostDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(cloudcostexporter.MetricPrefix, subsystem, "instance_memory_usd_per_gib_hour"),
-
-		"The cpu cost a GKE Instance in USD/(core*h)",
-		// Cannot simply do cluster because many metric scrapers will add a label for cluster and would interfere with the label we want to add
-		[]string{"cluster_name", "instance", "region", "family", "machine_type", "project", "price_tier"},
-		nil,
-	)
-	gkeNodeCPUHourlyCostDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(cloudcostexporter.MetricPrefix, subsystem, "instance_cpu_usd_per_core_hour"),
+	gkeNodeMemoryHourlyCostDesc = utils.GenerateDesc(
+		cloudcostexporter.MetricPrefix,
+		subsystem,
+		utils.InstanceMemoryCostSuffix,
 		"The memory cost of a GKE Instance in USD/(GiB*h)",
-		// Cannot simply do cluster because many metric scrapers will add a label for cluster and would interfere with the label we want to add
+		// Cannot simply use "cluster" because other metric scrapers may add a label for cluster, which would interfere
 		[]string{"cluster_name", "instance", "region", "family", "machine_type", "project", "price_tier"},
-		nil,
 	)
-	persistentVolumeHourlyCostDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(cloudcostexporter.MetricPrefix, subsystem, "persistent_volume_usd_per_hour"),
-		"The cost of a GKE Persistent Volume in USD.",
+	gkeNodeCPUHourlyCostDesc = utils.GenerateDesc(
+		cloudcostexporter.MetricPrefix,
+		subsystem,
+		utils.InstanceCPUCostSuffix,
+		"The CPU cost of a GKE Instance in USD/(core*h)",
+		// Cannot simply use "cluster" because other metric scrapers may add a label for cluster, which would interfere
+		[]string{"cluster_name", "instance", "region", "family", "machine_type", "project", "price_tier"},
+	)
+	persistentVolumeHourlyCostDesc = utils.GenerateDesc(
+		cloudcostexporter.MetricPrefix,
+		subsystem,
+		utils.PersistentVolumeCostSuffix,
+		"The cost of a GKE Persistent Volume in USD/h",
 		[]string{"cluster_name", "namespace", "persistentvolume", "region", "project", "storage_class", "disk_type", "use_status"},
-		nil,
 	)
 )
 

--- a/pkg/utils/consts.go
+++ b/pkg/utils/consts.go
@@ -1,5 +1,20 @@
 package utils
 
+import "github.com/prometheus/client_golang/prometheus"
+
 const (
-	HoursInMonth = 24.35 * 30 // 24.35 is the average amount of hours in a day over a year
+	HoursInMonth               = 24.35 * 30 // 24.35 is the average amount of hours in a day over a year
+	InstanceCPUCostSuffix      = "instance_cpu_usd_per_core_hour"
+	InstanceMemoryCostSuffix   = "instance_memory_usd_per_gib_hour"
+	InstanceTotalCostSuffix    = "instance_total_usd_per_hour"
+	PersistentVolumeCostSuffix = "persistent_volume_usd_per_hour"
 )
+
+func GenerateDesc(prefix, subsystem, suffix, description string, labels []string) *prometheus.Desc {
+	return prometheus.NewDesc(
+		prometheus.BuildFQName(prefix, subsystem, suffix),
+		description,
+		labels,
+		nil,
+	)
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -31,6 +31,7 @@ func TestGenerateDesc(t *testing.T) {
 	for _, label := range labels {
 		if !strings.Contains(desc.String(), label) {
 			t.Errorf("Expected label %s in desc, but got %s", label, desc.String())
+
 		}
 	}
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -31,7 +31,6 @@ func TestGenerateDesc(t *testing.T) {
 	for _, label := range labels {
 		if !strings.Contains(desc.String(), label) {
 			t.Errorf("Expected label %s in desc, but got %s", label, desc.String())
-
 		}
 	}
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,36 @@
+package utils_test
+
+import (
+	"github.com/grafana/cloudcost-exporter/pkg/utils"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestGenerateDesc(t *testing.T) {
+	prefix := "test_prefix"
+	subsystem := "test_subsystem"
+	suffix := "test_suffix"
+	description := "This is a test description"
+	labels := []string{"label1", "label2"}
+
+	desc := utils.GenerateDesc(prefix, subsystem, suffix, description, labels)
+
+	// Expected values
+	expectedFQName := prometheus.BuildFQName(prefix, subsystem, suffix)
+
+	if !strings.Contains(desc.String(), expectedFQName) {
+		t.Errorf("Expected FQName %s in desc, but got %s", expectedFQName, desc.String())
+	}
+
+	if !strings.Contains(desc.String(), description) {
+		t.Errorf("Expected description %s in desc, but got %s", description, desc.String())
+	}
+
+	for _, label := range labels {
+		if !strings.Contains(desc.String(), label) {
+			t.Errorf("Expected label %s in desc, but got %s", label, desc.String())
+		}
+	}
+}


### PR DESCRIPTION
 Implement a Uniform Approach for Defining Metric Descriptions

**Description:** 

- This PR refines the definition of metric descriptions in the `cloudcost-exporter` project by implementing a consistent and uniform approach. 

- Added new constants and generic reusable method in utils.

- Changed defining metric across all available providers