### PR TITLE
Generate initial Helm chart artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,6 @@ go.work
 .vscode
 
 cloudcost-exporter
+!cloudcost-exporter/
 
 dist/

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,7 @@
+# Deploy `cloudcost-exporter`
+
+Here you will find IaaS and container orcherstration deployment configuration and templates for `cloudcost-exporter`.
+
+## Helm
+
+The source code of the Helm chart used to deploy `cloudcost-exporter` can be found in `helm/`.

--- a/deploy/helm/cloudcost-exporter/.helmignore
+++ b/deploy/helm/cloudcost-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/helm/cloudcost-exporter/Chart.yaml
+++ b/deploy/helm/cloudcost-exporter/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: cloudcost-exporter
+description: Cloud Cost Exporter exports cloud provider agnostic cost metrics to Prometheus.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.7.7
+
+# This is the version of cloudcost-exporter to be deployed, which should be incremented
+# with each release.
+appVersion: "0.7.7"
+
+home: https://github.com/grafana/cloudcost-exporter

--- a/deploy/helm/cloudcost-exporter/README.md
+++ b/deploy/helm/cloudcost-exporter/README.md
@@ -1,0 +1,57 @@
+# Cloud Cost Exporter Helm chart
+
+## Usage
+
+[Helm](https://helm.sh/) must be installed in order to deploy the `cloudcost-exporter` Helm chart.
+
+### Setup the Grafana chart repository
+
+```console
+helm repo add grafana https://grafana.github.io/helm-charts
+helm repo update
+```
+
+### Install the chart
+
+To install the chart with the release name my-release:
+
+```console
+helm install my-release grafana/cloudcost-exporter
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the cloudcost-explorer Helm chart and their default values (in alphabetical order).
+
+Parameter | Description | Default
+--- | --- | ---
+`affinity` | node/pod affinities | `{}`
+`fullnameOverride` | optional full name override | `""`
+`image.pullPolicy` | image pull policy | `IfNotPresent`
+`image.repository` | image repository | `grafana/cloudcost-exporter`
+`image.tag` | overrides the image tag whose default is the chart appVersion | `""`
+`imagePullSecrets` | specify image pull secrets | `[]`
+`minReadySeconds` |  seconds a pod should be ready to be considered available  | `10`
+`nameOverride` | optional name override | `""`
+`nodeSelector` | node labels for pod assignment  | `{}`
+`podAnnotations` | annotations to add to each pod | `{}`
+`podSecurityContext.fsGroup` | filesystem group to associate for each pod | `10001`
+`replicaCount` | desired number of pods | `1` |
+`resources.limits.cpu` | cpu limit | `2`
+`resources.limits.memory` | memory limit | `2Gi`
+`resources.requests.cpu` | cpu request | `1`
+`resources.requests.memory` | memory request | `1Gi`
+`revisionHistoryLimit` | number of old versions to retain to allow rollback | `10`
+`serviceAccount.annotations` | annotations to add to the service account | `{}`
+`serviceAccount.create` | specifies whether a service account should be created | `true`
+`serviceAccount.name` | name of service account to use - generated | `""`
+`service.port` | port number for the service | `8080`
+`service.portName` | name of the port | `http`
+`service.protocol` | protocol for the serivce | `TCP`
+`service.type` | type of service | `ClusterIP`
+`tolerations` | list of node taints to tolerate | `[]`
+`volumes` | list of volumes | `[]`
+
+## Contribute
+
+Check out the [docs](../../../docs/contribute/releases.md#helm-chart) for more information on how to contribute to the `cloudcost-explorer`'s Helm chart.

--- a/deploy/helm/cloudcost-exporter/README.md
+++ b/deploy/helm/cloudcost-exporter/README.md
@@ -1,5 +1,11 @@
 # Cloud Cost Exporter Helm chart
 
+> [!WARNING]
+> This Helm chart is still a WIP.
+> The instructions below are not functional yet.
+>
+> Progress on the Helm chart is tracked here: https://github.com/grafana/cloudcost-exporter/issues/392
+
 ## Usage
 
 [Helm](https://helm.sh/) must be installed in order to deploy the `cloudcost-exporter` Helm chart.

--- a/deploy/helm/cloudcost-exporter/templates/NOTES.txt
+++ b/deploy/helm/cloudcost-exporter/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "cloudcost-exporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "cloudcost-exporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cloudcost-exporter.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "cloudcost-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/deploy/helm/cloudcost-exporter/templates/_helpers.tpl
+++ b/deploy/helm/cloudcost-exporter/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cloudcost-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cloudcost-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cloudcost-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cloudcost-exporter.labels" -}}
+helm.sh/chart: {{ include "cloudcost-exporter.chart" . }}
+{{ include "cloudcost-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cloudcost-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cloudcost-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cloudcost-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "cloudcost-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/cloudcost-exporter/templates/deployment.yaml
+++ b/deploy/helm/cloudcost-exporter/templates/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cloudcost-exporter.fullname" . }}
+  labels:
+    {{- include "cloudcost-exporter.labels" . | nindent 4 }}
+spec:
+  minReadySeconds: {{ .Values.minReadySeconds }}
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "cloudcost-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "cloudcost-exporter.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "cloudcost-exporter.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: {{ .Values.service.portName }}
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 8 }}
+          volumeMounts:
+            {{- toYaml .Values.volumeMounts | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/cloudcost-exporter/templates/service.yaml
+++ b/deploy/helm/cloudcost-exporter/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cloudcost-exporter.fullname" . }}
+  labels:
+    {{- include "cloudcost-exporter.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: {{ .Values.service.protocol }}
+      name: http
+  selector:
+    {{- include "cloudcost-exporter.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/cloudcost-exporter/templates/serviceaccount.yaml
+++ b/deploy/helm/cloudcost-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cloudcost-exporter.serviceAccountName" . }}
+  labels:
+    {{- include "cloudcost-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/cloudcost-exporter/templates/tests/test-connection.yaml
+++ b/deploy/helm/cloudcost-exporter/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "cloudcost-exporter.fullname" . }}-test-connection"
+  labels:
+    {{- include "cloudcost-exporter.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "cloudcost-exporter.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/deploy/helm/cloudcost-exporter/values.yaml
+++ b/deploy/helm/cloudcost-exporter/values.yaml
@@ -1,0 +1,55 @@
+# Default values for cloudcost-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: grafana/cloudcost-exporter
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  fsGroup: "10001"
+
+service:
+  type: ClusterIP
+  port: 8080
+  portName: http
+  protocol: TCP
+
+resources:
+  limits:
+    cpu: "2"
+    memory: 2Gi
+  requests:
+    cpu: "1"
+    memory: 1Gi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+volumes: []
+volumeMounts: []
+
+minReadySeconds: 10
+revisionHistoryLimit: 10

--- a/docs/contribute/releases.md
+++ b/docs/contribute/releases.md
@@ -43,3 +43,9 @@ jobs:
 ```
 
 Granular control of the version helps with security since commit SHAs are immutable.
+
+## Helm Chart
+
+The `cloudcost-exporter`'s Helm chart can be found in the repo's root path at [./deploy/helm/cloudcost-exporter](../../deploy/helm/cloudcost-exporter/README.md)
+
+To contribute to the Helm chart, make any changes to the [Kubernetes manifest templates](../../deploy/helm/cloudcost-exporter/templates/). Then, add the field to the list of configuration options in the chart's README [here](../../deploy/helm/cloudcost-exporter/README.md#configuration).


### PR DESCRIPTION
ref https://github.com/grafana/cloudcost-exporter/issues/392

This PR merges https://github.com/grafana/cloudcost-exporter/pull/398 to `main` with an additional warning message that the Helm chart is not functional yet. @Pokom and I decided to keep it simple and not hide the Helm chart WIP behind a feature branch :)