### PR TITLE
Fix helm chart compilation

### DIFF
--- a/deploy/helm/cloudcost-exporter/templates/deployment.yaml
+++ b/deploy/helm/cloudcost-exporter/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:
-            {{- toYaml .Values.podSecurityContext | nindent 8 }}
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
           volumeMounts:
             {{- toYaml .Values.volumeMounts | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/deploy/helm/cloudcost-exporter/values.yaml
+++ b/deploy/helm/cloudcost-exporter/values.yaml
@@ -53,3 +53,11 @@ volumeMounts: []
 
 minReadySeconds: 10
 revisionHistoryLimit: 10
+
+ingress:
+  enabled: false
+  hosts:
+    - host: chart-example.local
+      paths: []
+  annotations: {}
+  tls: []


### PR DESCRIPTION
The helm chart is failing to compile with the following errors:

```
helm template test-cloudcost-exporter ./deploy/helmcloudcost-exporter --debug
install.go:225: 2025-01-27 20:44:21.719520281 -0500 EST m=+0.031147000 [debug] Original chart version: ""
install.go:242: 2025-01-27 20:44:21.719550422 -0500 EST m=+0.031177142 [debug] CHART PATH: /home/poko/dev/grafana/cloudcost-exporter-test/deploy/helm/cloudcost-exporter

Error: template: cloudcost-exporter/templates/NOTES.txt:2:14: executing "cloudcost-exporter/templates/NOTES.txt" at <.Values.ingress.enabled>: nil pointer evaluating interface {}.enabled
helm.go:86: 2025-01-27 20:44:21.726666326 -0500 EST m=+0.038293046 [debug] template: cloudcost-exporter/templates/NOTES.txt:2:14: executing "cloudcost-exporter/templates/NOTES.txt" at <.Values.ingress.enabled>: nil pointer evaluating interface {}.enabled
```
Adds the `ingress` configuration block to `values.yaml` so that the chart can be compiled.

There was one other complitation issue as well for the deployment that was fixed. The `nindent` needs to match up for similar nested blocks.