### PR TITLE
[CI/CD] Fix build job permissions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -23,6 +23,9 @@ jobs:
   build:
     name: Build and Push Image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
**Changes in this PR**
- Follow-up to https://github.com/grafana/cloudcost-exporter/pull/652 to add the proper permissions to the `build` job which is now failing