### PR TITLE
Collect AWS RDS hourly cost metrics

### DIFF
--- a/docs/deploying/aws/permissions-policy.json
+++ b/docs/deploying/aws/permissions-policy.json
@@ -9,7 +9,8 @@
                 "ec2:DescribeInstances",
                 "ec2:DescribeSpotPriceHistory",
                 "ec2:DescribeVolumes",
-                "pricing:GetProducts"
+                "pricing:GetProducts",
+                "rds:DescribeDBInstances"
             ],
             "Resource": "*"
         }

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -134,8 +134,7 @@ func New(ctx context.Context, config *Config) (*AWS, error) {
 			}
 			awsRDSClient := client.NewAWSClient(client.Config{
 				PricingService: awsPricing.NewFromConfig(pricingConfig),
-				// EC2Service:     ec2.NewFromConfig(ac), //we also need to pass in the ec2 client in order to describe regions, as they are shared between RDS and EC2
-				RDSService: rds2.NewFromConfig(ac),
+				RDSService:     rds2.NewFromConfig(ac),
 			})
 			collector := rds.New(ctx, &rds.Config{
 				ScrapeInterval: config.ScrapeInterval,

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -137,10 +137,8 @@ func New(ctx context.Context, config *Config) (*AWS, error) {
 			}
 			awsRDSClient := client.NewAWSClient(client.Config{
 				PricingService: awsPricing.NewFromConfig(pricingConfig),
-				EC2Service:     ec2.NewFromConfig(ac),
-				BillingService: costexplorer.NewFromConfig(ac),
+				EC2Service:     ec2.NewFromConfig(ac), //we also need to pass in the ec2 client in order to describe regions, as they are shared between RDS and EC2
 				RDSService:     rds2.NewFromConfig(ac),
-				ELBService:     elbv2.NewFromConfig(ac),
 			})
 			regions, err = awsRDSClient.DescribeRegions(ctx, false)
 			if err != nil {

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -18,9 +18,9 @@ import (
 	awsPricing "github.com/aws/aws-sdk-go-v2/service/pricing"
 	rds2 "github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
-	"github.com/grafana/cloudcost-exporter/pkg/aws/client"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/grafana/cloudcost-exporter/pkg/aws/client"
 	ec2Collector "github.com/grafana/cloudcost-exporter/pkg/aws/ec2"
 	"github.com/grafana/cloudcost-exporter/pkg/aws/elb"
 	awsgwnat "github.com/grafana/cloudcost-exporter/pkg/aws/natgateway"

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -138,7 +138,6 @@ func New(ctx context.Context, config *Config) (*AWS, error) {
 			})
 			collector := rdsCollector.New(ctx, &rdsCollector.Config{
 				ScrapeInterval: config.ScrapeInterval,
-				Logger:         logger,
 				Regions:        regions,
 				RegionMap:      awsClientPerRegion,
 				Client:         awsRDSClient,

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -103,12 +103,9 @@ func New(ctx context.Context, config *Config) (*AWS, error) {
 	var regions []types.Region
 	for _, service := range config.Services {
 		service = strings.ToUpper(service)
-		// region API is shared between EC2, and NATGW
-		if service == serviceEC2 || service == serviceNATGW || service == serviceELB {
-			regions, err = awsClient.DescribeRegions(ctx, false)
-			if err != nil {
-				return nil, fmt.Errorf("error getting regions: %w", err)
-			}
+		regions, err = awsClient.DescribeRegions(ctx, false)
+		if err != nil {
+			return nil, fmt.Errorf("error getting regions: %w", err)
 		}
 
 		awsClientPerRegion, err := newRegionClientMap(ctx, ac, regions, config.Profile, config.RoleARN)
@@ -137,13 +134,9 @@ func New(ctx context.Context, config *Config) (*AWS, error) {
 			}
 			awsRDSClient := client.NewAWSClient(client.Config{
 				PricingService: awsPricing.NewFromConfig(pricingConfig),
-				EC2Service:     ec2.NewFromConfig(ac), //we also need to pass in the ec2 client in order to describe regions, as they are shared between RDS and EC2
-				RDSService:     rds2.NewFromConfig(ac),
+				// EC2Service:     ec2.NewFromConfig(ac), //we also need to pass in the ec2 client in order to describe regions, as they are shared between RDS and EC2
+				RDSService: rds2.NewFromConfig(ac),
 			})
-			regions, err = awsRDSClient.DescribeRegions(ctx, false)
-			if err != nil {
-				return nil, fmt.Errorf("error getting regions: %w", err)
-			}
 			collector := rds.New(ctx, &rds.Config{
 				ScrapeInterval: config.ScrapeInterval,
 				Logger:         logger,

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -93,7 +93,6 @@ func New(ctx context.Context, config *Config) (*AWS, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	awsClient := client.NewAWSClient(client.Config{
 		PricingService: awsPricing.NewFromConfig(ac),
 		EC2Service:     ec2.NewFromConfig(ac),
@@ -233,7 +232,7 @@ func (a *AWS) Collect(ch chan<- prometheus.Metric) {
 	wg.Wait()
 }
 
-func newRegionClientMap(ctx context.Context, cfg aws.Config, regions []types.Region, profile string, roleARN string) (map[string]client.Client, error) {
+func newRegionClientMap(ctx context.Context, globalConfig aws.Config, regions []types.Region, profile string, roleARN string) (map[string]client.Client, error) {
 	awsClientPerRegion := make(map[string]client.Client)
 	for _, region := range regions {
 		ac, err := createAWSConfig(ctx, *region.RegionName, profile, roleARN)
@@ -242,10 +241,10 @@ func newRegionClientMap(ctx context.Context, cfg aws.Config, regions []types.Reg
 		}
 		awsClientPerRegion[*region.RegionName] = client.NewAWSClient(
 			client.Config{
-				PricingService: awsPricing.NewFromConfig(cfg),
+				PricingService: awsPricing.NewFromConfig(globalConfig),
 				EC2Service:     ec2.NewFromConfig(ac),
-				BillingService: costexplorer.NewFromConfig(cfg),
-				RDSService:     rds2.NewFromConfig(cfg),
+				BillingService: costexplorer.NewFromConfig(globalConfig),
+				RDSService:     rds2.NewFromConfig(globalConfig),
 				ELBService:     elbv2.NewFromConfig(ac),
 			})
 	}

--- a/pkg/aws/client/aws_client.go
+++ b/pkg/aws/client/aws_client.go
@@ -87,3 +87,7 @@ func (c *AWSClient) ListELBPrices(ctx context.Context, region string) ([]string,
 func (c *AWSClient) DescribeLoadBalancers(ctx context.Context) ([]elbTypes.LoadBalancer, error) {
 	return c.elbService.describeLoadBalancers(ctx)
 }
+
+func (c *AWSClient) ListRDSPrices(ctx context.Context) ([]string, error) {
+	return c.priceService.listRDSPrices(ctx)
+}

--- a/pkg/aws/client/aws_client.go
+++ b/pkg/aws/client/aws_client.go
@@ -28,7 +28,7 @@ type AWSClient struct {
 	priceService   *pricing
 	computeService *compute
 	billing        *billing
-	rdsClient      *rdsClient
+	rdsService      *rds
 	elbService     *elb
 	metrics        *Metrics
 }

--- a/pkg/aws/client/aws_client.go
+++ b/pkg/aws/client/aws_client.go
@@ -28,7 +28,7 @@ type AWSClient struct {
 	priceService   *pricing
 	computeService *compute
 	billing        *billing
-	rdsService      *rds
+	rdsService     *rdsService
 	elbService     *elb
 	metrics        *Metrics
 }
@@ -40,7 +40,7 @@ func NewAWSClient(cfg Config) *AWSClient {
 		computeService: newCompute(cfg.EC2Service),
 		billing:        newBilling(cfg.BillingService, m),
 		elbService:     newELB(cfg.ELBService),
-		rdsClient:      newRDS(cfg.RDSService),
+		rdsService:     newRDS(cfg.RDSService),
 		metrics:        m,
 	}
 }
@@ -90,7 +90,7 @@ func (c *AWSClient) DescribeLoadBalancers(ctx context.Context) ([]elbTypes.LoadB
 }
 
 func (c *AWSClient) ListRDSInstances(ctx context.Context) ([]rdsTypes.DBInstance, error) {
-	return c.rdsClient.listRDSInstances(ctx)
+	return c.rdsService.listRDSInstances(ctx)
 }
 
 func (c *AWSClient) GetRDSUnitData(ctx context.Context, instType, region, deploymentOption, databaseEngine, locationType string) (string, error) {

--- a/pkg/aws/client/aws_client.go
+++ b/pkg/aws/client/aws_client.go
@@ -8,6 +8,7 @@ import (
 	elbTypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	pricingTypes "github.com/aws/aws-sdk-go-v2/service/pricing/types"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
+	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	c "github.com/grafana/cloudcost-exporter/pkg/aws/services/costexplorer"
 	e "github.com/grafana/cloudcost-exporter/pkg/aws/services/ec2"
 	elbv2client "github.com/grafana/cloudcost-exporter/pkg/aws/services/elbv2"
@@ -27,7 +28,7 @@ type AWSClient struct {
 	priceService   *pricing
 	computeService *compute
 	billing        *billing
-	rdsClient      *rds.Client
+	rdsClient      *rdsClient
 	elbService     *elb
 	metrics        *Metrics
 }
@@ -39,7 +40,7 @@ func NewAWSClient(cfg Config) *AWSClient {
 		computeService: newCompute(cfg.EC2Service),
 		billing:        newBilling(cfg.BillingService, m),
 		elbService:     newELB(cfg.ELBService),
-		rdsClient:      cfg.RDSService,
+		rdsClient:      newRDS(cfg.RDSService),
 		metrics:        m,
 	}
 }
@@ -86,6 +87,10 @@ func (c *AWSClient) ListELBPrices(ctx context.Context, region string) ([]string,
 
 func (c *AWSClient) DescribeLoadBalancers(ctx context.Context) ([]elbTypes.LoadBalancer, error) {
 	return c.elbService.describeLoadBalancers(ctx)
+}
+
+func (c *AWSClient) ListRDSInstances(ctx context.Context) ([]rdsTypes.DBInstance, error) {
+	return c.rdsClient.listRDSInstances(ctx)
 }
 
 func (c *AWSClient) ListRDSPrices(ctx context.Context) ([]string, error) {

--- a/pkg/aws/client/aws_client.go
+++ b/pkg/aws/client/aws_client.go
@@ -93,6 +93,6 @@ func (c *AWSClient) ListRDSInstances(ctx context.Context) ([]rdsTypes.DBInstance
 	return c.rdsClient.listRDSInstances(ctx)
 }
 
-func (c *AWSClient) ListRDSPrices(ctx context.Context) ([]string, error) {
-	return c.priceService.listRDSPrices(ctx)
+func (c *AWSClient) GetRDSUnitData(ctx context.Context, instType, region, deploymentOption, databaseEngine, locationType string) (string, error) {
+	return c.priceService.getRDSUnitData(ctx, instType, region, deploymentOption, databaseEngine, locationType)
 }

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	elbTypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	pricingTypes "github.com/aws/aws-sdk-go-v2/service/pricing/types"
+	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -23,6 +24,7 @@ type Client interface {
 	ListEC2ServicePrices(ctx context.Context, region string, filters []pricingTypes.Filter) ([]string, error)
 	ListELBPrices(ctx context.Context, region string) ([]string, error)
 	DescribeLoadBalancers(ctx context.Context) ([]elbTypes.LoadBalancer, error)
+	ListRDSInstances(ctx context.Context) ([]rdsTypes.DBInstance, error)
 	ListRDSPrices(ctx context.Context) ([]string, error)
 
 	// TODO: Break out Metrics into an independent interface

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -25,7 +25,7 @@ type Client interface {
 	ListELBPrices(ctx context.Context, region string) ([]string, error)
 	DescribeLoadBalancers(ctx context.Context) ([]elbTypes.LoadBalancer, error)
 	ListRDSInstances(ctx context.Context) ([]rdsTypes.DBInstance, error)
-	ListRDSPrices(ctx context.Context) ([]string, error)
+	GetRDSUnitData(ctx context.Context, instType, region, deploymentOption, engineCode, isOutpost string) (string, error)
 
 	// TODO: Break out Metrics into an independent interface
 	Metrics() []prometheus.Collector

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -23,6 +23,7 @@ type Client interface {
 	ListEC2ServicePrices(ctx context.Context, region string, filters []pricingTypes.Filter) ([]string, error)
 	ListELBPrices(ctx context.Context, region string) ([]string, error)
 	DescribeLoadBalancers(ctx context.Context) ([]elbTypes.LoadBalancer, error)
+	ListRDSPrices(ctx context.Context) ([]string, error)
 
 	// TODO: Break out Metrics into an independent interface
 	Metrics() []prometheus.Collector

--- a/pkg/aws/client/mocks/client.go
+++ b/pkg/aws/client/mocks/client.go
@@ -219,11 +219,11 @@ func (m *MockClient) ListRDSInstances(ctx context.Context) ([]rdsTypes.DBInstanc
 	return ret0, ret1
 }
 
-// ListRDSPrices mocks base method.
-func (m *MockClient) ListRDSPrices(ctx context.Context) ([]string, error) {
+// GetRDSUnitData mocks base method.
+func (m *MockClient) GetRDSUnitData(ctx context.Context, instType, region, deploymentOption, databaseEngine, locationType string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRDSPrices", ctx)
-	ret0, _ := ret[0].([]string)
+	ret := m.ctrl.Call(m, "GetRDSUnitPrice", ctx, instType, region, deploymentOption, databaseEngine, locationType)
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/aws/client/mocks/client.go
+++ b/pkg/aws/client/mocks/client.go
@@ -219,11 +219,20 @@ func (m *MockClient) ListRDSInstances(ctx context.Context) ([]rdsTypes.DBInstanc
 	return ret0, ret1
 }
 
-// GetRDSUnitData mocks base method.
+func (mr *MockClientMockRecorder) ListRDSInstances(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRDSInstances", reflect.TypeOf((*MockClient)(nil).ListRDSInstances), ctx)
+}
+
 func (m *MockClient) GetRDSUnitData(ctx context.Context, instType, region, deploymentOption, databaseEngine, locationType string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRDSUnitPrice", ctx, instType, region, deploymentOption, databaseEngine, locationType)
+	ret := m.ctrl.Call(m, "GetRDSUnitData", ctx, instType, region, deploymentOption, databaseEngine, locationType)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
+}
+
+func (mr *MockClientMockRecorder) GetRDSUnitData(ctx, instType, region, deploymentOption, databaseEngine, locationType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRDSUnitData", reflect.TypeOf((*MockClient)(nil).GetRDSUnitData), ctx, instType, region, deploymentOption, databaseEngine, locationType)
 }

--- a/pkg/aws/client/mocks/client.go
+++ b/pkg/aws/client/mocks/client.go
@@ -209,3 +209,12 @@ func (mr *MockClientMockRecorder) Metrics() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Metrics", reflect.TypeOf((*MockClient)(nil).Metrics))
 }
+
+// ListRDSPrices mocks base method.
+func (m *MockClient) ListRDSPrices(ctx context.Context) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRDSPrices", ctx)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}

--- a/pkg/aws/client/mocks/client.go
+++ b/pkg/aws/client/mocks/client.go
@@ -16,6 +16,7 @@ import (
 
 	types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	types0 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	types1 "github.com/aws/aws-sdk-go-v2/service/pricing/types"
 	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	client "github.com/grafana/cloudcost-exporter/pkg/aws/client"
 	prometheus "github.com/prometheus/client_golang/prometheus"

--- a/pkg/aws/client/mocks/client.go
+++ b/pkg/aws/client/mocks/client.go
@@ -16,7 +16,7 @@ import (
 
 	types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	types0 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
-	types1 "github.com/aws/aws-sdk-go-v2/service/pricing/types"
+	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	client "github.com/grafana/cloudcost-exporter/pkg/aws/client"
 	prometheus "github.com/prometheus/client_golang/prometheus"
 	gomock "go.uber.org/mock/gomock"
@@ -208,6 +208,15 @@ func (m *MockClient) Metrics() []prometheus.Collector {
 func (mr *MockClientMockRecorder) Metrics() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Metrics", reflect.TypeOf((*MockClient)(nil).Metrics))
+}
+
+// ListRDSInstances mocks base method.
+func (m *MockClient) ListRDSInstances(ctx context.Context) ([]rdsTypes.DBInstance, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRDSInstances", ctx)
+	ret0, _ := ret[0].([]rdsTypes.DBInstance)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // ListRDSPrices mocks base method.

--- a/pkg/aws/client/pricing.go
+++ b/pkg/aws/client/pricing.go
@@ -2,7 +2,10 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"time"
+
+	"log/slog"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -204,7 +207,8 @@ func (p *pricing) getPricesFromProductList(ctx context.Context, input *awsPricin
 	return productOutputs, nil
 }
 
-func (p *pricing) listRDSPrices(ctx context.Context) ([]string, error) {
+func (p *pricing) getRDSUnitData(ctx context.Context, instType, region, deploymentOption, databaseEngine, locationType string) (string, error) {
+	fmt.Println("Getting RDS unit price", instType, region, deploymentOption, databaseEngine, locationType)
 	input := &awsPricing.GetProductsInput{
 		ServiceCode: aws.String("AmazonRDS"),
 		Filters: []pricingTypes.Filter{
@@ -213,7 +217,43 @@ func (p *pricing) listRDSPrices(ctx context.Context) ([]string, error) {
 				Type:  pricingTypes.FilterTypeTermMatch,
 				Value: aws.String("Database Instance"),
 			},
+			{
+				Field: aws.String("instanceType"),
+				Type:  pricingTypes.FilterTypeTermMatch,
+				Value: aws.String(instType),
+			},
+			{
+				Field: aws.String("regionCode"),
+				Type:  pricingTypes.FilterTypeTermMatch,
+				Value: aws.String(region),
+			},
+			{
+				Field: aws.String("deploymentOption"),
+				Type:  pricingTypes.FilterTypeTermMatch,
+				Value: aws.String(deploymentOption),
+			},
+			{
+				Field: aws.String("databaseEngine"),
+				Type:  pricingTypes.FilterTypeContains,
+				Value: aws.String(databaseEngine),
+			},
+			{
+				Field: aws.String("locationType"),
+				Type:  pricingTypes.FilterTypeTermMatch,
+				Value: aws.String(locationType),
+			},
 		},
 	}
-	return p.getPricesFromProductList(ctx, input)
+
+	products, err := p.client.GetProducts(ctx, input)
+	if err != nil {
+		slog.ErrorContext(ctx, "error getting rds prices", "error", err)
+		return "", err
+	}
+
+	if len(products.PriceList) != 1 {
+		slog.ErrorContext(ctx, "expected 1 price list, got", "count", len(products.PriceList))
+		return "", fmt.Errorf("expected 1 price list, got %d", len(products.PriceList))
+	}
+	return products.PriceList[0], nil
 }

--- a/pkg/aws/client/pricing.go
+++ b/pkg/aws/client/pricing.go
@@ -208,7 +208,6 @@ func (p *pricing) getPricesFromProductList(ctx context.Context, input *awsPricin
 }
 
 func (p *pricing) getRDSUnitData(ctx context.Context, instType, region, deploymentOption, databaseEngine, locationType string) (string, error) {
-	fmt.Println("Getting RDS unit price", instType, region, deploymentOption, databaseEngine, locationType)
 	input := &awsPricing.GetProductsInput{
 		ServiceCode: aws.String("AmazonRDS"),
 		Filters: []pricingTypes.Filter{

--- a/pkg/aws/client/pricing.go
+++ b/pkg/aws/client/pricing.go
@@ -203,3 +203,17 @@ func (p *pricing) getPricesFromProductList(ctx context.Context, input *awsPricin
 	}
 	return productOutputs, nil
 }
+
+func (p *pricing) listRDSPrices(ctx context.Context) ([]string, error) {
+	input := &awsPricing.GetProductsInput{
+		ServiceCode: aws.String("AmazonRDS"),
+		Filters: []pricingTypes.Filter{
+			{
+				Field: aws.String("productFamily"),
+				Type:  pricingTypes.FilterTypeTermMatch,
+				Value: aws.String("Database Instance"),
+			},
+		},
+	}
+	return p.getPricesFromProductList(ctx, input)
+}

--- a/pkg/aws/client/pricing_test.go
+++ b/pkg/aws/client/pricing_test.go
@@ -306,8 +306,7 @@ func TestListStoragePrices(t *testing.T) {
 
 func Test_GetRDSUnitData(t *testing.T) {
 	tests := []struct {
-		name string
-		// priceList awsPricing.GetProductsOutput
+		name        string
 		GetProducts func(ctx context.Context, input *awsPricing.GetProductsInput, optFns ...func(*awsPricing.Options)) (*awsPricing.GetProductsOutput, error)
 		want        string
 		wantErr     bool

--- a/pkg/aws/client/rds.go
+++ b/pkg/aws/client/rds.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 )
@@ -16,9 +17,18 @@ func newRDS(client *rds.Client) *rdsClient {
 }
 
 func (e *rdsClient) listRDSInstances(ctx context.Context) ([]rdsTypes.DBInstance, error) {
-	o, err := e.client.DescribeDBInstances(ctx, nil)
-	if err != nil {
-		return nil, err
+	var rdsInstances []rdsTypes.DBInstance
+	pager := rds.NewDescribeDBInstancesPaginator(e.client, &rds.DescribeDBInstancesInput{
+		MaxRecords: aws.Int32(100),
+	})
+
+	for pager.HasMorePages() {
+		o, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		rdsInstances = append(rdsInstances, o.DBInstances...)
 	}
-	return o.DBInstances, nil
+
+	return rdsInstances, nil
 }

--- a/pkg/aws/client/rds.go
+++ b/pkg/aws/client/rds.go
@@ -8,15 +8,15 @@ import (
 	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 )
 
-type rdsClient struct {
+type rdsService struct {
 	client *rds.Client
 }
 
-func newRDS(client *rds.Client) *rdsClient {
-	return &rdsClient{client: client}
+func newRDS(client *rds.Client) *rdsService {
+	return &rdsService{client: client}
 }
 
-func (e *rdsClient) listRDSInstances(ctx context.Context) ([]rdsTypes.DBInstance, error) {
+func (e *rdsService) listRDSInstances(ctx context.Context) ([]rdsTypes.DBInstance, error) {
 	var rdsInstances []rdsTypes.DBInstance
 	pager := rds.NewDescribeDBInstancesPaginator(e.client, &rds.DescribeDBInstancesInput{
 		MaxRecords: aws.Int32(100),

--- a/pkg/aws/client/rds.go
+++ b/pkg/aws/client/rds.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+)
+
+type rdsClient struct {
+	client *rds.Client
+}
+
+func newRDS(client *rds.Client) *rdsClient {
+	return &rdsClient{client: client}
+}
+
+func (e *rdsClient) listRDSInstances(ctx context.Context) ([]rdsTypes.DBInstance, error) {
+	o, err := e.client.DescribeDBInstances(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	return o.DBInstances, nil
+}

--- a/pkg/aws/rds/pricing_map.go
+++ b/pkg/aws/rds/pricing_map.go
@@ -1,0 +1,93 @@
+package rds
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strconv"
+)
+
+type AWSPriceData struct {
+	Terms *AWSTerms `json:"terms"`
+}
+
+type AWSTerms struct {
+	OnDemand map[string]*AWSTerm `json:"OnDemand"`
+}
+
+type AWSTerm struct {
+	PriceDimensions map[string]*AWSPriceDimension `json:"priceDimensions"`
+}
+
+type AWSPriceDimension struct {
+	PricePerUnit map[string]string `json:"pricePerUnit"`
+}
+
+func validateRDSPriceData(ctx context.Context, priceList string) (float64, error) {
+	var priceData AWSPriceData
+	if err := json.Unmarshal([]byte(priceList), &priceData); err != nil {
+		slog.ErrorContext(ctx, "error unmarshaling price JSON", "error", err)
+		return 0, err
+	}
+
+	if priceData.Terms == nil {
+		slog.ErrorContext(ctx, "Terms is nil")
+		return 0, fmt.Errorf("terms is nil")
+	}
+	if priceData.Terms.OnDemand == nil {
+		slog.ErrorContext(ctx, "OnDemand is nil")
+		return 0, fmt.Errorf("OnDemand is nil")
+	}
+
+	// example of onDemandPayload
+	// {
+	// 	"terms": {
+	// 	  "OnDemand": {
+	// 		"<termId>": {
+	// 		  "priceDimensions": {
+	// 			"<dimensionId>": {
+	// 			  "pricePerUnit": {"USD": "0.0840000000"}
+	// 			}
+	// 		  }
+	// 		}
+	// 	  }
+	// 	}
+	//   }
+	var term *AWSTerm
+	// we iterate over the onDemand map to get the value
+	// since the key is unknown (AWS id specific)
+	for _, t := range priceData.Terms.OnDemand {
+		if t == nil || t.PriceDimensions == nil {
+			slog.ErrorContext(ctx, "PriceDimensions is nil")
+			return 0, fmt.Errorf("PriceDimensions is nil")
+		}
+		term = t
+		break
+	}
+
+	// same logic for the RDS price
+	var dimension *AWSPriceDimension
+	for _, d := range term.PriceDimensions {
+		if d == nil || d.PricePerUnit == nil {
+			slog.ErrorContext(ctx, "PricePerUnit is nil")
+			return 0, fmt.Errorf("PricePerUnit is nil")
+		}
+		dimension = d
+		break
+	}
+
+	priceStr, ok := dimension.PricePerUnit["USD"]
+	if !ok || priceStr == "" {
+		slog.ErrorContext(ctx, "No USD price found in PricePerUnit")
+		return 0, fmt.Errorf("no USD price found in PricePerUnit")
+	}
+
+	price, err := strconv.ParseFloat(priceStr, 64)
+	if err != nil {
+		slog.ErrorContext(ctx, "error parsing price string to float", "priceStr", priceStr, "error", err)
+		return 0, fmt.Errorf("error parsing price string '%s' to float: %w", priceStr, err)
+	}
+
+	return price, nil
+}

--- a/pkg/aws/rds/pricing_map_test.go
+++ b/pkg/aws/rds/pricing_map_test.go
@@ -1,2 +1,178 @@
 package rds
 
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateRDSPriceData(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		priceList string
+		want      float64
+		wantErr   bool
+	}{
+		{
+			name: "valid price data",
+			priceList: `{
+				"terms": {
+					"OnDemand": {
+						"some-term-id": {
+							"priceDimensions": {
+								"some-dimension-id": {
+									"pricePerUnit": {"USD": "0.0840000000"}
+								}
+							}
+						}
+					}
+				}
+			}`,
+			want:    0.084,
+			wantErr: false,
+		},
+		{
+			name:      "invalid JSON",
+			priceList: `{invalid json}`,
+			want:      0.0,
+			wantErr:   true,
+		},
+		{
+			name:      "missing terms",
+			priceList: `{}`,
+			want:      0.0,
+			wantErr:   true,
+		},
+		{
+			name:      "missing OnDemand",
+			priceList: `{"terms":{}}`,
+			want:      0.0,
+			wantErr:   true,
+		},
+		{
+			name: "missing priceDimensions",
+			priceList: `{
+				"terms": {
+					"OnDemand": {
+						"term1": {}
+					}
+				}
+			}`,
+			want:    0.0,
+			wantErr: true,
+		},
+		{
+			name: "more than one term",
+			priceList: `{
+				"terms": {
+					"OnDemand": {
+						"term1": {},
+						"term2": {}
+					}
+				}
+			}`,
+			want:    0.0,
+			wantErr: true,
+		},
+		{
+			name: "more than one price dimension",
+			priceList: `{
+				"terms": {
+					"OnDemand": {
+						"term1": {
+							"priceDimensions": {
+								"dim1": {},
+								"dim2": {}
+							}
+						}
+					}
+				}
+			}`,
+			want:    0.0,
+			wantErr: true,
+		},
+		{
+			name: "missing pricePerUnit",
+			priceList: `{
+				"terms": {
+					"OnDemand": {
+						"term1": {
+							"priceDimensions": {
+								"dim1": {}
+							}
+						}
+					}
+				}
+			}`,
+			want:    0.0,
+			wantErr: true,
+		},
+		{
+			name: "missing pricePerUnit",
+			priceList: `{
+				"terms": {
+					"OnDemand": {
+						"term1": {
+							"priceDimensions": {
+								"dim1": {}
+							}
+						}
+					}
+				}
+			}`,
+			want:    0.0,
+			wantErr: true,
+		},
+		{
+			name: "missing USD in pricePerUnit",
+			priceList: `{
+				"terms": {
+					"OnDemand": {
+						"term1": {
+							"priceDimensions": {
+								"dim1": {
+									"pricePerUnit": {}
+								}
+							}
+						}
+					}
+				}
+			}`,
+			want:    0.0,
+			wantErr: true,
+		},
+		{
+			name: "invalid price value",
+			priceList: `{
+				"terms": {
+					"OnDemand": {
+						"term1": {
+							"priceDimensions": {
+								"dim1": {
+									"pricePerUnit": {"USD": "not-a-number"}
+								}
+							}
+						}
+					}
+				}
+			}`,
+			want:    0.0,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			price, err := validateRDSPriceData(ctx, tt.priceList)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, price)
+		})
+	}
+}

--- a/pkg/aws/rds/pricing_map_test.go
+++ b/pkg/aws/rds/pricing_map_test.go
@@ -1,0 +1,2 @@
+package rds
+

--- a/pkg/aws/rds/pricing_map_test.go
+++ b/pkg/aws/rds/pricing_map_test.go
@@ -2,6 +2,8 @@ package rds
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -111,22 +113,6 @@ func TestValidateRDSPriceData(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "missing pricePerUnit",
-			priceList: `{
-				"terms": {
-					"OnDemand": {
-						"term1": {
-							"priceDimensions": {
-								"dim1": {}
-							}
-						}
-					}
-				}
-			}`,
-			want:    0.0,
-			wantErr: true,
-		},
-		{
 			name: "missing USD in pricePerUnit",
 			priceList: `{
 				"terms": {
@@ -175,4 +161,85 @@ func TestValidateRDSPriceData(t *testing.T) {
 			assert.Equal(t, tt.want, price)
 		})
 	}
+}
+
+func TestPricingMap_SetAndGet(t *testing.T) {
+	tests := []struct {
+		name       string
+		key        string
+		pricingMap pricingMap
+		wantValue  float64
+		wantOk     bool
+	}{
+		{
+			name:       "set and get existing key",
+			pricingMap: pricingMap{pricingMap: map[string]float64{"test": 1.0}},
+			key:        "test",
+			wantValue:  1.0,
+			wantOk:     true,
+		},
+		{
+			name:       "get non-existing key",
+			pricingMap: pricingMap{pricingMap: map[string]float64{}},
+			key:        "test",
+			wantValue:  0.0,
+			wantOk:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			price, ok := tt.pricingMap.Get(tt.key)
+			assert.Equal(t, tt.wantValue, price)
+			assert.Equal(t, tt.wantOk, ok)
+		})
+	}
+}
+
+func TestPricingMap_Concurrent(t *testing.T) {
+	t.Run("concurrent read/write", func(t *testing.T) {
+		pm := newPricingMap()
+
+		for i := range 100 {
+			key := fmt.Sprintf("key_%d", i)
+			pm.Set(key, float64(i))
+		}
+
+		var wg sync.WaitGroup
+
+		for i := range 50 {
+			wg.Add(1)
+			go func(key int) {
+				defer wg.Done()
+				for j := range 100 {
+					key := fmt.Sprintf("key_%d", j)
+					value, ok := pm.Get(key)
+					if ok {
+						assert.GreaterOrEqual(t, value, 0.0, "Reader %d: Value should be >= 0", key)
+						assert.LessOrEqual(t, value, 100.0, "Reader %d: Value should be <= 100", key)
+					}
+				}
+			}(i)
+		}
+
+		for i := range 50 {
+			wg.Add(1)
+			go func(key int) {
+				defer wg.Done()
+				for k := range 100 {
+					key := fmt.Sprintf("key_%d", key)
+					value := float64(k)
+					pm.Set(key, value)
+				}
+			}(i)
+		}
+
+		wg.Wait()
+
+		for i := range 100 {
+			key := fmt.Sprintf("key_%d", i)
+			_, ok := pm.Get(key)
+			assert.True(t, ok, "Key %s should exist", key)
+		}
+	})
 }

--- a/pkg/aws/rds/pricing_map_test.go
+++ b/pkg/aws/rds/pricing_map_test.go
@@ -167,20 +167,20 @@ func TestPricingMap_SetAndGet(t *testing.T) {
 	tests := []struct {
 		name       string
 		key        string
-		pricingMap pricingMap
+		pricingMap *pricingMap
 		wantValue  float64
 		wantOk     bool
 	}{
 		{
 			name:       "set and get existing key",
-			pricingMap: pricingMap{pricingMap: map[string]float64{"test": 1.0}},
+			pricingMap: &pricingMap{pricingMap: map[string]float64{"test": 1.0}},
 			key:        "test",
 			wantValue:  1.0,
 			wantOk:     true,
 		},
 		{
 			name:       "get non-existing key",
-			pricingMap: pricingMap{pricingMap: map[string]float64{}},
+			pricingMap: &pricingMap{pricingMap: map[string]float64{}},
 			key:        "test",
 			wantValue:  0.0,
 			wantOk:     false,

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -68,12 +68,11 @@ func NewMetrics() Metrics {
 
 // Collector is a prometheus collector that collects metrics from AWS RDS clusters.
 type Collector struct {
-	regions            []types.Region
-	scrapeInterval     time.Duration
-	awsRegionClientMap map[string]client.Client
-	NextComputeScrape  time.Time
-	NextStorageScrape  time.Time
-	logger             *slog.Logger
+	regions           []types.Region
+	scrapeInterval    time.Duration
+	NextComputeScrape time.Time
+	NextStorageScrape time.Time
+	logger            *slog.Logger
 }
 
 type Config struct {

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -31,13 +31,11 @@ var (
 
 // Collector is a prometheus collector that collects metrics from AWS RDS clusters.
 type Collector struct {
-	regions           []types.Region
-	regionMap         map[string]client.Client
-	scrapeInterval    time.Duration
-	NextComputeScrape time.Time
-	NextStorageScrape time.Time
-	Client            client.Client
-	pricingMap        map[string]float64
+	regions        []types.Region
+	regionMap      map[string]client.Client
+	scrapeInterval time.Duration
+	Client         client.Client
+	pricingMap     map[string]float64
 }
 
 type Config struct {

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -19,20 +19,6 @@ const (
 	subsystem = "aws_rds"
 )
 
-// type Metrics struct {
-// 	// HourlyCost measures the hourly cost of RDS databases in $/h, per region and class.
-// 	HourlyCost *prometheus.GaugeVec
-
-// 	// RequestCount is a counter that tracks the number of requests made to the AWS Cost Explorer API
-// 	RequestCount prometheus.Counter
-
-// 	// RequestErrorsCount is a counter that tracks the number of errors when making requests to the AWS Cost Explorer API
-// 	RequestErrorsCount prometheus.Counter
-
-// 	// NextScrapeGauge is a gauge that tracks the next time the exporter will scrape AWS billing data
-// 	NextScrape prometheus.Gauge
-// }
-
 var (
 	HourlyGaugeDesc = utils.GenerateDesc(
 		cloudcost_exporter.MetricPrefix,
@@ -40,27 +26,6 @@ var (
 		"hourly_rate_usd_per_hour",
 		"Hourly cost of NAT Gateway by region. Cost represented in USD/hour",
 		[]string{"region", "tier", "name"},
-	)
-	RequestCountDesc = utils.GenerateDesc(
-		cloudcost_exporter.MetricPrefix,
-		subsystem,
-		"cost_api_requests_total",
-		"Total number of requests made to the AWS Cost Explorer API",
-		[]string{},
-	)
-	RequestErrorsCountDesc = utils.GenerateDesc(
-		cloudcost_exporter.MetricPrefix,
-		subsystem,
-		"cost_api_requests_errors_total",
-		"Total number of errors when making requests to the AWS Cost Explorer API",
-		[]string{},
-	)
-	NextScrapeDesc = utils.GenerateDesc(
-		cloudcost_exporter.MetricPrefix,
-		subsystem,
-		"next_scrape",
-		"The next time the exporter will scrape AWS billing data. Can be used to trigger alerts if now - nextScrape > interval",
-		[]string{},
 	)
 )
 

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -94,7 +94,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 		var region = az[:len(az)-1]
 		depOption := multiOrSingleAZ(*instance.MultiAZ)
 		locationType := isOutpostsInstance(instance) // outposts locations have a different unit price
-		createPricingKey := createPricingKey(az, *instance.DBInstanceClass, *instance.Engine, depOption, locationType)
+		createPricingKey := createPricingKey(region, *instance.DBInstanceClass, *instance.Engine, depOption, locationType)
 		if _, ok := c.pricingMap[createPricingKey]; !ok {
 			v, err := c.Client.GetRDSUnitData(ctx, *instance.DBInstanceClass, region, depOption, *instance.Engine, locationType)
 			if err != nil {
@@ -142,8 +142,8 @@ func isOutpostsInstance(instance rdsTypes.DBInstance) string {
 	return "AWS Region"
 }
 
-func createPricingKey(az, tier, engine, depOption, locationType string) string {
-	return fmt.Sprintf("%s-%s-%s-%s-%s", az, tier, engine, depOption, locationType)
+func createPricingKey(region, tier, engine, depOption, locationType string) string {
+	return fmt.Sprintf("%s-%s-%s-%s-%s", region, tier, engine, depOption, locationType)
 }
 
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -2,10 +2,12 @@ package rds
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	cloudcost_exporter "github.com/grafana/cloudcost-exporter"
 	"github.com/grafana/cloudcost-exporter/pkg/aws/client"
 	"github.com/grafana/cloudcost-exporter/pkg/provider"
@@ -17,11 +19,8 @@ const (
 )
 
 type Metrics struct {
-	// StorageGauge measures the cost of storage in $/GiB, per region and class.
-	DBCost *prometheus.GaugeVec
-
-	// OperationsGauge measures the cost of operations in $/1k requests
-	DBOperationsCost *prometheus.GaugeVec
+	// HourlyCost measures the hourly cost of RDS databases in $/h, per region and class.
+	HourlyCost *prometheus.GaugeVec
 
 	// RequestCount is a counter that tracks the number of requests made to the AWS Cost Explorer API
 	RequestCount prometheus.Counter
@@ -35,18 +34,11 @@ type Metrics struct {
 
 func NewMetrics() Metrics {
 	return Metrics{
-		DBCost: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: prometheus.BuildFQName(cloudcost_exporter.MetricPrefix, subsystem, "storage_by_location_usd_per_gibyte_hour"),
-			Help: "Storage cost of RDS databases by region, class, and tier. Cost represented in USD/(GiB*h)",
+		HourlyCost: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: prometheus.BuildFQName(cloudcost_exporter.MetricPrefix, subsystem, "db_by_location_usd_per_hour"),
+			Help: "Hourly cost of RDS databases by region, class, and tier. Cost represented in USD/(h)",
 		},
-			[]string{"region", "class"},
-		),
-
-		DBOperationsCost: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: prometheus.BuildFQName(cloudcost_exporter.MetricPrefix, subsystem, "operation_by_location_usd_per_krequest"),
-			Help: "Operation cost of DB instances by region, class, and tier. Cost represented in USD/(1k req)",
-		},
-			[]string{"region", "class", "tier"},
+			[]string{"region", "tier", "az", "engine", "location_type"},
 		),
 
 		RequestCount: prometheus.NewCounter(prometheus.CounterOpts{
@@ -69,14 +61,19 @@ func NewMetrics() Metrics {
 // Collector is a prometheus collector that collects metrics from AWS RDS clusters.
 type Collector struct {
 	regions           []types.Region
+	regionMap         map[string]client.Client
 	scrapeInterval    time.Duration
 	NextComputeScrape time.Time
 	NextStorageScrape time.Time
 	logger            *slog.Logger
+	Client            client.Client
+	pricingMap        map[string]float64
+	metrics           Metrics
 }
 
 type Config struct {
 	Regions        []types.Region
+	RegionMap      map[string]client.Client
 	Client         client.Client
 	ScrapeInterval time.Duration
 	Logger         *slog.Logger
@@ -88,28 +85,107 @@ const (
 
 // New creates an rds collector
 func New(ctx context.Context, config *Config) *Collector {
-	logger := config.Logger.With("logger", serviceName)
-
-	_, err := config.Client.ListRDSPrices(ctx)
-	if err != nil {
-		logger.Error("error listing rds prices", "error", err)
-	}
 	return &Collector{
+		pricingMap:     make(map[string]float64),
 		regions:        config.Regions,
+		regionMap:      config.RegionMap,
 		scrapeInterval: config.ScrapeInterval,
 		logger:         config.Logger.With("logger", serviceName),
+		Client:         config.Client,
+		metrics:        NewMetrics(),
 	}
 }
 
 // CollectMetrics is a no-op function that satisfies the provider.Collector interface.
-// Deprecated: CollectMetrics is deprecated and will be removed in a future release.
+// Deprecated: CollectMetrics is deprecated and will be removed in a future release
 func (c *Collector) CollectMetrics(_ chan<- prometheus.Metric) float64 {
 	return 0
 }
 
 // Collect satisfies the provider.Collector interface.
 func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
+	ctx := context.Background()
+	var instances = []rdsTypes.DBInstance{}
+	for _, region := range c.regions {
+		regionName := *region.RegionName
+		regionClient, ok := c.regionMap[regionName]
+		if !ok {
+			c.logger.Warn("no client found for region", "region", regionName)
+			continue
+		}
+
+		is, err := regionClient.ListRDSInstances(ctx)
+		if err != nil {
+			c.logger.Error("error listing RDS instances", "region", regionName, "error", err)
+			continue
+		}
+
+		instances = append(instances, is...)
+	}
+
+	for _, instance := range instances {
+		// we need to get the region from the availability zone as there is no field for region
+		var az = *instance.AvailabilityZone
+		var region = az[:len(az)-1]
+		depOption := multiOrSingleAZ(*instance.MultiAZ)
+		locationType := isOutpostsInstance(instance) // outposts locations have a different unit price
+		createPricingKey := createPricingKey(az, region, depOption, locationType)
+		if _, ok := c.pricingMap[createPricingKey]; !ok {
+			fmt.Println("new key", createPricingKey)
+			v, err := c.Client.GetRDSUnitData(ctx, *instance.DBInstanceClass, region, depOption, *instance.Engine, locationType)
+			if err != nil {
+				c.logger.Error("error listing rds prices", "error", err)
+				return err
+			}
+			hourlyPrice, err := validateRDSPriceData(ctx, v)
+			fmt.Println("hourlyPrice", hourlyPrice)
+			if err != nil {
+				c.logger.Error("error validating RDS price data", "error", err)
+				return err
+			}
+			c.pricingMap[createPricingKey] = hourlyPrice
+			fmt.Println("pricingMap", c.pricingMap)
+		}
+
+		fmt.Printf("instance: %f \n", c.pricingMap[createPricingKey])
+
+		ch <- prometheus.MustNewConstMetric(
+			c.metrics.HourlyCost.WithLabelValues(region, depOption, az, *instance.Engine, locationType).Desc(),
+			prometheus.GaugeValue,
+			c.pricingMap[createPricingKey],
+			region,
+			depOption,
+			az,
+			*instance.Engine,
+			locationType,
+		)
+	}
 	return nil
+}
+
+func multiOrSingleAZ(multiAZ bool) string {
+	// listInstances api returns true if the instance is in a multi-az deployment
+	// but the pricing API expects a string
+	if multiAZ {
+		return "Multi-AZ"
+	}
+	return "Single-AZ"
+}
+
+func isOutpostsInstance(instance rdsTypes.DBInstance) string {
+	if instance.DBSubnetGroup != nil {
+		for _, subnet := range instance.DBSubnetGroup.Subnets {
+			// If SubnetOutpost.Arn is not null, the subnet is on Outposts
+			if subnet.SubnetOutpost != nil && subnet.SubnetOutpost.Arn != nil {
+				return "AWS Outposts"
+			}
+		}
+	}
+	return "AWS Region"
+}
+
+func createPricingKey(az, region, depOption, locationType string) string {
+	return fmt.Sprintf("%s-%s-%s-%s", az, region, depOption, locationType)
 }
 
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
@@ -120,6 +196,10 @@ func (c *Collector) Name() string {
 	return subsystem
 }
 
-func (c *Collector) Register(_ provider.Registry) error {
+func (c *Collector) Register(registry provider.Registry) error {
+	registry.MustRegister(c.metrics.HourlyCost)
+	// registry.MustRegister(c.metrics.RequestCount)
+	// registry.MustRegister(c.metrics.RequestErrorsCount)
+	// registry.MustRegister(c.metrics.NextScrape)
 	return nil
 }

--- a/pkg/aws/rds/rds_test.go
+++ b/pkg/aws/rds/rds_test.go
@@ -106,7 +106,7 @@ func TestMultiOrSingleAZ(t *testing.T) {
 }
 
 func TestCollector_Collect(t *testing.T) {
-	const cacheKey = "us-east-1a-db.t3.medium-mysql-Single-AZ-AWS Outposts"
+	const cacheKey = "us-east-1-db.t3.medium-mysql-Single-AZ-AWS Outposts"
 	tests := []struct {
 		name             string
 		ListRDSInstances []rdsTypes.DBInstance

--- a/pkg/aws/rds/rds_test.go
+++ b/pkg/aws/rds/rds_test.go
@@ -184,7 +184,7 @@ func TestCollector_Collect(t *testing.T) {
 			}
 
 			c := &Collector{
-				pricingMap:     map[string]float64{tt.pricingKey: 0.456, cacheKey: 0.123},
+				pricingMap:     &pricingMap{pricingMap: map[string]float64{tt.pricingKey: 0.456, cacheKey: 0.123}},
 				regions:        []types.Region{{RegionName: aws.String("us-east-1")}},
 				regionMap:      map[string]client.Client{"us-east-1": mockClient},
 				scrapeInterval: time.Minute,
@@ -201,9 +201,10 @@ func TestCollector_Collect(t *testing.T) {
 				close(ch)
 				assert.NoError(t, err)
 				labels := metricResult.Labels
+				hourlyPrice, _ := c.pricingMap.Get(tt.pricingKey)
 				assert.Equal(t, *tt.ListRDSInstances[0].DBInstanceClass, labels["tier"])
 				assert.Equal(t, *tt.ListRDSInstances[0].DBInstanceIdentifier, labels["name"])
-				assert.Equal(t, c.pricingMap[tt.pricingKey], metricResult.Value)
+				assert.Equal(t, hourlyPrice, metricResult.Value)
 			default:
 				t.Fatal("expected a metric to be collected")
 			}

--- a/pkg/aws/rds/rds_test.go
+++ b/pkg/aws/rds/rds_test.go
@@ -1,0 +1,99 @@
+package rds
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsOutpostsInstance(t *testing.T) {
+	tests := []struct {
+		name string
+		inst rdsTypes.DBInstance
+		want string
+	}{
+		{
+			name: "outposts instance type",
+			inst: rdsTypes.DBInstance{
+				DBSubnetGroup: &rdsTypes.DBSubnetGroup{
+					Subnets: []rdsTypes.Subnet{
+						{
+							SubnetOutpost: &rdsTypes.Outpost{
+								Arn: aws.String("some-outpost-arn"),
+							},
+						},
+					},
+				},
+			},
+			want: "AWS Outposts",
+		},
+		{
+			name: "non-outposts instance type",
+			inst: rdsTypes.DBInstance{
+				DBSubnetGroup: &rdsTypes.DBSubnetGroup{
+					Subnets: []rdsTypes.Subnet{
+						{
+							SubnetOutpost: nil,
+						},
+					},
+				},
+			},
+			want: "AWS Region",
+		},
+		{
+			name: "non-outposts instance type: DBSubnetGroup empty",
+			inst: rdsTypes.DBInstance{
+				DBSubnetGroup: &rdsTypes.DBSubnetGroup{},
+			},
+			want: "AWS Region",
+		},
+		{
+			name: "non-outposts instance type: arn empty",
+			inst: rdsTypes.DBInstance{
+				DBSubnetGroup: &rdsTypes.DBSubnetGroup{
+					Subnets: []rdsTypes.Subnet{
+						{
+							SubnetOutpost: &rdsTypes.Outpost{},
+						},
+					},
+				},
+			},
+			want: "AWS Region",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isOutpostsInstance(tt.inst)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMultiOrSingleAZ(t *testing.T) {
+	tests := []struct {
+		name    string
+		multiAZ bool
+		want    string
+	}{
+		{
+			name:    "Multi-AZ",
+			multiAZ: true,
+			want:    "Multi-AZ",
+		},
+		{
+			name:    "Single-AZ",
+			multiAZ: false,
+			want:    "Single-AZ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := multiOrSingleAZ(tt.multiAZ)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/aws/rds/rds_test.go
+++ b/pkg/aws/rds/rds_test.go
@@ -2,10 +2,17 @@ package rds
 
 import (
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	"github.com/grafana/cloudcost-exporter/pkg/aws/client"
+	mock "github.com/grafana/cloudcost-exporter/pkg/aws/client/mocks"
+	"github.com/grafana/cloudcost-exporter/pkg/utils"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 )
 
 func TestIsOutpostsInstance(t *testing.T) {
@@ -94,6 +101,112 @@ func TestMultiOrSingleAZ(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := multiOrSingleAZ(tt.multiAZ)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCollector_Collect(t *testing.T) {
+	const cacheKey = "us-east-1a-db.t3.medium-mysql-Single-AZ-AWS Outposts"
+	tests := []struct {
+		name             string
+		ListRDSInstances []rdsTypes.DBInstance
+		pricingKey       string
+	}{
+		{
+			name: "instance without price in cache",
+			ListRDSInstances: []rdsTypes.DBInstance{rdsTypes.DBInstance{
+				DBSubnetGroup: &rdsTypes.DBSubnetGroup{
+					Subnets: []rdsTypes.Subnet{
+						{
+							SubnetOutpost: &rdsTypes.Outpost{
+								Arn: aws.String("some-outpost-arn"),
+							},
+						},
+					},
+				},
+				AvailabilityZone:     aws.String("us-east-1a"),
+				DBInstanceClass:      aws.String("db.t3.medium"),
+				Engine:               aws.String("postgres"),
+				DBInstanceIdentifier: aws.String("test-db"),
+				MultiAZ:              aws.Bool(false),
+			}},
+			pricingKey: createPricingKey("us-east-1", "db.t3.medium", "postgres", "Single-AZ", "AWS Region"),
+		},
+		{
+			name: "instance with price in cache",
+			ListRDSInstances: []rdsTypes.DBInstance{rdsTypes.DBInstance{
+				DBSubnetGroup: &rdsTypes.DBSubnetGroup{
+					Subnets: []rdsTypes.Subnet{
+						{
+							SubnetOutpost: &rdsTypes.Outpost{
+								Arn: aws.String("some-outpost-arn"),
+							},
+						},
+					},
+				},
+				AvailabilityZone:     aws.String("us-east-1a"),
+				DBInstanceClass:      aws.String("db.t3.medium"),
+				Engine:               aws.String("mysql"),
+				DBInstanceIdentifier: aws.String("test-db-2"),
+				MultiAZ:              aws.Bool(false),
+			}},
+			pricingKey: cacheKey,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			mockClient := mock.NewMockClient(mockCtrl)
+			mockClient.EXPECT().ListRDSInstances(gomock.Any()).
+				Return(tt.ListRDSInstances, nil).
+				Times(1)
+
+			// if the pricing key is not empty, then we expect the GetRDSUnitData method to be called
+			if tt.pricingKey != "cache-key" {
+				mockClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(`{
+            "terms": {
+                "OnDemand": {
+                    "term1": {
+                        "priceDimensions": {
+                            "dim1": {
+                                "pricePerUnit": {"USD": "0.456"}
+                            }
+                        }
+                    }
+                }
+            }
+        }`, nil).
+					AnyTimes()
+			}
+
+			c := &Collector{
+				pricingMap:     map[string]float64{tt.pricingKey: 0.456, cacheKey: 0.123},
+				regions:        []types.Region{{RegionName: aws.String("us-east-1")}},
+				regionMap:      map[string]client.Client{"us-east-1": mockClient},
+				scrapeInterval: time.Minute,
+				Client:         mockClient,
+			}
+
+			ch := make(chan prometheus.Metric, 1)
+			err := c.Collect(ch)
+			assert.NoError(t, err)
+
+			select {
+			case metric := <-ch:
+				metricResult := utils.ReadMetrics(metric)
+				close(ch)
+				assert.NoError(t, err)
+				labels := metricResult.Labels
+				assert.Equal(t, *tt.ListRDSInstances[0].DBInstanceClass, labels["tier"])
+				assert.Equal(t, *tt.ListRDSInstances[0].DBInstanceIdentifier, labels["name"])
+				assert.Equal(t, c.pricingMap[tt.pricingKey], metricResult.Value)
+			default:
+				t.Fatal("expected a metric to be collected")
+			}
 		})
 	}
 }

--- a/pkg/aws/rds/rds_test.go
+++ b/pkg/aws/rds/rds_test.go
@@ -114,7 +114,7 @@ func TestCollector_Collect(t *testing.T) {
 	}{
 		{
 			name: "instance without price in cache",
-			ListRDSInstances: []rdsTypes.DBInstance{rdsTypes.DBInstance{
+			ListRDSInstances: []rdsTypes.DBInstance{{
 				DBSubnetGroup: &rdsTypes.DBSubnetGroup{
 					Subnets: []rdsTypes.Subnet{
 						{
@@ -134,7 +134,7 @@ func TestCollector_Collect(t *testing.T) {
 		},
 		{
 			name: "instance with price in cache",
-			ListRDSInstances: []rdsTypes.DBInstance{rdsTypes.DBInstance{
+			ListRDSInstances: []rdsTypes.DBInstance{{
 				DBSubnetGroup: &rdsTypes.DBSubnetGroup{
 					Subnets: []rdsTypes.Subnet{
 						{

--- a/pkg/aws/services/rds.go
+++ b/pkg/aws/services/rds.go
@@ -1,0 +1,11 @@
+package rds
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+)
+
+type RDS interface {
+	DescribeDBInstances(ctx context.Context, e *rds.DescribeDBInstancesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error)
+}


### PR DESCRIPTION
Process to collect RDS hourly cost metrics:
- fetch all existing RDS instances
- identify the 5 dimensions needed to uniquely get an hourly rate for running a certain instance: `tier`, `region`, `engine`,  `single or multi availability` and `location type`.
- if there is already an hourly price for a certain DB instance in memory, use that one
- otherwise, use the pricing API to fetch the hourly price.

Chosen metric labels are db `name`, `tier` and `region`. We can later join that with `aws_rds_info{}` on db `name` to get the DB's namespace.

NOTE:
Refreshing metrics takes ~1m and I'll work on parallelising this process next. However, considering that the scraping interval happens every 60m, I don't think it's a blocker to get this merged. 


Example of exported metrics:
```
# TYPE cloudcost_aws_rds_hourly_rate_usd_per_hour gauge
cloudcost_aws_rds_hourly_rate_usd_per_hour{name="asserts-prod-ap-northeast-0",region="ap-northeast-1",tier="db.t4g.small"} 0.101
cloudcost_aws_rds_hourly_rate_usd_per_hour{name="asserts-prod-ap-south-1",region="ap-south-1",tier="db.t4g.small"} 0.084
cloudcost_aws_rds_hourly_rate_usd_per_hour{name="asserts-prod-ap-southeast-1",region="ap-southeast-1",tier="db.t4g.small"} 0.102
cloudcost_aws_rds_hourly_rate_usd_per_hour{name="asserts-prod-ap-southeast-2",region="ap-southeast-3",tier="db.t4g.small"} 0.102
cloudcost_aws_rds_hourly_rate_usd_per_hour{name="asserts-prod-au-southeast-1",region="ap-southeast-2",tier="db.t4g.small"} 0.102
cloudcost_aws_rds_hourly_rate_usd_per_hour{name="asserts-prod-ca-east-0",region="ca-central-1",tier="db.t4g.small"} 0.07
cloudcost_aws_rds_hourly_rate_usd_per_hour{name="asserts-prod-eu-central-0",region="eu-central-2",tier="db.t4g.small"} 0.082
cloudcost_aws_rds_hourly_rate_usd_per_hour{name="asserts-prod-eu-north-0",region="eu-north-1",tier="db.t4g.small"} 0.065
```