### PR TITLE
Pin version in goreleaser action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # 6.1.0
         with:
           distribution: goreleaser
-          versions: '~> v2'
+          version: 2
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix for the error in the release pipeline: https://github.com/grafana/cloudcost-exporter/actions/runs/11934973233