### PR TITLE
[maint] Add leading space to fix PR comment link

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -69,5 +69,5 @@ jobs:
           parameters: |
             imageName=grafana/cloudcost-exporter
             dockertag=${{ steps.version.outputs.version }}
-            prCommentContext=Triggered by release ${{ steps.version.outputs.version }} in grafana/cloudcost-exporter
+            prCommentContext= Triggered by release ${{ steps.version.outputs.version }} in grafana/cloudcost-exporter
             commit_author=grafana-delivery-bot


### PR DESCRIPTION
**Changes in this PR**
- Fixes the PR comment link that appends the release info by adding a leading space
- Follow-up to https://github.com/grafana/cloudcost-exporter/pull/653

<img width="997" height="502" alt="Screenshot 2025-10-16 at 6 06 44 PM" src="https://github.com/user-attachments/assets/27ee4ce2-f63c-4e76-a9d4-1e60b95a05bb" />
