### PR TITLE
feat(gke): Implement StoragePricing to handle HyperDIsk Dimensions

### DIFF
--- a/pkg/google/gke/pricing_map.go
+++ b/pkg/google/gke/pricing_map.go
@@ -278,8 +278,8 @@ func (pm *PricingMap) ParseSkus(skus []*billingpb.Sku) error {
 					log.Printf("Storage class contains Confidential: %s\n%s\n", storageClass, data.Description)
 					continue
 				}
-				// First time seen, need to initialize
-				if pm.Storage[data.Region].Storage[storageClass] == nil {
+				// First time seen, need to initialize the StoragePrices for the storageClass
+				if _, ok := pm.Storage[data.Region].Storage[storageClass]; !ok {
 					pm.Storage[data.Region].Storage[storageClass] = &StoragePrices{}
 				}
 				if pm.Storage[data.Region].Storage[storageClass].ProvisionedSpaceGiB != 0.0 {

--- a/pkg/google/gke/pricing_map_test.go
+++ b/pkg/google/gke/pricing_map_test.go
@@ -437,8 +437,10 @@ func TestPricingMapParseSkus(t *testing.T) {
 			expectedPricingMap: &PricingMap{
 				Storage: map[string]*StoragePricing{
 					"europe-west1": {
-						Storage: map[string]float64{
-							"pd-standard": 1.0 / utils.HoursInMonth,
+						Storage: map[string]*StoragePrices{
+							"pd-standard": {
+								ProvisionedSpaceGiB: 1.0 / utils.HoursInMonth,
+							},
 						},
 					},
 				},
@@ -464,8 +466,10 @@ func TestPricingMapParseSkus(t *testing.T) {
 			expectedPricingMap: &PricingMap{
 				Storage: map[string]*StoragePricing{
 					"europe-west1": {
-						Storage: map[string]float64{
-							"pd-ssd": 1.0 / utils.HoursInMonth,
+						Storage: map[string]*StoragePrices{
+							"pd-ssd": {
+								ProvisionedSpaceGiB: 1.0 / utils.HoursInMonth,
+							},
 						},
 					},
 				},
@@ -504,8 +508,10 @@ func TestPricingMapParseSkus(t *testing.T) {
 			expectedPricingMap: &PricingMap{
 				Storage: map[string]*StoragePricing{
 					"europe-west1": {
-						Storage: map[string]float64{
-							"pd-balanced": 1.0 / utils.HoursInMonth,
+						Storage: map[string]*StoragePrices{
+							"pd-balanced": {
+								ProvisionedSpaceGiB: 1.0 / utils.HoursInMonth,
+							},
 						},
 					},
 				},
@@ -531,8 +537,10 @@ func TestPricingMapParseSkus(t *testing.T) {
 			expectedPricingMap: &PricingMap{
 				Storage: map[string]*StoragePricing{
 					"europe-west1": {
-						Storage: map[string]float64{
-							"pd-extreme": 1.0 / utils.HoursInMonth,
+						Storage: map[string]*StoragePrices{
+							"pd-extreme": {
+								ProvisionedSpaceGiB: 1.0 / utils.HoursInMonth,
+							},
 						},
 					},
 				},
@@ -558,8 +566,10 @@ func TestPricingMapParseSkus(t *testing.T) {
 			expectedPricingMap: &PricingMap{
 				Storage: map[string]*StoragePricing{
 					"europe-west1": {
-						Storage: map[string]float64{
-							"hyperdisk-balanced": 1.0 / utils.HoursInMonth,
+						Storage: map[string]*StoragePrices{
+							"hyperdisk-balanced": {
+								ProvisionedSpaceGiB: 1.0 / utils.HoursInMonth,
+							},
 						},
 					},
 				},
@@ -600,8 +610,10 @@ func TestPricingMapParseSkus(t *testing.T) {
 			expectedPricingMap: &PricingMap{
 				Storage: map[string]*StoragePricing{
 					"us-east4": {
-						Storage: map[string]float64{
-							"pd-ssd": 187000000 * 1e-9 / utils.HoursInMonth,
+						Storage: map[string]*StoragePrices{
+							"pd-ssd": {
+								ProvisionedSpaceGiB: 187000000 * 1e-9 / utils.HoursInMonth,
+							},
 						},
 					},
 				},


### PR DESCRIPTION
First part of refactoring the GKE disks to account for HyperDisk pricing dimensions. Extends the storage pricing map to have a `StoragePrice` struct that has the costs for
- ProvisionedSpace
- IOPs
- Throughput

The first of many changes that's meant to incrementally add support.

Next steps
- Return the `StoragePrice` struct to pass down calculating cost to `disk.go`