### PR TITLE
Use full clone in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # 5.1.0


### PR DESCRIPTION
Using a [shallow clone](https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/#) in the release workflow borks the changelog. I reverted that since we don't need to do a shallow clone to pass the zizmor check (it only required that we set `persist-credentials: false`). Successful zizmor check:
```
zizmor .
 INFO zizmor: skipping forbidden-uses: audit not configured
 INFO audit: zizmor: 🌈 completed ./.github/actions/setup-goversion/action.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/docker.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/release.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/tests.yml
No findings to report. Good job! (3 suppressed)
```