### PR TITLE
Define Helm GitHub Actions

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,28 @@
+---
+name: Helm Tests
+on:
+  push:
+    paths:
+      - 'deploy/helm/**'
+  pull_request:
+    paths:
+      - 'deploy/helm/**'
+  # Allows you to run this workflow manually
+  workflow_dispatch:
+jobs:
+  check-for-doc-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - name: Install make
+        run: sudo apt-get update && sudo apt-get install -y make
+        shell: bash
+      - name: Regenerate Helm Docs
+        run: |
+          make helm > /dev/null # we don't actually need to output, just the results
+          if ! git diff --exit-code; then
+            echo "Helm docs are out of date. Please run 'make -C deploy/helm docs' and commit the changes."
+            exit 1
+          fi
+        shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,18 +13,34 @@ jobs:
   build-lint-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - uses: ./.github/actions/setup-goversion
+      - uses: ./.github/actions/setup-goversion
 
-    - name: Build
-      run: go build -v ./...
+      - name: Build
+        run: go build -v ./...
 
-    - name: Lint
-      uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # 6.1.1
-      with:
-        version: v1.56
+      - name: Lint
+        uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # 6.1.1
+        with:
+          version: v1.56
 
-    - name: Test
-      run: go test -v ./...
+      - name: Test
+        run: go test -v ./...
+  check-for-doc-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - name: Install make
+        run: sudo apt-get update && sudo apt-get install -y make
+        shell: bash
+      - name: Regenerate Helm Docs
+        run: |
+          make helm > /dev/null # we don't actually need to output, just the results
+          if ! git diff --exit-code; then
+            echo "Helm docs are out of date. Please run 'make -C deploy/helm docs' and commit the changes."
+            exit 1
+          fi
+        shell: bash
 


### PR DESCRIPTION
This is the first attempt at adding helm github actions. The primary goal is to focus first on tests, then in a later PR we can add releases.

The following tests are run
- checking for doc changes