### PR TITLE
Get pricelist for AWS RDS

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -93,7 +93,6 @@ func New(ctx context.Context, config *Config) (*AWS, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	awsClient := client.NewAWSClient(client.Config{
 		PricingService: awsPricing.NewFromConfig(ac),
 		EC2Service:     ec2.NewFromConfig(ac),
@@ -233,7 +232,7 @@ func (a *AWS) Collect(ch chan<- prometheus.Metric) {
 	wg.Wait()
 }
 
-func newRegionClientMap(ctx context.Context, cfg aws.Config, regions []types.Region, profile string, roleARN string) (map[string]client.Client, error) {
+func newRegionClientMap(ctx context.Context, globalConfig aws.Config, regions []types.Region, profile string, roleARN string) (map[string]client.Client, error) {
 	awsClientPerRegion := make(map[string]client.Client)
 	for _, region := range regions {
 		ac, err := createAWSConfig(ctx, *region.RegionName, profile, roleARN)
@@ -242,10 +241,10 @@ func newRegionClientMap(ctx context.Context, cfg aws.Config, regions []types.Reg
 		}
 		awsClientPerRegion[*region.RegionName] = client.NewAWSClient(
 			client.Config{
-				PricingService: awsPricing.NewFromConfig(cfg),
+				PricingService: awsPricing.NewFromConfig(globalConfig),
 				EC2Service:     ec2.NewFromConfig(ac),
-				BillingService: costexplorer.NewFromConfig(cfg),
-				RDSService:     rds2.NewFromConfig(cfg),
+				BillingService: costexplorer.NewFromConfig(globalConfig),
+				RDSService:     rds2.NewFromConfig(globalConfig),
 				ELBService:     elbv2.NewFromConfig(ac),
 			})
 	}

--- a/pkg/aws/client/aws_client.go
+++ b/pkg/aws/client/aws_client.go
@@ -87,3 +87,7 @@ func (c *AWSClient) ListELBPrices(ctx context.Context, region string) ([]string,
 func (c *AWSClient) DescribeLoadBalancers(ctx context.Context) ([]elbTypes.LoadBalancer, error) {
 	return c.elbService.describeLoadBalancers(ctx)
 }
+
+func (c *AWSClient) ListRDSPrices(ctx context.Context) ([]string, error) {
+	return c.priceService.listRDSPrices(ctx)
+}

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -23,6 +23,7 @@ type Client interface {
 	ListEC2ServicePrices(ctx context.Context, region string, filters []pricingTypes.Filter) ([]string, error)
 	ListELBPrices(ctx context.Context, region string) ([]string, error)
 	DescribeLoadBalancers(ctx context.Context) ([]elbTypes.LoadBalancer, error)
+	ListRDSPrices(ctx context.Context) ([]string, error)
 
 	// TODO: Break out Metrics into an independent interface
 	Metrics() []prometheus.Collector

--- a/pkg/aws/client/mocks/client.go
+++ b/pkg/aws/client/mocks/client.go
@@ -209,3 +209,12 @@ func (mr *MockClientMockRecorder) Metrics() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Metrics", reflect.TypeOf((*MockClient)(nil).Metrics))
 }
+
+// ListRDSPrices mocks base method.
+func (m *MockClient) ListRDSPrices(ctx context.Context) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRDSPrices", ctx)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}

--- a/pkg/aws/client/pricing.go
+++ b/pkg/aws/client/pricing.go
@@ -203,3 +203,17 @@ func (p *pricing) getPricesFromProductList(ctx context.Context, input *awsPricin
 	}
 	return productOutputs, nil
 }
+
+func (p *pricing) listRDSPrices(ctx context.Context) ([]string, error) {
+	input := &awsPricing.GetProductsInput{
+		ServiceCode: aws.String("AmazonRDS"),
+		Filters: []pricingTypes.Filter{
+			{
+				Field: aws.String("productFamily"),
+				Type:  pricingTypes.FilterTypeTermMatch,
+				Value: aws.String("Database Instance"),
+			},
+		},
+	}
+	return p.getPricesFromProductList(ctx, input)
+}


### PR DESCRIPTION
Get price rates for all AWS RDS instances.

This PR only instantiates the RDS client and fetches the price list. Work for populating this into metrics and exporting them will come in a follow-up PR.

Part of https://github.com/grafana/cloudcost-exporter/issues/575