### PR TITLE
Update release workflow's permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
       - v*
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   goreleaser:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,7 @@
 # Make sure to check the documentation at https://goreleaser.com
 
+version: 2
+
 project_name: cloudcost-explorer
 builds:
   - id: cloudcost-explorer


### PR DESCRIPTION
- Increase permissions of release workflow from read to write
- Specify version 2 in goreleaser workflow to get rid of warning