### PR TITLE
feat(gke): Handle hyperdisk balanced volumes

### DIFF
--- a/pkg/google/gke/pricing_map.go
+++ b/pkg/google/gke/pricing_map.go
@@ -188,10 +188,11 @@ func (m PricingMap) GetCostOfStorage(region, storageClass string) (float64, erro
 
 var (
 	storageClasses = map[string]string{
-		"Storage PD Capacity":    "pd-standard",
-		"SSD backed PD Capacity": "pd-ssd",
-		"Balanced PD Capacity":   "pd-balanced",
-		"Extreme PD Capacity":    "pd-extreme",
+		"Storage PD Capacity":         "pd-standard",
+		"SSD backed PD Capacity":      "pd-ssd",
+		"Balanced PD Capacity":        "pd-balanced",
+		"Extreme PD Capacity":         "pd-extreme",
+		"Hyperdisk Balanced Capacity": "hyperdisk-balanced",
 	}
 )
 
@@ -264,6 +265,10 @@ func (pm *PricingMap) Populate(ctx context.Context, billingService *billingv1.Cl
 						break
 					}
 				}
+				if strings.Contains(data.Description, "Confidential") {
+					log.Printf("Storage class contains Confidential: %s\n%s\n", storageClass, data.Description)
+					continue
+				}
 				if storageClass == "" {
 					log.Printf("Storage class not found for %s. Skipping", data.Description)
 					continue
@@ -272,6 +277,15 @@ func (pm *PricingMap) Populate(ctx context.Context, billingService *billingv1.Cl
 					log.Printf("Storage class %s already exists in region %s", storageClass, data.Region)
 					continue
 				}
+				// Switch statement must go here to handle hyperdisk cases, otherwise what's happening is
+				// The four dimenions get ignored. There is a sku for:
+				// 1. Standard IOPS( Hyperdisk Balanced Storage Pools Standard IOPS - Oregon)
+				// 2. Capacity (Hyperdisk Balanced Capacity in Milan)
+				// 3. Throughput (Hyperdisk Balanced Throughput in Columbus)
+				// 4. High Availability Iops(Hyperdisk Balanced High Availability Iops in Mexico)
+				// The current implementation specifically looks for `Hyperdisk Balanced Capacity` to avoid taking the last price that's found
+				// Then there is one variation of hyperdisks that are priced differently:
+				// 1. Storage Pools Advanced Capacity(Hyperdisk Balanced Storage Pools Advanced Capacity - Mexico)
 				pm.Storage[data.Region].Storage[storageClass] = float64(data.Price) * 1e-9 / utils.HoursInMonth
 			}
 		}

--- a/pkg/google/gke/pricing_map_test.go
+++ b/pkg/google/gke/pricing_map_test.go
@@ -544,6 +544,33 @@ func TestGeneratePricingMap(t *testing.T) {
 			},
 		},
 		{
+			name: "HyperDisk Pricing",
+			skus: []*billingpb.Sku{{
+				Description:    "Hyperdisk PD Capacity",
+				Category:       &billingpb.Category{ResourceFamily: "Storage"},
+				ServiceRegions: []string{"europe-west1"},
+				PricingInfo: []*billingpb.PricingInfo{{
+					PricingExpression: &billingpb.PricingExpression{
+						TieredRates: []*billingpb.PricingExpression_TierRate{{
+							UnitPrice: &money.Money{
+								Nanos: 1e9,
+							},
+						}},
+					},
+				}},
+			}},
+			expectedPricingMap: &PricingMap{
+				Storage: map[string]*StoragePricing{
+					"europe-west1": {
+						Storage: map[string]float64{
+							"hyperdisk-balanced": 1.0 / utils.HoursInMonth,
+						},
+					},
+				},
+				Compute: map[string]*FamilyPricing{},
+			},
+		},
+		{
 			name: "us-east-4 region with many skus",
 			skus: []*billingpb.Sku{{
 				Description:    "SSD backed PD Capacity",


### PR DESCRIPTION
First attempt at handling hyperdisk balanced volumes. The primary goal was to update the pricing map logic in such a way that would parse of hyperdisks  balanced and include only the cost of capacity. Hyperdisk Balanced pricing is done in such a way that if you don't configure IOPS and Throughput, you use a free tier.

In the future IOPS, Throughput, and High Availability costs need to be saved and calculated as well.