### PR TITLE
Match release and image tag values

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,4 +35,4 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ env.TAGS_CONFIG }}
+          tags: v${{ env.TAGS_CONFIG }}


### PR DESCRIPTION
After https://github.com/grafana/deployment_tools/pull/354348 got merged, there were some changes on the argo generate function which replaced our wait for deployment rules. This new metric expects something with a v , whereas the old one didn't. We think it gets this value from the docker tag (which doesn't have a v), so I'm going to change the tag to add this v . This way we also make it consistent between releases (it already has a v) and tags.