### PR TITLE
Enforce linting and fix existing linter issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,9 +24,9 @@ jobs:
       - name: Build
         run: go build -v ./...
       - name: Lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v1.64.6
+          version: v2.1.0
       - name: Test
         run: go test -v ./...
       - name: Install make

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,49 @@
+version: "2"
+
 output:
-  formats: 
-    - format: colored-line-number
+  formats:
+    tab:
+      print-linter-name: true
 
 linters:
-  disable-all: true
+  default: none
   enable:
-    - goimports
-    - gofmt
     - misspell
     - errorlint
     - unused
+    - bodyclose
+    - errcheck
+    - revive
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck
+    - unused
+  settings:
+    revive:
+        confidence: 0.8
+        severity: warning
+        rules:
+            - name: blank-imports
+            - name: context-as-argument
+            - name: context-keys-type
+            - name: error-return
+            - name: error-strings
+            - name: error-naming
+            - name: exported
+            - name: if-return
+            - name: increment-decrement
+            - name: var-naming
+            - name: var-declaration
+            - name: package-comments
+            - name: range
+            - name: receiver-naming
+            - name: time-naming
+            - name: unexported-return
+            - name: indent-error-flow
+            - name: errorf
+
+formatters:
+  enable:
+    - goimports
+    - gofmt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - errorlint
     - unused
     - bodyclose
+    # TODO: Enable revive after fixing all the issues
     # - revive
     - govet
     - ineffassign
@@ -20,26 +21,26 @@ linters:
     - unused
   # settings:
   #   revive:
-        # confidence: 0.8
-        # severity: warning
-        # rules:
-        #     - name: blank-imports
-        #     - name: context-as-argument
-        #     - name: context-keys-type
-        #     - name: error-return
-        #     - name: error-strings
-            # - name: error-naming
-            # - name: exported
-            # - name: if-return
-            # - name: increment-decrement
-            # - name: var-naming
-            # - name: var-declaration
-            # - name: range
-            # - name: receiver-naming
-            # - name: time-naming
-            # - name: unexported-return
-            # - name: indent-error-flow
-            # - name: errorf
+  #       confidence: 0.8
+  #       severity: warning
+  #       rules:
+  #           - name: blank-imports
+  #           - name: context-as-argument
+  #           - name: context-keys-type
+  #           - name: error-return
+  #           - name: error-strings
+  #           - name: error-naming
+  #           - name: exported
+  #           - name: if-return
+  #           - name: increment-decrement
+  #           - name: var-naming
+  #           - name: var-declaration
+  #           - name: range
+  #           - name: receiver-naming
+  #           - name: time-naming
+  #           - name: unexported-return
+  #           - name: indent-error-flow
+  #           - name: errorf
 
 formatters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,36 +12,34 @@ linters:
     - errorlint
     - unused
     - bodyclose
-    - errcheck
-    - revive
+    # - revive
     - govet
     - ineffassign
     - misspell
     - staticcheck
     - unused
-  settings:
-    revive:
-        confidence: 0.8
-        severity: warning
-        rules:
-            - name: blank-imports
-            - name: context-as-argument
-            - name: context-keys-type
-            - name: error-return
-            - name: error-strings
-            - name: error-naming
-            - name: exported
-            - name: if-return
-            - name: increment-decrement
-            - name: var-naming
-            - name: var-declaration
-            - name: package-comments
-            - name: range
-            - name: receiver-naming
-            - name: time-naming
-            - name: unexported-return
-            - name: indent-error-flow
-            - name: errorf
+  # settings:
+  #   revive:
+        # confidence: 0.8
+        # severity: warning
+        # rules:
+        #     - name: blank-imports
+        #     - name: context-as-argument
+        #     - name: context-keys-type
+        #     - name: error-return
+        #     - name: error-strings
+            # - name: error-naming
+            # - name: exported
+            # - name: if-return
+            # - name: increment-decrement
+            # - name: var-naming
+            # - name: var-declaration
+            # - name: range
+            # - name: receiver-naming
+            # - name: time-naming
+            # - name: unexported-return
+            # - name: indent-error-flow
+            # - name: errorf
 
 formatters:
   enable:

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,12 @@ build-image:
 build-binary:
 	CGO_ENABLED=0 go build -v -ldflags "$(GO_LDFLAGS)" -o cloudcost-exporter ./cmd/exporter
 
-build: build-binary build-image
+build: lint build-binary build-image
 
-test: build
+test: lint build
 	go test -v ./...
 
-lint:
+lint: ## Run linter over the codebase
 	golangci-lint run ./...
 
 push-dev: build test

--- a/cloudcost-exporter-dashboards/convertor/convert_dashboard.go
+++ b/cloudcost-exporter-dashboards/convertor/convert_dashboard.go
@@ -1,3 +1,5 @@
+// Command convert_dashboard converts a Grafana dashboard JSON into a Go struct
+// using the grafana-foundation-sdk and prints the converted representation.
 package main
 
 import (

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -68,7 +68,7 @@ const (
 
 func New(ctx context.Context, config *Config) (*AWS, error) {
 	var collectors []provider.Collector
-	logger := config.Logger.With("provider", "aws")
+	logger := config.Logger.With("provider", subsystem)
 	// There are two scenarios:
 	// 1. Running locally, the user must pass in a region and profile to use
 	// 2. Running within an EC2 instance and the region and profile can be derived
@@ -83,9 +83,11 @@ func New(ctx context.Context, config *Config) (*AWS, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	var regions []types.Region
 	for _, service := range config.Services {
 		service = strings.ToUpper(service)
+
 		// region API is shared between EC2 and RDS
 		if service == serviceRDS || service == serviceEC2 {
 			regions, err = awsClient.DescribeRegions(ctx, false)

--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -198,9 +198,6 @@ func Test_CollectMetrics(t *testing.T) {
 				metrics = append(metrics, metric)
 			}
 			assert.ElementsMatch(t, metrics, tt.expectedMetrics)
-			// clean up metrics for next test
-			metrics = []*utils.MetricResult{}
-			aws.collectors = []provider.Collector{}
 		})
 	}
 }

--- a/pkg/aws/client/aws_client.go
+++ b/pkg/aws/client/aws_client.go
@@ -18,28 +18,28 @@ import (
 
 const maxRetryAttempts = 10
 
-type Option func(client []func(options *awsconfig.LoadOptions) error)
+type Option func(client *[]func(options *awsconfig.LoadOptions) error)
 
 func WithRegion(region string) Option {
-	return func(options []func(options *awsconfig.LoadOptions) error) {
-		options = append(options, awsconfig.WithRegion(region))
+	return func(options *[]func(options *awsconfig.LoadOptions) error) {
+		*options = append(*options, awsconfig.WithRegion(region))
 	}
 }
 
 func WithProfile(profile string) Option {
-	return func(options []func(options *awsconfig.LoadOptions) error) {
-		options = append(options, awsconfig.WithSharedConfigProfile(profile))
+	return func(options *[]func(options *awsconfig.LoadOptions) error) {
+		*options = append(*options, awsconfig.WithSharedConfigProfile(profile))
 	}
 }
 
 func WithRoleARN(roleARN string) Option {
-	return func(options []func(options *awsconfig.LoadOptions) error) {
-		option, err := assumeRole(roleARN, options)
+	return func(options *[]func(options *awsconfig.LoadOptions) error) {
+		option, err := assumeRole(roleARN, *options)
 		if err != nil {
 			return
 		}
 
-		options = append(options, option)
+		*options = append(*options, option)
 	}
 }
 
@@ -63,7 +63,7 @@ func NewAWSClient(ctx context.Context, opts ...Option) (*AWSClient, error) {
 	optionsFunc = append(optionsFunc, awsconfig.WithRetryMaxAttempts(maxRetryAttempts))
 
 	for _, opt := range opts {
-		opt(optionsFunc)
+		opt(&optionsFunc)
 	}
 
 	ac, err := awsconfig.LoadDefaultConfig(ctx, optionsFunc...)

--- a/pkg/aws/services.go
+++ b/pkg/aws/services.go
@@ -1,9 +1,0 @@
-package aws
-
-// Service name constants used across the AWS provider.
-const (
-    ServiceS3  = "S3"
-    ServiceEC2 = "EC2"
-    ServiceRDS = "RDS"
-)
-

--- a/pkg/aws/services.go
+++ b/pkg/aws/services.go
@@ -1,0 +1,9 @@
+package aws
+
+// Service name constants used across the AWS provider.
+const (
+    ServiceS3  = "S3"
+    ServiceEC2 = "EC2"
+    ServiceRDS = "RDS"
+)
+

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -23,7 +23,7 @@ const (
 )
 
 var (
-	InvalidSubscriptionId = errors.New("subscription id was invalid")
+	errInvalidSubscriptionID = errors.New("subscription id was invalid")
 )
 
 var (
@@ -73,7 +73,7 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 
 	if config.SubscriptionId == "" {
 		logger.LogAttrs(ctx, slog.LevelError, "subscription id was invalid")
-		return nil, InvalidSubscriptionId
+		return nil, errInvalidSubscriptionID
 	}
 
 	creds, err := azidentity.NewDefaultAzureCredential(nil)

--- a/pkg/azure/azure_test.go
+++ b/pkg/azure/azure_test.go
@@ -202,9 +202,6 @@ func Test_CollectMetrics(t *testing.T) {
 				metrics = append(metrics, metric)
 			}
 			assert.ElementsMatch(t, metrics, tt.expectedMetrics)
-			// clean up metrics for next test
-			metrics = []*utils.MetricResult{}
-			azure.collectors = []provider.Collector{}
 		})
 	}
 }

--- a/pkg/azure/azure_test.go
+++ b/pkg/azure/azure_test.go
@@ -28,7 +28,7 @@ func Test_New(t *testing.T) {
 		subId       string
 	}{
 		"no subscription ID": {
-			expectedErr: InvalidSubscriptionId,
+			expectedErr: errInvalidSubscriptionID,
 			subId:       "",
 		},
 

--- a/pkg/google/client/billing.go
+++ b/pkg/google/client/billing.go
@@ -14,7 +14,7 @@ import (
 )
 
 // ServiceNotFound indicates the requested GCP service was not found in the Cloud Catalog.
-var ServiceNotFound = errors.New("service not found")
+var errServiceNotFound = errors.New("service not found")
 
 var (
 	// errTaggingNotSupported indicates that tagging SKUs are not supported by the exporter.
@@ -54,7 +54,7 @@ func (b *Billing) getServiceName(ctx context.Context, name string) (string, erro
 			return service.Name, nil
 		}
 	}
-	return "", ServiceNotFound
+	return "", errServiceNotFound
 }
 
 func (b *Billing) exportBilling(ctx context.Context, serviceName string, m *metrics.Metrics) float64 {

--- a/pkg/google/client/billing.go
+++ b/pkg/google/client/billing.go
@@ -140,12 +140,13 @@ func parseStorageSku(sku *billingpb.Sku, m *metrics.Metrics) error {
 	priceUnit := priceInfo.PricingExpression.UsageUnitDescription
 
 	// Adjust price to hourly
-	if priceUnit == gibMonthly {
+	switch priceUnit {
+	case gibMonthly:
 		price = price / 31 / 24
-	} else if priceUnit == gibDay {
+	case gibDay:
 		// For Early-Delete in Archive, CloudStorage and Nearline classes
 		price = price / 24
-	} else {
+	default:
 		return fmt.Errorf("%w:%s, %s", errUnknownPricingUnit, sku.Description, priceUnit)
 	}
 

--- a/pkg/google/client/billing_test.go
+++ b/pkg/google/client/billing_test.go
@@ -135,7 +135,7 @@ func Test_parseOpSku(t *testing.T) {
 				},
 				ServiceRegions: []string{"us-east1"},
 			},
-			err: invalidSku,
+			err: errInvalidSKU,
 		},
 		"should fail to parse sku with tagging": {
 			sku: &billingpb.Sku{
@@ -144,7 +144,7 @@ func Test_parseOpSku(t *testing.T) {
 				},
 				Description: "Tagging",
 			},
-			err: taggingError,
+			err: errTaggingNotSupported,
 		},
 		"should parse a sku with pricing and description": {
 			sku: &billingpb.Sku{
@@ -184,7 +184,7 @@ func Test_parseStorageSku(t *testing.T) {
 				},
 				ServiceRegions: []string{"us-east1"},
 			},
-			err: invalidSku,
+			err: errInvalidSKU,
 		},
 		"should fail to parse sku with unknown pricing unit": {
 			sku: &billingpb.Sku{
@@ -203,7 +203,7 @@ func Test_parseStorageSku(t *testing.T) {
 					},
 				},
 			},
-			err: unknownPricingUnit,
+			err: errUnknownPricingUnit,
 		},
 		"should parse a sku with one pricing unit with gibDaily": {
 			sku: &billingpb.Sku{

--- a/pkg/google/client/cache/cache.go
+++ b/pkg/google/client/cache/cache.go
@@ -5,17 +5,11 @@ type Cache[T any] interface {
 	Set(project string, buckets T)
 }
 
-type NoopCache[T any] struct {
-	v T
-}
+type NoopCache[T any] struct{}
 
-func (c NoopCache[T]) Get(_ string) T {
-	return c.v
-}
+func (c NoopCache[T]) Get(_ string) T { var zero T; return zero }
 
-func (c NoopCache[T]) Set(_ string, buckets T) {
-	c.v = buckets
-}
+func (c NoopCache[T]) Set(_ string, _ T) {}
 
 func NewNoopCache[T any]() Cache[T] {
 	return NoopCache[T]{}

--- a/pkg/google/gcp.go
+++ b/pkg/google/gcp.go
@@ -60,7 +60,7 @@ type Config struct {
 // collector specific services further down.
 func New(config *Config) (*GCP, error) {
 	ctx := context.Background()
-	logger := config.Logger.With("provider", "gcp")
+	logger := config.Logger.With("provider", subsystem)
 
 	gcpClient, err := client.NewGCPClient(ctx, client.Config{ProjectId: config.ProjectId, Discount: config.DefaultDiscount})
 	if err != nil {

--- a/pkg/google/gcp_test.go
+++ b/pkg/google/gcp_test.go
@@ -170,9 +170,6 @@ func TestGCP_CollectMetrics(t *testing.T) {
 				metrics = append(metrics, metric)
 			}
 			assert.ElementsMatch(t, metrics, tt.expectedMetrics)
-			// clean up metrics for next test
-			metrics = []*utils.MetricResult{}
-			gcp.collectors = []provider.Collector{}
 		})
 	}
 }

--- a/pkg/google/gke/pricing_map.go
+++ b/pkg/google/gke/pricing_map.go
@@ -385,7 +385,7 @@ func getPricingInfoFromSku(sku *billingpb.Sku) (int32, error) {
 		return 0, fmt.Errorf("no pricing info found for sku %s", sku.Name)
 	}
 	pricingInfo := sku.PricingInfo[0]
-	if pricingInfo.PricingExpression.TieredRates == nil || len(pricingInfo.PricingExpression.TieredRates) < 1 {
+	if len(pricingInfo.PricingExpression.TieredRates) < 1 {
 		return 0, fmt.Errorf("no tiered rates found for sku %s", sku.Name)
 	}
 	// TODO: We need to consider if there are many teired rates here. For instance, Storage will have a standard disk that has two rates. The first one is zero for the first GiB, then $/GiB after.

--- a/pkg/utils/consts.go
+++ b/pkg/utils/consts.go
@@ -1,15 +1,23 @@
+// Package utils contains shared helpers for metric construction and constants.
 package utils
 
 import "github.com/prometheus/client_golang/prometheus"
 
 const (
-	HoursInMonth               = 24.35 * 30 // 24.35 is the average amount of hours in a day over a year
-	InstanceCPUCostSuffix      = "instance_cpu_usd_per_core_hour"
-	InstanceMemoryCostSuffix   = "instance_memory_usd_per_gib_hour"
-	InstanceTotalCostSuffix    = "instance_total_usd_per_hour"
+	// HoursInMonth is an approximate average number of hours in a month.
+	// 24.35 is the average number of hours per day over a year.
+	HoursInMonth = 24.35 * 30
+	// InstanceCPUCostSuffix is the suffix for per-core-hour CPU cost metrics.
+	InstanceCPUCostSuffix = "instance_cpu_usd_per_core_hour"
+	// InstanceMemoryCostSuffix is the suffix for per-GiB-hour memory cost metrics.
+	InstanceMemoryCostSuffix = "instance_memory_usd_per_gib_hour"
+	// InstanceTotalCostSuffix is the suffix for total per-hour instance cost metrics.
+	InstanceTotalCostSuffix = "instance_total_usd_per_hour"
+	// PersistentVolumeCostSuffix is the suffix for per-hour EBS volume cost metrics.
 	PersistentVolumeCostSuffix = "persistent_volume_usd_per_hour"
 )
 
+// GenerateDesc creates a Prometheus metric descriptor with a standardized fqname.
 func GenerateDesc(prefix, subsystem, suffix, description string, labels []string) *prometheus.Desc {
 	return prometheus.NewDesc(
 		prometheus.BuildFQName(prefix, subsystem, suffix),

--- a/scripts/gcp-fetch-skus/gcp-fetch-skus.go
+++ b/scripts/gcp-fetch-skus/gcp-fetch-skus.go
@@ -20,11 +20,11 @@ type Config struct {
 }
 
 func main() {
-	var config *Config
+	var config Config
 	flag.StringVar(&config.Service, "service", "Compute Engine", "The service to fetch skus for")
 	flag.StringVar(&config.OutputFile, "output-file", "skus.csv", "The file to write the skus to")
 	flag.Parse()
-	if err := run(config); err != nil {
+	if err := run(&config); err != nil {
 		log.Printf("error: %v", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Our Go linter was light. This PR refactors cloudcost-exporter to improve the code quality by adding more Go linters.

### Changes

* Improves code quality (no-op)
  * Adds constants for AWS service names
  * Use consts for AWS & GCP provider initialisatin
* Upgrades the golangci-lint configuration file to use `v2`
* Adds new linters to golangci-lint
* Fixes all linter issues from newly introduced linters (mostly no-ops)
  * Omit nil checks where len for nil slice is zero
  * Replace if-else conditionals with a switch
  * Add some Go doc comments to packages and some exporter funcs but not all - the `revive` was complaining about 40+ issues so I commented it out to add that later
  * Fix `ineffassign`s (noop)
  * Change errors to use errFoo convention
  * Change AWS `Option` to accept a pointer to the options slice - the options were not being assigned from the last refactor ⚠️ 
* Upgrades golanci-lint-action to use golangci-lint v2