### PR TITLE
Fix build step for release workflow

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,10 +1,11 @@
 # Make sure to check the documentation at https://goreleaser.com
 
+project_name: cloudcost-explorer
 builds:
   - id: cloudcost-explorer
     binary: cloudcost-explorer
     main: ./cmd/exporter/exporter.go
-  - env:
+    env:
       - CGO_ENABLED=0
     goos:
       - linux


### PR DESCRIPTION
2nd error from the failed [run](https://github.com/grafana/cloudcost-exporter/actions/runs/11934973233/job/33591750094):
```
error=build for cloudcost-exporter does not contain a main function
```

The path to `main()` is set, but it may have been trying to create multiple builds due to the list syntax. Let's try this way.