### PR TITLE
feat(gke): Handle ARM instance families

### DIFF
--- a/pkg/google/gke/pricing_map.go
+++ b/pkg/google/gke/pricing_map.go
@@ -28,7 +28,7 @@ var (
 
 	spotRegex        = `(?P<spot>Spot Preemptible )`
 	machineTypeRegex = `(?P<machineType>\w{1,3})`
-	amd              = `(?P<amd> AMD)`
+	chipset          = `(?P<chipset> (Arm|AMD))` // note the space before core, it _must_ be set
 	n1Suffix         = `(?: Predefined)`
 	resource         = `(?P<resource>Core|Ram)`
 	regionRegex      = `\w+(?: \w+){0,2}`
@@ -38,7 +38,7 @@ var (
 		machineTypeRegex,
 		computeOptimized,
 		n1Suffix,
-		amd,
+		chipset,
 		resource,
 		regionRegex)
 	reOnDemand = regexp.MustCompile(onDemandString)
@@ -208,7 +208,9 @@ func (pm *PricingMap) Populate(ctx context.Context, billingService *billingv1.Cl
 
 	for _, sku := range skus {
 		rawData, err := getDataFromSku(sku)
-
+		if strings.Contains(sku.Description, "C4A") {
+			fmt.Printf("%v", sku)
+		}
 		if errors.Is(err, ErrSkuNotRelevant) {
 			continue
 		}
@@ -288,7 +290,6 @@ func GeneratePricingMap(skus []*billingpb.Sku) (*PricingMap, error) {
 	pricingMap := NewComputePricingMap()
 	for _, sku := range skus {
 		rawData, err := getDataFromSku(sku)
-
 		if errors.Is(err, ErrSkuNotRelevant) {
 			continue
 		}

--- a/pkg/google/gke/pricing_map.go
+++ b/pkg/google/gke/pricing_map.go
@@ -208,9 +208,6 @@ func (pm *PricingMap) Populate(ctx context.Context, billingService *billingv1.Cl
 
 	for _, sku := range skus {
 		rawData, err := getDataFromSku(sku)
-		if strings.Contains(sku.Description, "C4A") {
-			fmt.Printf("%v", sku)
-		}
 		if errors.Is(err, ErrSkuNotRelevant) {
 			continue
 		}

--- a/pkg/google/gke/pricing_map_test.go
+++ b/pkg/google/gke/pricing_map_test.go
@@ -239,6 +239,66 @@ func TestGeneratePricingMap(t *testing.T) {
 			},
 		},
 		{
+			name: "spot cpu c4a",
+			skus: []*billingpb.Sku{{
+				Description:    "Spot Preemptible C4A Arm Instance Core running in Belgium",
+				ServiceRegions: []string{"europe-west1"},
+				PricingInfo: []*billingpb.PricingInfo{{
+					PricingExpression: &billingpb.PricingExpression{
+						TieredRates: []*billingpb.PricingExpression_TierRate{{
+							UnitPrice: &money.Money{
+								Nanos: 1e9,
+							},
+						}},
+					},
+				}},
+			}},
+			expectedPricingMap: &PricingMap{
+				Compute: map[string]*FamilyPricing{
+					"europe-west1": {
+						Family: map[string]*PriceTiers{
+							"c4a": {
+								Spot: Prices{
+									Cpu: 1,
+								},
+							},
+						},
+					},
+				},
+				Storage: map[string]*StoragePricing{},
+			},
+		},
+		{
+			name: "spot c4a ram",
+			skus: []*billingpb.Sku{{
+				Description:    "Spot Preemptible C4A Arm Instance Ram running in Belgium",
+				ServiceRegions: []string{"europe-west1"},
+				PricingInfo: []*billingpb.PricingInfo{{
+					PricingExpression: &billingpb.PricingExpression{
+						TieredRates: []*billingpb.PricingExpression_TierRate{{
+							UnitPrice: &money.Money{
+								Nanos: 1e9,
+							},
+						}},
+					},
+				}},
+			}},
+			expectedPricingMap: &PricingMap{
+				Compute: map[string]*FamilyPricing{
+					"europe-west1": {
+						Family: map[string]*PriceTiers{
+							"c4a": {
+								Spot: Prices{
+									Ram: 1,
+								},
+							},
+						},
+					},
+				},
+				Storage: map[string]*StoragePricing{},
+			},
+		},
+		{
 			name: "on-demand cpu c4a",
 			skus: []*billingpb.Sku{{
 				Description:    "C4A Arm Instance Core running in Belgium",
@@ -268,8 +328,6 @@ func TestGeneratePricingMap(t *testing.T) {
 				Storage: map[string]*StoragePricing{},
 			},
 		},
-		// TODO: ADd spot
-		// Spot Preemptible C4A Arm Instance Ram running in Netherlands
 		{
 			name: "c4a ram",
 			skus: []*billingpb.Sku{{

--- a/pkg/google/gke/pricing_map_test.go
+++ b/pkg/google/gke/pricing_map_test.go
@@ -239,6 +239,68 @@ func TestGeneratePricingMap(t *testing.T) {
 			},
 		},
 		{
+			name: "on-demand cpu c4a",
+			skus: []*billingpb.Sku{{
+				Description:    "C4A Arm Instance Core running in Belgium",
+				ServiceRegions: []string{"europe-west1"},
+				PricingInfo: []*billingpb.PricingInfo{{
+					PricingExpression: &billingpb.PricingExpression{
+						TieredRates: []*billingpb.PricingExpression_TierRate{{
+							UnitPrice: &money.Money{
+								Nanos: 1e9,
+							},
+						}},
+					},
+				}},
+			}},
+			expectedPricingMap: &PricingMap{
+				Compute: map[string]*FamilyPricing{
+					"europe-west1": {
+						Family: map[string]*PriceTiers{
+							"c4a": {
+								OnDemand: Prices{
+									Cpu: 1,
+								},
+							},
+						},
+					},
+				},
+				Storage: map[string]*StoragePricing{},
+			},
+		},
+		// TODO: ADd spot
+		// Spot Preemptible C4A Arm Instance Ram running in Netherlands
+		{
+			name: "c4a ram",
+			skus: []*billingpb.Sku{{
+				Description:    "C4A Arm Instance Ram running in Belgium",
+				ServiceRegions: []string{"europe-west1"},
+				PricingInfo: []*billingpb.PricingInfo{{
+					PricingExpression: &billingpb.PricingExpression{
+						TieredRates: []*billingpb.PricingExpression_TierRate{{
+							UnitPrice: &money.Money{
+								Nanos: 1e9,
+							},
+						}},
+					},
+				}},
+			}},
+			expectedPricingMap: &PricingMap{
+				Compute: map[string]*FamilyPricing{
+					"europe-west1": {
+						Family: map[string]*PriceTiers{
+							"c4a": {
+								OnDemand: Prices{
+									Ram: 1,
+								},
+							},
+						},
+					},
+				},
+				Storage: map[string]*StoragePricing{},
+			},
+		},
+		{
 			name: "on-demand ram",
 			skus: []*billingpb.Sku{{
 				Description:    "G2 Instance Ram running in Belgium",


### PR DESCRIPTION
Now that GCP has publicly unveiled the C4A family, let's update the pricing map to handle both ARM and AMD chipsets.

- refs #337