### PR TITLE
Initialise client mocks

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -67,8 +67,8 @@ const (
 )
 
 func New(ctx context.Context, config *Config) (*AWS, error) {
-	var collectors []provider.Collector
 	logger := config.Logger.With("provider", subsystem)
+
 	// There are two scenarios:
 	// 1. Running locally, the user must pass in a region and profile to use
 	// 2. Running within an EC2 instance and the region and profile can be derived
@@ -78,13 +78,18 @@ func New(ctx context.Context, config *Config) (*AWS, error) {
 	awsClient, err := client.NewAWSClient(ctx,
 		client.WithRegion(config.Region),
 		client.WithProfile(config.Profile),
-		client.WithRoleARN(config.RoleARN))
+		client.WithRoleARN(config.RoleARN),
+	)
 
 	if err != nil {
 		return nil, err
 	}
 
-	var regions []types.Region
+	var (
+		regions    []types.Region
+		collectors []provider.Collector
+	)
+
 	for _, service := range config.Services {
 		service = strings.ToUpper(service)
 

--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -15,8 +15,10 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/grafana/cloudcost-exporter/pkg/provider"
-	mock_provider "github.com/grafana/cloudcost-exporter/pkg/provider/mocks"
 	"github.com/grafana/cloudcost-exporter/pkg/utils"
+
+	mock_client "github.com/grafana/cloudcost-exporter/pkg/aws/client/mocks"
+	mock_provider "github.com/grafana/cloudcost-exporter/pkg/provider/mocks"
 )
 
 var logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
@@ -25,16 +27,21 @@ func Test_New(t *testing.T) {
 	for _, tc := range []struct {
 		name          string
 		expectedError error
+		config        *Config
 	}{
 		{
-			name: "no error",
+			name:          "no error",
+			expectedError: nil,
+			config: &Config{
+				Logger: logger,
+			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			// TODO refactor New()
-			t.SkipNow()
+			ctrl := gomock.NewController(t)
+			r := mock_client.NewMockClient(ctrl)
 
-			a, err := New(context.Background(), &Config{})
+			a, err := New(context.Background(), tc.config)
 			if tc.expectedError != nil {
 				require.EqualError(t, err, tc.expectedError.Error())
 				return


### PR DESCRIPTION
Closes https://github.com/grafana/cloudcost-exporter/issues/559

Add unit tests to cover the AWS provider's `New` func and the AWS clients.