### PR TITLE
Remove unused metrics

### DIFF
--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -117,12 +117,6 @@ func Test_CollectMetrics(t *testing.T) {
 			},
 			expectedMetrics: []*utils.MetricResult{
 				{
-					FqName:     "cloudcost_exporter_collector_success",
-					Labels:     utils.LabelMap{"provider": "aws", "collector": "test2"},
-					Value:      0,
-					MetricType: prometheus.CounterValue,
-				},
-				{
 					FqName:     "cloudcost_exporter_collector_last_scrape_error",
 					Labels:     utils.LabelMap{"provider": "aws", "collector": "test2"},
 					Value:      1,
@@ -147,18 +141,6 @@ func Test_CollectMetrics(t *testing.T) {
 					Value:      0,
 					MetricType: prometheus.CounterValue,
 				},
-				{
-					FqName:     "cloudcost_exporter_collector_success",
-					Labels:     utils.LabelMap{"provider": "aws", "collector": "test3"},
-					Value:      1,
-					MetricType: prometheus.CounterValue,
-				},
-				{
-					FqName:     "cloudcost_exporter_collector_success",
-					Labels:     utils.LabelMap{"provider": "aws", "collector": "test3"},
-					Value:      2,
-					MetricType: prometheus.CounterValue,
-				},
 			},
 		},
 	}
@@ -169,7 +151,6 @@ func Test_CollectMetrics(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			c := mock_provider.NewMockCollector(ctrl)
 			registry := mock_provider.NewMockRegistry(ctrl)
-			registry.EXPECT().MustRegister(gomock.Any()).AnyTimes()
 			if tt.collect != nil {
 				c.EXPECT().Name().Return(tt.collectorName).AnyTimes()
 				c.EXPECT().Collect(ch).DoAndReturn(tt.collect).AnyTimes()

--- a/pkg/azure/azure_test.go
+++ b/pkg/azure/azure_test.go
@@ -93,7 +93,6 @@ func Test_RegisterCollectors(t *testing.T) {
 				azProvider.collectors = append(azProvider.collectors, c)
 			}
 
-			mockRegistry.EXPECT().MustRegister(gomock.Any()).Times(1)
 			err := azProvider.RegisterCollectors(mockRegistry)
 			assert.Equal(t, err, tc.expectedErr)
 		})
@@ -120,12 +119,6 @@ func Test_CollectMetrics(t *testing.T) {
 			},
 			expectedMetrics: []*utils.MetricResult{
 				{
-					FqName:     "cloudcost_exporter_collector_success",
-					Labels:     utils.LabelMap{"provider": "azure", "collector": "test2"},
-					Value:      0,
-					MetricType: prometheus.CounterValue,
-				},
-				{
 					FqName:     "cloudcost_exporter_collector_last_scrape_error",
 					Labels:     utils.LabelMap{"provider": "azure", "collector": "test2"},
 					Value:      1,
@@ -150,18 +143,6 @@ func Test_CollectMetrics(t *testing.T) {
 					Value:      0,
 					MetricType: prometheus.CounterValue,
 				},
-				{
-					FqName:     "cloudcost_exporter_collector_success",
-					Labels:     utils.LabelMap{"provider": "azure", "collector": "test3"},
-					Value:      1,
-					MetricType: prometheus.CounterValue,
-				},
-				{
-					FqName:     "cloudcost_exporter_collector_success",
-					Labels:     utils.LabelMap{"provider": "azure", "collector": "test3"},
-					Value:      2,
-					MetricType: prometheus.CounterValue,
-				},
 			},
 		},
 	}
@@ -178,6 +159,7 @@ func Test_CollectMetrics(t *testing.T) {
 				c.EXPECT().Collect(ch).DoAndReturn(tt.collect).AnyTimes()
 				c.EXPECT().Register(registry).Return(nil).AnyTimes()
 			}
+			registry.EXPECT().MustRegister(gomock.Any()).AnyTimes()
 			azure := &Azure{
 				context:    parentCtx,
 				logger:     testLogger,

--- a/pkg/google/gcp.go
+++ b/pkg/google/gcp.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"math"
 	"strings"
 	"sync"
 	"time"
@@ -13,7 +12,6 @@ import (
 	computeapiv1 "cloud.google.com/go/compute/apiv1"
 	"cloud.google.com/go/storage"
 	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
 	computev1 "google.golang.org/api/compute/v1"
 
 	cloudcost_exporter "github.com/grafana/cloudcost-exporter"
@@ -39,22 +37,9 @@ var (
 		[]string{"provider", "collector"},
 		nil,
 	)
-	collectorScrapesTotalCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: prometheus.BuildFQName(cloudcost_exporter.ExporterName, "collector", "scrapes_total"),
-			Help: "Total number of scrapes for a collector.",
-		},
-		[]string{"provider", "collector"},
-	)
 	collectorLastScrapeTime = prometheus.NewDesc(
 		prometheus.BuildFQName(cloudcost_exporter.ExporterName, "collector", "last_scrape_time"),
 		"Time of the last scrape.W",
-		[]string{"provider", "collector"},
-		nil,
-	)
-	collectorSuccessDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(cloudcost_exporter.ExporterName, "collector", "success"),
-		"Count the number of successful scrapes for a collector.",
 		[]string{"provider", "collector"},
 		nil,
 	)
@@ -151,7 +136,6 @@ func New(config *Config) (*GCP, error) {
 
 // RegisterCollectors will iterate over all the collectors instantiated during New and register their metrics.
 func (g *GCP) RegisterCollectors(registry provider.Registry) error {
-	registry.MustRegister(collectorScrapesTotalCounter)
 	for _, c := range g.collectors {
 		if err := c.Register(registry); err != nil {
 			return err
@@ -165,7 +149,6 @@ func (g *GCP) Describe(ch chan<- *prometheus.Desc) {
 	ch <- collectorLastScrapeErrorDesc
 	ch <- collectorDurationDesc
 	ch <- collectorLastScrapeTime
-	ch <- collectorSuccessDesc
 	for _, c := range g.collectors {
 		if err := c.Describe(ch); err != nil {
 			g.logger.LogAttrs(context.Background(), slog.LevelError, "Error calling describe",
@@ -198,12 +181,6 @@ func (g *GCP) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(collectorLastScrapeErrorDesc, prometheus.CounterValue, collectorErrors, subsystem, c.Name())
 			ch <- prometheus.MustNewConstMetric(collectorDurationDesc, prometheus.GaugeValue, time.Since(now).Seconds(), subsystem, c.Name())
 			ch <- prometheus.MustNewConstMetric(collectorLastScrapeTime, prometheus.GaugeValue, float64(time.Now().Unix()), subsystem, c.Name())
-			collectorScrapesTotalCounter.WithLabelValues(subsystem, c.Name()).Inc()
-
-			counter := collectorScrapesTotalCounter.WithLabelValues(subsystem, c.Name())
-			totalMetricCount := &dto.Metric{}
-			counter.Write(totalMetricCount)
-			ch <- prometheus.MustNewConstMetric(collectorSuccessDesc, prometheus.CounterValue, math.Max(0, totalMetricCount.GetCounter().GetValue()-collectorErrors), subsystem, c.Name())
 		}(c)
 	}
 	wg.Wait()

--- a/pkg/google/gcp_test.go
+++ b/pkg/google/gcp_test.go
@@ -87,12 +87,6 @@ func TestGCP_CollectMetrics(t *testing.T) {
 			},
 			expectedMetrics: []*utils.MetricResult{
 				{
-					FqName:     "cloudcost_exporter_collector_success",
-					Labels:     utils.LabelMap{"provider": "gcp", "collector": "test2"},
-					Value:      0,
-					MetricType: prometheus.CounterValue,
-				},
-				{
 					FqName:     "cloudcost_exporter_collector_last_scrape_error",
 					Labels:     utils.LabelMap{"provider": "gcp", "collector": "test2"},
 					Value:      1,
@@ -115,18 +109,6 @@ func TestGCP_CollectMetrics(t *testing.T) {
 					FqName:     "cloudcost_exporter_collector_last_scrape_error",
 					Labels:     utils.LabelMap{"provider": "gcp", "collector": "test3"},
 					Value:      0,
-					MetricType: prometheus.CounterValue,
-				},
-				{
-					FqName:     "cloudcost_exporter_collector_success",
-					Labels:     utils.LabelMap{"provider": "gcp", "collector": "test3"},
-					Value:      1,
-					MetricType: prometheus.CounterValue,
-				},
-				{
-					FqName:     "cloudcost_exporter_collector_success",
-					Labels:     utils.LabelMap{"provider": "gcp", "collector": "test3"},
-					Value:      2,
 					MetricType: prometheus.CounterValue,
 				},
 			},


### PR DESCRIPTION
After defining SLOs for this application, there is some cleanup we can in regards to metrics, namely, remove `cloudcost_collector_success` and `cloudcost_collector_scrapes_total`

They weren't reliable metrics: total scrapes is discouraged to be collected according to [Prometheus collector best practices](https://prometheus.io/docs/instrumenting/writing_exporters/#metrics-about-the-scrape-itself) and successful scrapes was based on the total scrapes, so there's also no point on leaving this around.

Relates to https://github.com/grafana/deployment_tools/issues/275831