### PR TITLE
Add AWS authentication docs

### DIFF
--- a/docs/deploying/aws/README.md
+++ b/docs/deploying/aws/README.md
@@ -26,7 +26,7 @@ The following role needs to be created:
 }
 ```
 
-In the [values.yaml](./helm/cloudcost-exporter/values.yaml) file, annotate the `serviceAccount` with the ARN of the role created above.
+In the [values.yaml](../../../deploy/helm/cloudcost-exporter/values.yaml) file, annotate the `serviceAccount` with the ARN of the role created above.
 An example values file is provided below:
 
 ```yaml

--- a/docs/deploying/aws/README.md
+++ b/docs/deploying/aws/README.md
@@ -1,0 +1,29 @@
+# AWS CloudCost Exporter Deployment
+
+## Authentication
+
+cloudcost-exporter uses [AWS SDK for Go V2](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/getting-started.html) and supports providing authentication via the [AWS SDK's default credential provider chain](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/security_iam_service-with-iam.html).
+This means that the CloudCost Exporter can be deployed on an EC2 instance, ECS, EKS, or any other AWS service that supports IAM roles for service accounts.
+The following role needs to be created:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ce:*",
+                "ec2:DescribeRegions",
+                "ec2:DescribeInstances",
+                "ec2:DescribeSpotPriceHistory",
+                "ec2:DescribeVolumes",
+                "pricing:GetProducts"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+This role needs to be attached to the EC2 instance, ECS task, or EKS pod that the CloudCost Exporter is running on.

--- a/docs/deploying/aws/README.md
+++ b/docs/deploying/aws/README.md
@@ -26,4 +26,11 @@ The following role needs to be created:
 }
 ```
 
-This role needs to be attached to the EC2 instance, ECS task, or EKS pod that the CloudCost Exporter is running on.
+In the [values.yaml](./helm/cloudcost-exporter/values.yaml) file, annotate the `serviceAccount` with the ARN of the role created above.
+An example values file is provided below:
+
+```yaml
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/CloudCostExporterRole
+```


### PR DESCRIPTION
This is this first part of documenting how to configure AWS's deployment so that it can access AWS endpoints. This was tested with changes introduced in #413:

```
helm template my-release ./deploy/helm/cloudcost-exporter --set replicaCount=3 --set image.tag=latest --set serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn=arn:aws:iam::123456789012:role/CloudCostExporterRole | kubectl apply --dry-run=client -f -
```

+
```
helm template my-release ./deploy/helm/cloudcost-exporter --set replicaCount=3 --set image.tag=latest --set serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn=arn:aws:iam::123456789012:role/CloudCostExporterRoke      1 ↵
---
# Source: cloudcost-exporter/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: my-release-cloudcost-exporter
  labels:
    helm.sh/chart: cloudcost-exporter-0.7.7
    app.kubernetes.io/name: cloudcost-exporter
    app.kubernetes.io/instance: my-release
    app.kubernetes.io/version: "0.7.7"
    app.kubernetes.io/managed-by: Helm
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/CloudCostExporterRoke
---
```