### PR TITLE
Add duration and request errors on the metrics endpoint

### DIFF
--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -139,6 +139,8 @@ func runServer(ctx context.Context, cfg *config.Config, csp provider.Provider, l
 			return fmt.Errorf("error shutting down server: %w", err)
 		}
 	case err := <-errChan:
+		// FIXME: This is not correct, we need to get the status code from the response
+		// and it doesn't fit how histogram works as they expect a value distribution and not a counter.
 		requestErrors.WithLabelValues(cfg.Server.Path, "GET").Observe(1)
 		if !errors.Is(err, http.ErrServerClosed) {
 			return fmt.Errorf("error running server: %w", err)

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -141,10 +141,11 @@ func runServer(ctx context.Context, cfg *config.Config, csp provider.Provider, l
 }
 
 func createPromRegistryHandler(csp provider.Provider) (http.Handler, error) {
+	var subsystem = "metrics_handler"
 	requestDuration := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "cloudcost_exporter_request_duration_seconds",
-			Help:    "Duration of HTTP requests in seconds",
+			Name:    prometheus.BuildFQName(cloudcost_exporter.ExporterName, subsystem, "request_duration_seconds"),
+			Help:    "Duration of HTTP requests in seconds for the metrics endpoint",
 			Buckets: prometheus.DefBuckets,
 		},
 		[]string{"method"},
@@ -152,8 +153,8 @@ func createPromRegistryHandler(csp provider.Provider) (http.Handler, error) {
 
 	requestCounter := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "cloudcost_exporter_requests_total",
-			Help: "Total number of HTTP requests",
+			Name: prometheus.BuildFQName(cloudcost_exporter.ExporterName, subsystem, "requests_total"),
+			Help: "Total number of HTTP requests for the metrics endpoint",
 		},
 		[]string{"code", "method"},
 	)

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -102,14 +102,20 @@ func setupLogger(level string, output string, logtype string) *slog.Logger {
 // runServer is a helper method that is responsible for starting the metrics server and handling shutdown signals.
 func runServer(ctx context.Context, cfg *config.Config, csp provider.Provider, log *slog.Logger) error {
 	mux := http.NewServeMux()
-
+	requestErrors := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cloudcost_exporter_request_errors_total",
+			Help: "Total number of errors in HTTP requests",
+		},
+		[]string{"path", "method"},
+	)
 	mux.HandleFunc("/", web.HomePageHandler(cfg.Server.Path)) // landing page
 
-	registryHandler, err := createPromRegistryHandler(csp) // prom metrics handler
+	registryHandler, err := createPromRegistryHandler(csp, requestErrors) // prom metrics handler
 	if err != nil {
 		return err
 	}
-	mux.Handle(cfg.Server.Path, registryHandler) // prom metrics handler
+	mux.Handle(cfg.Server.Path, registryHandler) // prom metrics handler (/metrics)
 
 	server := &http.Server{Addr: cfg.Server.Address, Handler: mux}
 	errChan := make(chan error)
@@ -132,6 +138,7 @@ func runServer(ctx context.Context, cfg *config.Config, csp provider.Provider, l
 			return fmt.Errorf("error shutting down server: %w", err)
 		}
 	case err := <-errChan:
+		requestErrors.WithLabelValues(cfg.Server.Path, "GET").Inc()
 		if !errors.Is(err, http.ErrServerClosed) {
 			return fmt.Errorf("error running server: %w", err)
 		}
@@ -140,7 +147,15 @@ func runServer(ctx context.Context, cfg *config.Config, csp provider.Provider, l
 	return nil
 }
 
-func createPromRegistryHandler(csp provider.Provider) (http.Handler, error) {
+func createPromRegistryHandler(csp provider.Provider, requestErrors *prometheus.CounterVec) (http.Handler, error) {
+	requestDuration := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "cloudcost_exporter_request_duration_seconds",
+			Help:    "Duration of HTTP requests in seconds",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"path", "method"},
+	)
 	registry := prometheus.NewRegistry()
 	registry.MustRegister(
 		collectors.NewBuildInfoCollector(),
@@ -148,15 +163,29 @@ func createPromRegistryHandler(csp provider.Provider) (http.Handler, error) {
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 		version.NewCollector(cloudcost_exporter.ExporterName),
 		csp,
+		requestDuration,
+		requestErrors,
 	)
 	err := csp.RegisterCollectors(registry)
 	if err != nil {
 		return nil, err
 	}
+
 	// CollectMetrics http server for prometheus
-	return promhttp.HandlerFor(registry, promhttp.HandlerOpts{
-		EnableOpenMetrics: true,
-	}), nil
+	return prometheusMiddleware(
+		promhttp.HandlerFor(registry, promhttp.HandlerOpts{
+			EnableOpenMetrics: true,
+		}),
+		requestDuration,
+	), nil
+}
+
+func prometheusMiddleware(next http.Handler, requestDuration *prometheus.HistogramVec) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		timer := prometheus.NewTimer(requestDuration.With(prometheus.Labels{"path": r.URL.Path, "method": r.Method}))
+		defer timer.ObserveDuration()
+		next.ServeHTTP(w, r)
+	})
 }
 
 func selectProvider(ctx context.Context, cfg *config.Config) (provider.Provider, error) {


### PR DESCRIPTION
Instrument prometheus using InstrumentHandlerDuration and InstrumentHandlerCounter so we get added the following metrics:
- `cloudcost_exporter_request_duration_seconds_bucket`
- `cloudcost_exporter_request_duration_seconds_sum`
- `cloudcost_exporter_request_duration_seconds_count`
- `cloudcost_exporter_requests_total`

<img width="1474" height="465" alt="Screenshot 2025-07-23 at 13 17 32" src="https://github.com/user-attachments/assets/f5ca5bb5-1413-4ca4-b5bd-2fa56b84efa2" />


It will help to define SLOs in https://github.com/grafana/deployment_tools/pull/302655
