### PR TITLE
Implement experimental dashboards with Foundation SDK

### DIFF
--- a/config/grafana/README.md
+++ b/config/grafana/README.md
@@ -1,0 +1,25 @@
+# Grafana Dashboards
+
+> [!WARNING]
+> This is still highly experimental as engineers at Grafana Labs are learning how to generate dashboards as code.
+> The main goal is for us to be able to generate and use the same internal dashboards as we recommend OSS users to use.
+
+This container a set of Grafana Dashboards that are generated using the [Grafana Foundation SDK](https://github.com/grafana/grafana-foundation-sdk).
+
+## Getting Started
+
+> [!INFO]
+> If you want to develop these dashboards and view them against a live Grafana instance,
+> install and configure [grizzly](https://grafana.github.io/grizzly/installation/)
+
+To generate the dashboards:
+
+```shell
+go run operations_dashboard.go > operations_dashboard.json
+```
+
+To iteratively develop dashboards with live reload:
+
+```shell
+grr serve -p 8088 -w -S 'go run *.go' .
+```

--- a/config/grafana/convertor/README.md
+++ b/config/grafana/convertor/README.md
@@ -1,0 +1,14 @@
+# Convertor
+
+This is a small script that's intended to be used to convert a json blob dashboard to Go code using Grafana's Foundation SDK to manage dashboards.
+
+## Usage
+
+First get a dashboard represented as a [json blob](https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/#export-a-dashboard-as-json) and output the contents into `dashboard.json`
+
+Then execute the script with the following command:
+```bash
+go run convert_dashboard.go
+```
+Copy the output and paste it into a new file in the `config/dashboards` directory. 
+

--- a/config/grafana/convertor/convert_dashboard.go
+++ b/config/grafana/convertor/convert_dashboard.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/grafana/grafana-foundation-sdk/go/cog/plugins"
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+)
+
+func main() {
+
+	// Required to correctly unmarshal panels and dataqueries
+	plugins.RegisterDefaultPlugins()
+
+	dashboardJSON, err := os.ReadFile("dashboard.json")
+	if err != nil {
+		panic(err)
+	}
+
+	dash := dashboard.Dashboard{}
+	if err := dash.UnmarshalJSONStrict(dashboardJSON); err != nil {
+		fmt.Printf("Error unmarshalling dashboard: %v\n", err)
+	}
+
+	if err = json.Unmarshal(dashboardJSON, &dash); err != nil {
+		panic(err)
+	}
+
+	converted := dashboard.DashboardConverter(dash)
+	fmt.Println(converted)
+}

--- a/config/grafana/convertor/convert_dashboard.go
+++ b/config/grafana/convertor/convert_dashboard.go
@@ -20,9 +20,6 @@ func main() {
 	}
 
 	dash := dashboard.Dashboard{}
-	if err := dash.UnmarshalJSONStrict(dashboardJSON); err != nil {
-		fmt.Printf("Error unmarshalling dashboard: %v\n", err)
-	}
 
 	if err = json.Unmarshal(dashboardJSON, &dash); err != nil {
 		panic(err)

--- a/config/grafana/convertor/dashboard.json
+++ b/config/grafana/convertor/dashboard.json
@@ -1,0 +1,818 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": 10297,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 8,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Display the status of all the collectors running.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "index": 0,
+                  "text": "Up"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "Down"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 11,
+        "x": 0,
+        "y": 1
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.0-80683",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "max by (provider, collector) (cloudcost_exporter_collector_last_scrape_error == 0)",
+          "instant": false,
+          "legendFormat": "{{provider}}:{{collector}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Collector Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 13,
+        "x": 11,
+        "y": 1
+      },
+      "id": 14,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": ["testing"],
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": false
+      },
+      "pluginVersion": "11.5.0-80683",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "cortex-ops-01"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max by (cluster, version) (cloudcost_exporter_build_info{})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Version Info",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "version",
+                "cluster"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Duration of scrapes by provider and collector",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.0-80683",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "cloudcost_exporter_collector_last_scrape_duration_seconds",
+          "instant": false,
+          "legendFormat": "{{provider}}:{{collector}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "vector(60)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "scrape_interval",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Collector Scrape Duration",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 7,
+      "panels": [],
+      "title": "AWS",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 11,
+        "x": 0,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.0-80683",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000134"
+          },
+          "editorMode": "code",
+          "expr": "sum by (cluster) (increase(cloudcost_exporter_aws_s3_cost_api_requests_total{cluster=~\"$cluster\"}[5m]))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CostExplorer API Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "The AWS s3 module uses cost data pulled from Cost Explorer, which costs $0.01 per API call. The cost metrics are refreshed every hour, so if this value goes below 0, it indicates a problem with refreshing the pricing map and thus needs investigation.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 13,
+        "x": 11,
+        "y": 16
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.0-80683",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000134"
+          },
+          "editorMode": "code",
+          "expr": "max by (cluster) (cloudcost_exporter_aws_s3_next_scrape{cluster=~\"$cluster\"}) - time() ",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Next pricing map refresh",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 2,
+      "panels": [],
+      "title": "GCP",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 11,
+        "x": 0,
+        "y": 25
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.0-80683",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000134"
+          },
+          "editorMode": "code",
+          "expr": "sum by (cluster, status) (increase(cloudcost_exporter_gcp_gcs_bucket_list_status_total[5m]))",
+          "instant": false,
+          "legendFormat": "{{cluster}}:{{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GCS List Buckets Requests Per Second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "The amount of time before the next refresh of the GCS pricing map. ",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 13,
+        "x": 11,
+        "y": 25
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.0-80683",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000134"
+          },
+          "editorMode": "code",
+          "expr": "max by (cluster) (cloudcost_exporter_gcp_gcs_next_scrape{cluster=~\"$cluster\"}) - time() ",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GCS Pricing Map Refresh Time",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 40,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "ops-cortex",
+          "value": "000000134"
+        },
+        "includeAll": false,
+        "label": "Data Source",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "ops-cortex|dev-cortex|default",
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": [
+            "dev-us-central-0",
+            "dev-us-east-0",
+            "prod-us-east-0"
+          ],
+          "value": [
+            "dev-us-central-0",
+            "dev-us-east-0",
+            "prod-us-east-0"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(tanka_environment_info{app=\"cloudcost-exporter\"},exported_cluster)",
+        "includeAll": true,
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(tanka_environment_info{app=\"cloudcost-exporter\"},exported_cluster)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "CloudCost Exporter",
+  "uid": "1a9c0de366458599246184cf0ae8b468",
+  "version": 2,
+  "weekStart": ""
+}

--- a/config/grafana/operations_dashboard.go
+++ b/config/grafana/operations_dashboard.go
@@ -13,53 +13,64 @@ import (
 	"github.com/grafana/grafana-foundation-sdk/go/timeseries"
 )
 
+func prometheusDatasourceRef() dashboard.DataSourceRef {
+	return dashboard.DataSourceRef{
+		Type: cog.ToPtr[string]("prometheus"),
+		Uid:  cog.ToPtr[string]("${datasource}"),
+	}
+}
+
+func prometheusQuery(expression string, legendFormat string) *prometheus.DataqueryBuilder {
+	return prometheus.NewDataqueryBuilder().
+		Expr(expression).
+		Range().
+		LegendFormat(legendFormat)
+}
+
 func main() {
 	builder := dashboard.NewDashboardBuilder("CloudCost Exporter").
-		Id(10297).
+		// leaving this for BC reasons, but a proper human-readable UID would be better.
 		Uid("1a9c0de366458599246184cf0ae8b468").
-		Title("CloudCost Exporter").
 		Editable().
-		Tooltip(1).
-		Timepicker(dashboard.NewTimePickerBuilder()).
+		Tooltip(dashboard.DashboardCursorSyncCrosshair).
 		Refresh("30s").
-		Version(0x2).
-		Variables([]cog.Builder[dashboard.VariableModel]{dashboard.NewDatasourceVariableBuilder("datasource").
-			Name("datasource").
+		WithVariable(dashboard.NewDatasourceVariableBuilder("datasource").
 			Label("Data Source").
 			Type("prometheus"),
-			dashboard.NewQueryVariableBuilder("cluster").
-				Name("cluster").
-				Query(dashboard.StringOrMap{Map: map[string]interface{}{"query": "label_values(tanka_environment_info{app=\"cloudcost-exporter\"},exported_cluster)", "refId": "PrometheusVariableQueryEditor-VariableQuery"}}).
-				Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("${datasource}")}).
-				Current(dashboard.VariableOption{Text: dashboard.StringOrArrayOfString{ArrayOfString: []string{"dev-us-central-0", "dev-us-east-0", "prod-us-east-0"}}, Value: dashboard.StringOrArrayOfString{ArrayOfString: []string{"dev-us-central-0", "dev-us-east-0", "prod-us-east-0"}}}).
-				Multi(true).
-				Refresh(1).
-				IncludeAll(true).
-				AllValue(".*")}).
-		Annotations([]cog.Builder[dashboard.AnnotationQuery]{dashboard.NewAnnotationQueryBuilder().
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("cluster").
+			// TODO: this looks grafana-specific
+			Query(dashboard.StringOrMap{
+				String: cog.ToPtr("label_values(tanka_environment_info{app=\"cloudcost-exporter\"},exported_cluster)"),
+			}).
+			Datasource(prometheusDatasourceRef()).
+			Multi(true).
+			Refresh(dashboard.VariableRefreshOnDashboardLoad).
+			IncludeAll(true).
+			AllValue(".*"),
+		).
+		Annotation(dashboard.NewAnnotationQueryBuilder().
 			Name("Annotations & Alerts").
-			Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("grafana"), Uid: cog.ToPtr[string]("-- Grafana --")}).
+			Datasource(dashboard.DataSourceRef{
+				Type: cog.ToPtr[string]("grafana"),
+				Uid:  cog.ToPtr[string]("-- Grafana --"),
+			}).
 			Hide(true).
 			IconColor("rgba(0, 211, 255, 1)").
 			Type("dashboard").
-			BuiltIn(1)}).
-		Preload(false).
-		WithRow(dashboard.NewRowBuilder("Overview").
-			Title("Overview").
-			GridPos(dashboard.GridPos{H: 1, W: 24, X: 0, Y: 0}).
-			Id(0x8)).
-		WithPanel(buildUpPanel()).
-		WithPanel(buildCollectorScrapeDurationPanel()).
+			BuiltIn(1),
+		).
+		WithRow(dashboard.NewRowBuilder("Overview")).
+		WithPanel(collectorStatusCurrent().Height(6).Span(11)).
+		WithPanel(collectorScrapeDurationOverTime()).
 		WithRow(dashboard.NewRowBuilder("AWS").
 			Title("AWS").
-			GridPos(dashboard.GridPos{H: 1, W: 24, X: 0, Y: 15}).
-			Id(0x7)).
+			GridPos(dashboard.GridPos{H: 1, W: 24, X: 0, Y: 15})).
 		WithPanel(buildCostExplorerAPIRequestsPanel()).
 		WithPanel(buildAWSS3NextScrapePanel()).
 		WithRow(dashboard.NewRowBuilder("GCP").
 			Title("GCP").
-			GridPos(dashboard.GridPos{H: 1, W: 24, X: 0, Y: 24}).
-			Id(0x2)).
+			GridPos(dashboard.GridPos{H: 1, W: 24, X: 0, Y: 24})).
 		WithPanel(buildGCPlistBucketsRPSPanel()).
 		WithPanel(buildNextScrapePanel())
 
@@ -75,37 +86,27 @@ func main() {
 	fmt.Println(string(dashboardJson))
 }
 
-func buildCollectorScrapeDurationPanel() *timeseries.PanelBuilder {
+func collectorScrapeDurationOverTime() *timeseries.PanelBuilder {
 	return timeseries.NewPanelBuilder().
-		Id(0xd).
-		Targets([]cog.Builder[variants.Dataquery]{prometheus.NewDataqueryBuilder().
-			Expr("cloudcost_exporter_collector_last_scrape_duration_seconds").
-			Range().
-			EditorMode("code").
-			LegendFormat("{{provider}}:{{collector}}").
-			RefId("A").
-			Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("${datasource}")}),
-			prometheus.NewDataqueryBuilder().
-				Expr("vector(60)").
-				Range().
-				EditorMode("code").
-				LegendFormat("scrape_interval").
-				RefId("B").
-				Hide(false).
-				Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("${datasource}")})}).
 		Title("Collector Scrape Duration").
 		Description("Duration of scrapes by provider and collector").
-		Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("${datasource}")}).
+		Datasource(prometheusDatasourceRef()).
+		WithTarget(
+			prometheusQuery("cloudcost_exporter_collector_last_scrape_duration_seconds", "{{provider}}:{{collector}}"),
+		).
 		GridPos(dashboard.GridPos{H: 8, W: 24, X: 0, Y: 7}).
 		Height(0x8).
 		Span(0x18).
 		Unit("s").
+		ThresholdsStyle(common.NewGraphThresholdsStyleConfigBuilder().Mode(common.GraphThresholdsStyleModeLine)).
 		Thresholds(dashboard.NewThresholdsConfigBuilder().
-			Mode("absolute").
-			Steps([]dashboard.Threshold{dashboard.Threshold{Color: "green"},
-				dashboard.Threshold{Value: cog.ToPtr[float64](80), Color: "red"}})).
-		ColorScheme(dashboard.NewFieldColorBuilder().
-			Mode("palette-classic")).
+			Mode(dashboard.ThresholdsModeAbsolute).
+			Steps([]dashboard.Threshold{
+				{Color: "green"},
+				{Value: cog.ToPtr[float64](60), Color: "red"},
+			}),
+		).
+		ColorScheme(dashboard.NewFieldColorBuilder().Mode("palette-classic")).
 		Legend(common.NewVizLegendOptionsBuilder().
 			DisplayMode("table").
 			Placement("bottom").
@@ -120,8 +121,6 @@ func buildCollectorScrapeDurationPanel() *timeseries.PanelBuilder {
 			Sort("none")).
 		DrawStyle("line").
 		GradientMode("none").
-		ThresholdsStyle(common.NewGraphThresholdsStyleConfigBuilder().
-			Mode("off")).
 		LineWidth(1).
 		LineInterpolation("linear").
 		FillOpacity(0).
@@ -148,7 +147,6 @@ func buildCollectorScrapeDurationPanel() *timeseries.PanelBuilder {
 
 func buildCostExplorerAPIRequestsPanel() *timeseries.PanelBuilder {
 	return timeseries.NewPanelBuilder().
-		Id(0x6).
 		Targets([]cog.Builder[variants.Dataquery]{prometheus.NewDataqueryBuilder().
 			Expr("sum by (cluster) (increase(cloudcost_exporter_aws_s3_cost_api_requests_total{cluster=~\"$cluster\"}[5m]))").
 			Range().
@@ -157,7 +155,7 @@ func buildCostExplorerAPIRequestsPanel() *timeseries.PanelBuilder {
 			RefId("A").
 			Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("000000134")})}).
 		Title("CostExplorer API Requests").
-		Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("${datasource}")}).
+		Datasource(prometheusDatasourceRef()).
 		GridPos(dashboard.GridPos{H: 8, W: 11, X: 0, Y: 16}).
 		Height(0x8).
 		Span(0xb).
@@ -205,7 +203,6 @@ func buildCostExplorerAPIRequestsPanel() *timeseries.PanelBuilder {
 
 func buildAWSS3NextScrapePanel() *timeseries.PanelBuilder {
 	return timeseries.NewPanelBuilder().
-		Id(0x9).
 		Targets([]cog.Builder[variants.Dataquery]{prometheus.NewDataqueryBuilder().
 			Expr("max by (cluster) (cloudcost_exporter_aws_s3_next_scrape{cluster=~\"$cluster\"}) - time() ").
 			Range().
@@ -215,7 +212,7 @@ func buildAWSS3NextScrapePanel() *timeseries.PanelBuilder {
 			Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("000000134")})}).
 		Title("Next pricing map refresh").
 		Description("The AWS s3 module uses cost data pulled from Cost Explorer, which costs $0.01 per API call. The cost metrics are refreshed every hour, so if this value goes below 0, it indicates a problem with refreshing the pricing map and thus needs investigation.").
-		Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("${datasource}")}).
+		Datasource(prometheusDatasourceRef()).
 		GridPos(dashboard.GridPos{H: 8, W: 13, X: 11, Y: 16}).
 		Height(0x8).
 		Span(0xd).
@@ -263,7 +260,6 @@ func buildAWSS3NextScrapePanel() *timeseries.PanelBuilder {
 
 func buildGCPlistBucketsRPSPanel() *timeseries.PanelBuilder {
 	return timeseries.NewPanelBuilder().
-		Id(0x3).
 		Targets([]cog.Builder[variants.Dataquery]{prometheus.NewDataqueryBuilder().
 			Expr("sum by (cluster, status) (increase(cloudcost_exporter_gcp_gcs_bucket_list_status_total[5m]))").
 			Range().
@@ -272,7 +268,7 @@ func buildGCPlistBucketsRPSPanel() *timeseries.PanelBuilder {
 			RefId("A").
 			Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("000000134")})}).
 		Title("GCS List Buckets Requests Per Second").
-		Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("${datasource}")}).
+		Datasource(prometheusDatasourceRef()).
 		GridPos(dashboard.GridPos{H: 7, W: 11, X: 0, Y: 25}).
 		Height(0x7).
 		Span(0xb).
@@ -320,7 +316,6 @@ func buildGCPlistBucketsRPSPanel() *timeseries.PanelBuilder {
 
 func buildNextScrapePanel() *timeseries.PanelBuilder {
 	return timeseries.NewPanelBuilder().
-		Id(0xa).
 		Targets([]cog.Builder[variants.Dataquery]{prometheus.NewDataqueryBuilder().
 			Expr("max by (cluster) (cloudcost_exporter_gcp_gcs_next_scrape{cluster=~\"$cluster\"}) - time() ").
 			Range().
@@ -330,7 +325,7 @@ func buildNextScrapePanel() *timeseries.PanelBuilder {
 			Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("000000134")})}).
 		Title("GCS Pricing Map Refresh Time").
 		Description("The amount of time before the next refresh of the GCS pricing map. ").
-		Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("${datasource}")}).
+		Datasource(prometheusDatasourceRef()).
 		GridPos(dashboard.GridPos{H: 7, W: 13, X: 11, Y: 25}).
 		Height(0x7).
 		Span(0xd).
@@ -376,38 +371,44 @@ func buildNextScrapePanel() *timeseries.PanelBuilder {
 		AxisBorderShow(false)
 }
 
-func buildUpPanel() *stat.PanelBuilder {
+func collectorStatusCurrent() *stat.PanelBuilder {
 	return stat.NewPanelBuilder().
-		Id(0xc).
-		Targets([]cog.Builder[variants.Dataquery]{prometheus.NewDataqueryBuilder().
-			Expr("max by (provider, collector) (cloudcost_exporter_collector_last_scrape_error == 0)").
-			Range().
-			EditorMode("code").
-			LegendFormat("{{provider}}:{{collector}}").
-			RefId("A").
-			Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("${datasource}")})}).
 		Title("Collector Status").
 		Description("Display the status of all the collectors running.").
-		Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("${datasource}")}).
-		GridPos(dashboard.GridPos{H: 6, W: 11, X: 0, Y: 1}).
-		Height(0x6).
-		Span(0xb).
+		Datasource(prometheusDatasourceRef()).
 		Unit("short").
-		Mappings([]dashboard.ValueMapping{dashboard.ValueMapOrRangeMapOrRegexMapOrSpecialValueMap{ValueMap: cog.ToPtr[dashboard.ValueMap](dashboard.ValueMap{Type: "value", Options: map[string]dashboard.ValueMappingResult{"0": dashboard.ValueMappingResult{Text: cog.ToPtr[string]("Up"), Index: cog.ToPtr[int32](0)}}})},
-			dashboard.ValueMapOrRangeMapOrRegexMapOrSpecialValueMap{SpecialValueMap: cog.ToPtr[dashboard.SpecialValueMap](dashboard.SpecialValueMap{Type: "special", Options: dashboard.DashboardSpecialValueMapOptions{Match: "null+nan", Result: dashboard.ValueMappingResult{Text: cog.ToPtr[string]("Down"), Color: cog.ToPtr[string]("red"), Index: cog.ToPtr[int32](1)}}})}}).
-		Thresholds(dashboard.NewThresholdsConfigBuilder().
-			Mode("absolute").
-			Steps([]dashboard.Threshold{dashboard.Threshold{Color: "green"},
-				dashboard.Threshold{Value: cog.ToPtr[float64](80), Color: "red"}})).
-		ColorScheme(dashboard.NewFieldColorBuilder().
-			Mode("thresholds")).
-		GraphMode("area").
-		ColorMode("value").
-		JustifyMode("auto").
-		TextMode("auto").
+		WithTarget(
+			prometheusQuery("max by (provider, collector) (cloudcost_exporter_collector_last_scrape_error == 0)", "{{provider}}:{{collector}}").
+				Instant(),
+		).
+		JustifyMode(common.BigValueJustifyModeAuto).
+		TextMode(common.BigValueTextModeAuto).
+		Orientation(common.VizOrientationAuto).
 		ReduceOptions(common.NewReduceDataOptionsBuilder().
 			Values(false).
-			Calcs([]string{"lastNotNull"})).
-		PercentChangeColorMode("standard").
-		Orientation("auto")
+			Calcs([]string{"lastNotNull"}),
+		).
+		Mappings([]dashboard.ValueMapping{
+			{
+				ValueMap: cog.ToPtr[dashboard.ValueMap](dashboard.ValueMap{
+					Type: "value",
+					Options: map[string]dashboard.ValueMappingResult{
+						"0": {Text: cog.ToPtr[string]("Up"), Index: cog.ToPtr[int32](0)},
+					},
+				}),
+			},
+			{
+				SpecialValueMap: cog.ToPtr[dashboard.SpecialValueMap](dashboard.SpecialValueMap{
+					Type: "special",
+					Options: dashboard.DashboardSpecialValueMapOptions{
+						Match: "null+nan",
+						Result: dashboard.ValueMappingResult{
+							Text:  cog.ToPtr[string]("Down"),
+							Color: cog.ToPtr[string]("red"),
+							Index: cog.ToPtr[int32](1),
+						},
+					},
+				}),
+			},
+		})
 }

--- a/config/grafana/operations_dashboard.go
+++ b/config/grafana/operations_dashboard.go
@@ -121,12 +121,7 @@ func costExplorerAPIRequestsOverTime() *timeseries.PanelBuilder {
 				"__auto",
 			),
 		).
-		Unit("reqps").
-		Legend(common.NewVizLegendOptionsBuilder().
-			DisplayMode(common.LegendDisplayModeList).
-			Placement(common.LegendPlacementBottom).
-			ShowLegend(true),
-		)
+		Unit("reqps")
 }
 
 func awsS3NextPricingMapRefreshOverTime() *timeseries.PanelBuilder {
@@ -140,11 +135,7 @@ func awsS3NextPricingMapRefreshOverTime() *timeseries.PanelBuilder {
 				"max by (cluster) (cloudcost_exporter_aws_s3_next_scrape{cluster=~\"$cluster\"}) - time() ",
 				"__auto",
 			),
-		).
-		Legend(common.NewVizLegendOptionsBuilder().
-			DisplayMode(common.LegendDisplayModeList).
-			Placement(common.LegendPlacementBottom).
-			ShowLegend(true))
+		)
 }
 
 func gcpListBucketsRPSOverTime() *timeseries.PanelBuilder {
@@ -153,12 +144,7 @@ func gcpListBucketsRPSOverTime() *timeseries.PanelBuilder {
 		Description("The number of requests per second to list buckets in GCS.").
 		Datasource(prometheusDatasourceRef()).
 		Unit("reqps").
-		WithTarget(prometheusQuery("sum by (cluster, status) (increase(cloudcost_exporter_gcp_gcs_bucket_list_status_total[5m]))", "{{cluster}}:{{status}}")).
-		Legend(common.NewVizLegendOptionsBuilder().
-			DisplayMode(common.LegendDisplayModeList).
-			Placement(common.LegendPlacementBottom).
-			ShowLegend(true),
-		)
+		WithTarget(prometheusQuery("sum by (cluster, status) (increase(cloudcost_exporter_gcp_gcs_bucket_list_status_total[5m]))", "{{cluster}}:{{status}}"))
 }
 
 func gcpNextScrapeOverTime() *timeseries.PanelBuilder {
@@ -169,11 +155,6 @@ func gcpNextScrapeOverTime() *timeseries.PanelBuilder {
 		Unit("s").
 		WithTarget(
 			prometheusQuery("max by (cluster) (cloudcost_exporter_gcp_gcs_next_scrape{cluster=~\"$cluster\"}) - time() ", "__auto"),
-		).
-		Legend(common.NewVizLegendOptionsBuilder().
-			DisplayMode(common.LegendDisplayModeList).
-			Placement(common.LegendPlacementBottom).
-			ShowLegend(true),
 		)
 }
 

--- a/config/grafana/operations_dashboard.go
+++ b/config/grafana/operations_dashboard.go
@@ -1,0 +1,413 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/grafana/grafana-foundation-sdk/go/cog"
+	"github.com/grafana/grafana-foundation-sdk/go/cog/variants"
+	"github.com/grafana/grafana-foundation-sdk/go/common"
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+	"github.com/grafana/grafana-foundation-sdk/go/prometheus"
+	"github.com/grafana/grafana-foundation-sdk/go/stat"
+	"github.com/grafana/grafana-foundation-sdk/go/timeseries"
+)
+
+func main() {
+	builder := dashboard.NewDashboardBuilder("CloudCost Exporter").
+		Id(10297).
+		Uid("1a9c0de366458599246184cf0ae8b468").
+		Title("CloudCost Exporter").
+		Editable().
+		Tooltip(1).
+		Timepicker(dashboard.NewTimePickerBuilder()).
+		Refresh("30s").
+		Version(0x2).
+		Variables([]cog.Builder[dashboard.VariableModel]{dashboard.NewDatasourceVariableBuilder("datasource").
+			Name("datasource").
+			Label("Data Source").
+			Type("prometheus"),
+			dashboard.NewQueryVariableBuilder("cluster").
+				Name("cluster").
+				Query(dashboard.StringOrMap{Map: map[string]interface{}{"query": "label_values(tanka_environment_info{app=\"cloudcost-exporter\"},exported_cluster)", "refId": "PrometheusVariableQueryEditor-VariableQuery"}}).
+				Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("${datasource}")}).
+				Current(dashboard.VariableOption{Text: dashboard.StringOrArrayOfString{ArrayOfString: []string{"dev-us-central-0", "dev-us-east-0", "prod-us-east-0"}}, Value: dashboard.StringOrArrayOfString{ArrayOfString: []string{"dev-us-central-0", "dev-us-east-0", "prod-us-east-0"}}}).
+				Multi(true).
+				Refresh(1).
+				IncludeAll(true).
+				AllValue(".*")}).
+		Annotations([]cog.Builder[dashboard.AnnotationQuery]{dashboard.NewAnnotationQueryBuilder().
+			Name("Annotations & Alerts").
+			Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("grafana"), Uid: cog.ToPtr[string]("-- Grafana --")}).
+			Hide(true).
+			IconColor("rgba(0, 211, 255, 1)").
+			Type("dashboard").
+			BuiltIn(1)}).
+		Preload(false).
+		WithRow(dashboard.NewRowBuilder("Overview").
+			Title("Overview").
+			GridPos(dashboard.GridPos{H: 1, W: 24, X: 0, Y: 0}).
+			Id(0x8)).
+		WithPanel(buildUpPanel()).
+		WithPanel(buildCollectorScrapeDurationPanel()).
+		WithRow(dashboard.NewRowBuilder("AWS").
+			Title("AWS").
+			GridPos(dashboard.GridPos{H: 1, W: 24, X: 0, Y: 15}).
+			Id(0x7)).
+		WithPanel(buildCostExplorerAPIRequestsPanel()).
+		WithPanel(buildAWSS3NextScrapePanel()).
+		WithRow(dashboard.NewRowBuilder("GCP").
+			Title("GCP").
+			GridPos(dashboard.GridPos{H: 1, W: 24, X: 0, Y: 24}).
+			Id(0x2)).
+		WithPanel(buildGCPlistBucketsRPSPanel()).
+		WithPanel(buildNextScrapePanel())
+
+	sampleDashboard, err := builder.Build()
+	if err != nil {
+		panic(err)
+	}
+	dashboardJson, err := json.MarshalIndent(sampleDashboard, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(string(dashboardJson))
+}
+
+func buildCollectorScrapeDurationPanel() *timeseries.PanelBuilder {
+	return timeseries.NewPanelBuilder().
+		Id(0xd).
+		Targets([]cog.Builder[variants.Dataquery]{prometheus.NewDataqueryBuilder().
+			Expr("cloudcost_exporter_collector_last_scrape_duration_seconds").
+			Range().
+			EditorMode("code").
+			LegendFormat("{{provider}}:{{collector}}").
+			RefId("A").
+			Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("${datasource}")}),
+			prometheus.NewDataqueryBuilder().
+				Expr("vector(60)").
+				Range().
+				EditorMode("code").
+				LegendFormat("scrape_interval").
+				RefId("B").
+				Hide(false).
+				Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("${datasource}")})}).
+		Title("Collector Scrape Duration").
+		Description("Duration of scrapes by provider and collector").
+		Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("${datasource}")}).
+		GridPos(dashboard.GridPos{H: 8, W: 24, X: 0, Y: 7}).
+		Height(0x8).
+		Span(0x18).
+		Unit("s").
+		Thresholds(dashboard.NewThresholdsConfigBuilder().
+			Mode("absolute").
+			Steps([]dashboard.Threshold{dashboard.Threshold{Color: "green"},
+				dashboard.Threshold{Value: cog.ToPtr[float64](80), Color: "red"}})).
+		ColorScheme(dashboard.NewFieldColorBuilder().
+			Mode("palette-classic")).
+		Legend(common.NewVizLegendOptionsBuilder().
+			DisplayMode("table").
+			Placement("bottom").
+			ShowLegend(true).
+			SortBy("Last *").
+			SortDesc(true).
+			Calcs([]string{"lastNotNull",
+				"min",
+				"max"})).
+		Tooltip(common.NewVizTooltipOptionsBuilder().
+			Mode("single").
+			Sort("none")).
+		DrawStyle("line").
+		GradientMode("none").
+		ThresholdsStyle(common.NewGraphThresholdsStyleConfigBuilder().
+			Mode("off")).
+		LineWidth(1).
+		LineInterpolation("linear").
+		FillOpacity(0).
+		ShowPoints("auto").
+		PointSize(4).
+		AxisPlacement("auto").
+		AxisColorMode("text").
+		ScaleDistribution(common.NewScaleDistributionConfigBuilder().
+			Type("linear")).
+		AxisCenteredZero(false).
+		BarAlignment(0).
+		BarWidthFactor(0.6).
+		Stacking(common.NewStackingConfigBuilder().
+			Mode("none").
+			Group("A")).
+		HideFrom(common.NewHideSeriesConfigBuilder().
+			Tooltip(false).
+			Legend(false).
+			Viz(false)).
+		InsertNulls(common.BoolOrFloat64{Bool: cog.ToPtr[bool](false)}).
+		SpanNulls(common.BoolOrFloat64{Bool: cog.ToPtr[bool](false)}).
+		AxisBorderShow(false)
+}
+
+func buildCostExplorerAPIRequestsPanel() *timeseries.PanelBuilder {
+	return timeseries.NewPanelBuilder().
+		Id(0x6).
+		Targets([]cog.Builder[variants.Dataquery]{prometheus.NewDataqueryBuilder().
+			Expr("sum by (cluster) (increase(cloudcost_exporter_aws_s3_cost_api_requests_total{cluster=~\"$cluster\"}[5m]))").
+			Range().
+			EditorMode("code").
+			LegendFormat("__auto").
+			RefId("A").
+			Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("000000134")})}).
+		Title("CostExplorer API Requests").
+		Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("${datasource}")}).
+		GridPos(dashboard.GridPos{H: 8, W: 11, X: 0, Y: 16}).
+		Height(0x8).
+		Span(0xb).
+		Unit("reqps").
+		Thresholds(dashboard.NewThresholdsConfigBuilder().
+			Mode("absolute").
+			Steps([]dashboard.Threshold{dashboard.Threshold{Color: "green"},
+				dashboard.Threshold{Value: cog.ToPtr[float64](80), Color: "red"}})).
+		ColorScheme(dashboard.NewFieldColorBuilder().
+			Mode("palette-classic")).
+		Legend(common.NewVizLegendOptionsBuilder().
+			DisplayMode("list").
+			Placement("bottom").
+			ShowLegend(true)).
+		Tooltip(common.NewVizTooltipOptionsBuilder().
+			Mode("single").
+			Sort("none")).
+		DrawStyle("line").
+		GradientMode("none").
+		ThresholdsStyle(common.NewGraphThresholdsStyleConfigBuilder().
+			Mode("off")).
+		LineWidth(1).
+		LineInterpolation("linear").
+		FillOpacity(0).
+		ShowPoints("auto").
+		PointSize(5).
+		AxisPlacement("auto").
+		AxisColorMode("text").
+		ScaleDistribution(common.NewScaleDistributionConfigBuilder().
+			Type("linear")).
+		AxisCenteredZero(false).
+		BarAlignment(0).
+		BarWidthFactor(0.6).
+		Stacking(common.NewStackingConfigBuilder().
+			Mode("none").
+			Group("A")).
+		HideFrom(common.NewHideSeriesConfigBuilder().
+			Tooltip(false).
+			Legend(false).
+			Viz(false)).
+		InsertNulls(common.BoolOrFloat64{Bool: cog.ToPtr[bool](false)}).
+		SpanNulls(common.BoolOrFloat64{Bool: cog.ToPtr[bool](false)}).
+		AxisBorderShow(false)
+}
+
+func buildAWSS3NextScrapePanel() *timeseries.PanelBuilder {
+	return timeseries.NewPanelBuilder().
+		Id(0x9).
+		Targets([]cog.Builder[variants.Dataquery]{prometheus.NewDataqueryBuilder().
+			Expr("max by (cluster) (cloudcost_exporter_aws_s3_next_scrape{cluster=~\"$cluster\"}) - time() ").
+			Range().
+			EditorMode("code").
+			LegendFormat("__auto").
+			RefId("A").
+			Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("000000134")})}).
+		Title("Next pricing map refresh").
+		Description("The AWS s3 module uses cost data pulled from Cost Explorer, which costs $0.01 per API call. The cost metrics are refreshed every hour, so if this value goes below 0, it indicates a problem with refreshing the pricing map and thus needs investigation.").
+		Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("${datasource}")}).
+		GridPos(dashboard.GridPos{H: 8, W: 13, X: 11, Y: 16}).
+		Height(0x8).
+		Span(0xd).
+		Unit("s").
+		Thresholds(dashboard.NewThresholdsConfigBuilder().
+			Mode("absolute").
+			Steps([]dashboard.Threshold{dashboard.Threshold{Color: "green"},
+				dashboard.Threshold{Value: cog.ToPtr[float64](80), Color: "red"}})).
+		ColorScheme(dashboard.NewFieldColorBuilder().
+			Mode("palette-classic")).
+		Legend(common.NewVizLegendOptionsBuilder().
+			DisplayMode("list").
+			Placement("bottom").
+			ShowLegend(true)).
+		Tooltip(common.NewVizTooltipOptionsBuilder().
+			Mode("single").
+			Sort("none")).
+		DrawStyle("line").
+		GradientMode("none").
+		ThresholdsStyle(common.NewGraphThresholdsStyleConfigBuilder().
+			Mode("off")).
+		LineWidth(1).
+		LineInterpolation("linear").
+		FillOpacity(0).
+		ShowPoints("auto").
+		PointSize(5).
+		AxisPlacement("auto").
+		AxisColorMode("text").
+		ScaleDistribution(common.NewScaleDistributionConfigBuilder().
+			Type("linear")).
+		AxisCenteredZero(false).
+		BarAlignment(0).
+		BarWidthFactor(0.6).
+		Stacking(common.NewStackingConfigBuilder().
+			Mode("none").
+			Group("A")).
+		HideFrom(common.NewHideSeriesConfigBuilder().
+			Tooltip(false).
+			Legend(false).
+			Viz(false)).
+		InsertNulls(common.BoolOrFloat64{Bool: cog.ToPtr[bool](false)}).
+		SpanNulls(common.BoolOrFloat64{Bool: cog.ToPtr[bool](false)}).
+		AxisBorderShow(false)
+}
+
+func buildGCPlistBucketsRPSPanel() *timeseries.PanelBuilder {
+	return timeseries.NewPanelBuilder().
+		Id(0x3).
+		Targets([]cog.Builder[variants.Dataquery]{prometheus.NewDataqueryBuilder().
+			Expr("sum by (cluster, status) (increase(cloudcost_exporter_gcp_gcs_bucket_list_status_total[5m]))").
+			Range().
+			EditorMode("code").
+			LegendFormat("{{cluster}}:{{status}}").
+			RefId("A").
+			Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("000000134")})}).
+		Title("GCS List Buckets Requests Per Second").
+		Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("${datasource}")}).
+		GridPos(dashboard.GridPos{H: 7, W: 11, X: 0, Y: 25}).
+		Height(0x7).
+		Span(0xb).
+		Unit("reqps").
+		Thresholds(dashboard.NewThresholdsConfigBuilder().
+			Mode("absolute").
+			Steps([]dashboard.Threshold{dashboard.Threshold{Color: "green"},
+				dashboard.Threshold{Value: cog.ToPtr[float64](80), Color: "red"}})).
+		ColorScheme(dashboard.NewFieldColorBuilder().
+			Mode("palette-classic")).
+		Legend(common.NewVizLegendOptionsBuilder().
+			DisplayMode("list").
+			Placement("bottom").
+			ShowLegend(true)).
+		Tooltip(common.NewVizTooltipOptionsBuilder().
+			Mode("single").
+			Sort("none")).
+		DrawStyle("line").
+		GradientMode("none").
+		ThresholdsStyle(common.NewGraphThresholdsStyleConfigBuilder().
+			Mode("off")).
+		LineWidth(1).
+		LineInterpolation("linear").
+		FillOpacity(0).
+		ShowPoints("auto").
+		PointSize(5).
+		AxisPlacement("auto").
+		AxisColorMode("text").
+		ScaleDistribution(common.NewScaleDistributionConfigBuilder().
+			Type("linear")).
+		AxisCenteredZero(false).
+		BarAlignment(0).
+		BarWidthFactor(0.6).
+		Stacking(common.NewStackingConfigBuilder().
+			Mode("none").
+			Group("A")).
+		HideFrom(common.NewHideSeriesConfigBuilder().
+			Tooltip(false).
+			Legend(false).
+			Viz(false)).
+		InsertNulls(common.BoolOrFloat64{Bool: cog.ToPtr[bool](false)}).
+		SpanNulls(common.BoolOrFloat64{Bool: cog.ToPtr[bool](false)}).
+		AxisBorderShow(false)
+}
+
+func buildNextScrapePanel() *timeseries.PanelBuilder {
+	return timeseries.NewPanelBuilder().
+		Id(0xa).
+		Targets([]cog.Builder[variants.Dataquery]{prometheus.NewDataqueryBuilder().
+			Expr("max by (cluster) (cloudcost_exporter_gcp_gcs_next_scrape{cluster=~\"$cluster\"}) - time() ").
+			Range().
+			EditorMode("code").
+			LegendFormat("__auto").
+			RefId("A").
+			Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("000000134")})}).
+		Title("GCS Pricing Map Refresh Time").
+		Description("The amount of time before the next refresh of the GCS pricing map. ").
+		Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("${datasource}")}).
+		GridPos(dashboard.GridPos{H: 7, W: 13, X: 11, Y: 25}).
+		Height(0x7).
+		Span(0xd).
+		Unit("s").
+		Thresholds(dashboard.NewThresholdsConfigBuilder().
+			Mode("absolute").
+			Steps([]dashboard.Threshold{dashboard.Threshold{Color: "green"},
+				dashboard.Threshold{Value: cog.ToPtr[float64](80), Color: "red"}})).
+		ColorScheme(dashboard.NewFieldColorBuilder().
+			Mode("palette-classic")).
+		Legend(common.NewVizLegendOptionsBuilder().
+			DisplayMode("list").
+			Placement("bottom").
+			ShowLegend(true)).
+		Tooltip(common.NewVizTooltipOptionsBuilder().
+			Mode("single").
+			Sort("none")).
+		DrawStyle("line").
+		GradientMode("none").
+		ThresholdsStyle(common.NewGraphThresholdsStyleConfigBuilder().
+			Mode("off")).
+		LineWidth(1).
+		LineInterpolation("linear").
+		FillOpacity(0).
+		ShowPoints("auto").
+		PointSize(5).
+		AxisPlacement("auto").
+		AxisColorMode("text").
+		ScaleDistribution(common.NewScaleDistributionConfigBuilder().
+			Type("linear")).
+		AxisCenteredZero(false).
+		BarAlignment(0).
+		BarWidthFactor(0.6).
+		Stacking(common.NewStackingConfigBuilder().
+			Mode("none").
+			Group("A")).
+		HideFrom(common.NewHideSeriesConfigBuilder().
+			Tooltip(false).
+			Legend(false).
+			Viz(false)).
+		InsertNulls(common.BoolOrFloat64{Bool: cog.ToPtr[bool](false)}).
+		SpanNulls(common.BoolOrFloat64{Bool: cog.ToPtr[bool](false)}).
+		AxisBorderShow(false)
+}
+
+func buildUpPanel() *stat.PanelBuilder {
+	return stat.NewPanelBuilder().
+		Id(0xc).
+		Targets([]cog.Builder[variants.Dataquery]{prometheus.NewDataqueryBuilder().
+			Expr("max by (provider, collector) (cloudcost_exporter_collector_last_scrape_error == 0)").
+			Range().
+			EditorMode("code").
+			LegendFormat("{{provider}}:{{collector}}").
+			RefId("A").
+			Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("${datasource}")})}).
+		Title("Collector Status").
+		Description("Display the status of all the collectors running.").
+		Datasource(dashboard.DataSourceRef{Type: cog.ToPtr[string]("prometheus"), Uid: cog.ToPtr[string]("${datasource}")}).
+		GridPos(dashboard.GridPos{H: 6, W: 11, X: 0, Y: 1}).
+		Height(0x6).
+		Span(0xb).
+		Unit("short").
+		Mappings([]dashboard.ValueMapping{dashboard.ValueMapOrRangeMapOrRegexMapOrSpecialValueMap{ValueMap: cog.ToPtr[dashboard.ValueMap](dashboard.ValueMap{Type: "value", Options: map[string]dashboard.ValueMappingResult{"0": dashboard.ValueMappingResult{Text: cog.ToPtr[string]("Up"), Index: cog.ToPtr[int32](0)}}})},
+			dashboard.ValueMapOrRangeMapOrRegexMapOrSpecialValueMap{SpecialValueMap: cog.ToPtr[dashboard.SpecialValueMap](dashboard.SpecialValueMap{Type: "special", Options: dashboard.DashboardSpecialValueMapOptions{Match: "null+nan", Result: dashboard.ValueMappingResult{Text: cog.ToPtr[string]("Down"), Color: cog.ToPtr[string]("red"), Index: cog.ToPtr[int32](1)}}})}}).
+		Thresholds(dashboard.NewThresholdsConfigBuilder().
+			Mode("absolute").
+			Steps([]dashboard.Threshold{dashboard.Threshold{Color: "green"},
+				dashboard.Threshold{Value: cog.ToPtr[float64](80), Color: "red"}})).
+		ColorScheme(dashboard.NewFieldColorBuilder().
+			Mode("thresholds")).
+		GraphMode("area").
+		ColorMode("value").
+		JustifyMode("auto").
+		TextMode("auto").
+		ReduceOptions(common.NewReduceDataOptionsBuilder().
+			Values(false).
+			Calcs([]string{"lastNotNull"})).
+		PercentChangeColorMode("standard").
+		Orientation("auto")
+}

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/pricing v1.32.7
 	github.com/google/go-cmp v0.6.0
 	github.com/googleapis/gax-go/v2 v2.14.1
+	github.com/grafana/grafana-foundation-sdk/go v0.0.0-20241213004919-4516aa9d3732
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.60.0

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.4 h1:XYIDZApgAnrN1c855gT
 github.com/googleapis/enterprise-certificate-proxy v0.3.4/go.mod h1:YKe7cfqYXjKGpGvmSg28/fFvhNzinZQm8DGnaburhGA=
 github.com/googleapis/gax-go/v2 v2.14.1 h1:hb0FFeiPaQskmvakKu5EbCbpntQn48jyHuvrkurSS/Q=
 github.com/googleapis/gax-go/v2 v2.14.1/go.mod h1:Hb/NubMaVM88SrNkvl8X/o8XWwDJEPqouaLeN2IUxoA=
+github.com/grafana/grafana-foundation-sdk/go v0.0.0-20241213004919-4516aa9d3732 h1:56xP7BiNykV3Zo1acyWZj+GTndkXFKTJVkbntoVZ3+M=
+github.com/grafana/grafana-foundation-sdk/go v0.0.0-20241213004919-4516aa9d3732/go.mod h1:48EA8jF85SrReYflLa39Sk34b6NpxwJPBwjF3TJgRpE=
 github.com/keybase/go-keychain v0.0.0-20231219164618-57a3676c3af6 h1:IsMZxCuZqKuao2vNdfD82fjjgPLfyHLpR41Z88viRWs=
 github.com/keybase/go-keychain v0.0.0-20231219164618-57a3676c3af6/go.mod h1:3VeWNIJaW+O5xpRQbPp0Ybqu1vJd/pm7s2F473HRrkw=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=


### PR DESCRIPTION
This change adds two components
- Go code to convert dashboards represented as json into Go code
- Operational dashboard for `cloudcost-exporter` that is written in go using Grafana's Foundation SDK

Adds a README for each section on how to use the tools. The goal of this PR is mostly to solicit feedback on how the code is structured and ways to improve it.