### PR TITLE
renamed GCP projects in providerFlags

### DIFF
--- a/cmd/exporter/config/config.go
+++ b/cmd/exporter/config/config.go
@@ -16,10 +16,11 @@ type Config struct {
 			RoleARN  string
 		}
 		GCP struct {
-			DefaultGCSDiscount int
-			Projects           StringSliceFlag
-			Region             string
-			Services           StringSliceFlag
+			DefaultGCSDiscount        int
+			Projects                  StringSliceFlag
+			BucketProjectsDeprecated  bool 
+			Region                    string
+			Services                  StringSliceFlag
 		}
 		Azure struct {
 			Services       StringSliceFlag

--- a/cmd/exporter/config/config.go
+++ b/cmd/exporter/config/config.go
@@ -16,11 +16,11 @@ type Config struct {
 			RoleARN  string
 		}
 		GCP struct {
-			DefaultGCSDiscount        int
-			Projects                  StringSliceFlag
-			BucketProjectsDeprecated  bool 
-			Region                    string
-			Services                  StringSliceFlag
+			DefaultGCSDiscount       int
+			Projects                 StringSliceFlag
+			BucketProjectsDeprecated bool
+			Region                   string
+			Services                 StringSliceFlag
 		}
 		Azure struct {
 			Services       StringSliceFlag

--- a/cmd/exporter/config/string_slice_flag.go
+++ b/cmd/exporter/config/string_slice_flag.go
@@ -14,8 +14,8 @@ func (f *StringSliceFlag) Set(value string) error {
 }
 
 type DeprecatedStringSliceFlag struct {
-	values   *StringSliceFlag
-	wasUsed  *bool
+	values  *StringSliceFlag
+	wasUsed *bool
 }
 
 func NewDeprecatedStringSliceFlag(values *StringSliceFlag, wasUsed *bool) *DeprecatedStringSliceFlag {

--- a/cmd/exporter/config/string_slice_flag.go
+++ b/cmd/exporter/config/string_slice_flag.go
@@ -12,3 +12,24 @@ func (f *StringSliceFlag) Set(value string) error {
 	*f = append(*f, value)
 	return nil
 }
+
+type DeprecatedStringSliceFlag struct {
+	values   *StringSliceFlag
+	wasUsed  *bool
+}
+
+func NewDeprecatedStringSliceFlag(values *StringSliceFlag, wasUsed *bool) *DeprecatedStringSliceFlag {
+	return &DeprecatedStringSliceFlag{
+		values:  values,
+		wasUsed: wasUsed,
+	}
+}
+
+func (f *DeprecatedStringSliceFlag) String() string {
+	return f.values.String()
+}
+
+func (f *DeprecatedStringSliceFlag) Set(value string) error {
+	*f.wasUsed = true
+	return f.values.Set(value)
+}

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -67,7 +67,7 @@ func providerFlags(fs *flag.FlagSet, cfg *config.Config) {
 	flag.StringVar(&cfg.Provider, "provider", "aws", "aws, gcp, or azure")
 	fs.StringVar(&cfg.Providers.AWS.Profile, "aws.profile", "", "AWS Profile to authenticate with.")
 	// TODO: RENAME THIS TO JUST PROJECTS
-	fs.Var(&cfg.Providers.GCP.Projects, "gcp.bucket-projects", "GCP project(s).")
+	fs.Var(&cfg.Providers.GCP.Projects, "gcp.projects", "GCP project(s).")
 	fs.Var(&cfg.Providers.AWS.Services, "aws.services", "AWS service(s).")
 	fs.Var(&cfg.Providers.Azure.Services, "azure.services", "Azure service(s).")
 	fs.Var(&cfg.Providers.GCP.Services, "gcp.services", "GCP service(s).")

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -45,6 +45,10 @@ func main() {
 	)
 	cfg.Logger = logs
 
+	if cfg.Providers.GCP.BucketProjectsDeprecated {
+		logs.LogAttrs(ctx, slog.LevelWarn, "'gcp.bucket-projects' is deprecated and will be removed in a future version. Use '--gcp.projects' instead.")
+	}
+
 	csp, err := selectProvider(ctx, &cfg)
 	if err != nil {
 		logs.LogAttrs(ctx, slog.LevelError, "Error selecting provider",
@@ -66,8 +70,8 @@ func main() {
 func providerFlags(fs *flag.FlagSet, cfg *config.Config) {
 	flag.StringVar(&cfg.Provider, "provider", "aws", "aws, gcp, or azure")
 	fs.StringVar(&cfg.Providers.AWS.Profile, "aws.profile", "", "AWS Profile to authenticate with.")
-	// TODO: RENAME THIS TO JUST PROJECTS
 	fs.Var(&cfg.Providers.GCP.Projects, "gcp.projects", "GCP project(s).")
+	fs.Var(config.NewDeprecatedStringSliceFlag(&cfg.Providers.GCP.Projects, &cfg.Providers.GCP.BucketProjectsDeprecated), "gcp.bucket-projects", "GCP project(s). (deprecated: use --gcp.projects instead)")
 	fs.Var(&cfg.Providers.AWS.Services, "aws.services", "AWS service(s).")
 	fs.Var(&cfg.Providers.Azure.Services, "azure.services", "Azure service(s).")
 	fs.Var(&cfg.Providers.GCP.Services, "gcp.services", "GCP service(s).")

--- a/docs/contribute/developer-guide.md
+++ b/docs/contribute/developer-guide.md
@@ -36,7 +36,7 @@ go run cmd/exporter/exporter.go -provider gcp -project-id=$GCP_PROJECT_ID
 
 # GCP - with custom bucket projects
 
-go run cmd/exporter/exporter.go -provider gcp -project-id=$GCP_PROJECT_ID -gcp.bucket-projects=$GPC_PROJECT_ID -gcp.bucket-projects=$GPC_PROJECT_ID
+go run cmd/exporter/exporter.go -provider gcp -project-id=$GCP_PROJECT_ID -gcp.projects=$GPC_PROJECT_ID -gcp.projects=$GPC_PROJECT_ID
 
 # AWS - Prod
 go run cmd/exporter/exporter.go -provider aws -aws.profile $AWS_PROFILE


### PR DESCRIPTION
**Rename gcp.bucket-projects to gcp.projects for clarity**

This merge request improves the user experience when configuring GCP projects by introducing a more intuitive flag name. The existing` gcp.bucket-projects` flag is currently used for all GCP metrics (not just bucket metrics), which is confusing and counterintuitive.


Changes made: 

1. Added a new `gcp.projects` flag in exporter.go that serves the same purpose as the legacy flag
2. Updated the developer guide to reflect the new recommended flag usage
 