### PR TITLE
Validate that option is not empty string before adding

### DIFF
--- a/pkg/aws/client/aws_client.go
+++ b/pkg/aws/client/aws_client.go
@@ -22,24 +22,30 @@ type Option func(client *[]func(options *awsconfig.LoadOptions) error)
 
 func WithRegion(region string) Option {
 	return func(options *[]func(options *awsconfig.LoadOptions) error) {
-		*options = append(*options, awsconfig.WithRegion(region))
+		if region != "" {
+			*options = append(*options, awsconfig.WithRegion(region))
+		}
 	}
 }
 
 func WithProfile(profile string) Option {
 	return func(options *[]func(options *awsconfig.LoadOptions) error) {
-		*options = append(*options, awsconfig.WithSharedConfigProfile(profile))
+		if profile != "" {
+			*options = append(*options, awsconfig.WithSharedConfigProfile(profile))
+		}
 	}
 }
 
 func WithRoleARN(roleARN string) Option {
 	return func(options *[]func(options *awsconfig.LoadOptions) error) {
-		option, err := assumeRole(roleARN, *options)
-		if err != nil {
-			return
-		}
+		if roleARN != "" {
+			option, err := assumeRole(roleARN, *options)
+			if err != nil {
+				return
+			}
 
-		*options = append(*options, option)
+			*options = append(*options, option)
+		}
 	}
 }
 


### PR DESCRIPTION
This is a bug in the cloudcost-exporter at the moment.
We need to validate that the config fields are not empty before adding them.