### PR TITLE
Remove Prometheus collector duration log

### DIFF
--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -103,7 +103,6 @@ func (c *Collector) CollectMetrics(_ chan<- prometheus.Metric) float64 {
 
 // Collect satisfies the provider.Collector interface.
 func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
-	start := time.Now()
 	ctx := context.Background()
 	c.logger.LogAttrs(ctx, slog.LevelInfo, "calling collect")
 
@@ -161,7 +160,6 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 	}()
 	c.emitMetricsFromReservationsChannel(instanceCh, ch)
 	c.emitMetricsFromVolumesChannel(volumeCh, ch)
-	c.logger.LogAttrs(ctx, slog.LevelInfo, "Finished collect", slog.Duration("duration", time.Since(start)))
 	return nil
 }
 

--- a/pkg/aws/natgateway/natgateway.go
+++ b/pkg/aws/natgateway/natgateway.go
@@ -92,7 +92,6 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
 // Collect satisfies the provider.Collector interface.
 func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 	c.logger.LogAttrs(context.Background(), slog.LevelInfo, "calling collect")
-	start := time.Now()
 
 	for region, pricePerUnit := range c.PricingStore.GetPricePerUnitPerRegion() {
 		for usageType, price := range *pricePerUnit {
@@ -105,7 +104,6 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 		}
 	}
 
-	c.logger.Info("Finished collect", "subsystem", subsystem, "duration", time.Since(start))
 	return nil
 }
 

--- a/pkg/aws/vpc/vpc.go
+++ b/pkg/aws/vpc/vpc.go
@@ -128,7 +128,6 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
 // Collect satisfies the provider.Collector interface.
 func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 	c.logger.LogAttrs(c.ctx, slog.LevelInfo, "calling collect")
-	start := time.Now()
 
 	// Collect VPC Endpoint pricing for all regions
 	for _, region := range c.regions {
@@ -210,7 +209,6 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) error {
 		}
 	}
 
-	c.logger.Info("Finished collect", "subsystem", subsystem, "duration", time.Since(start))
 	return nil
 }
 

--- a/pkg/azure/aks/machine_store.go
+++ b/pkg/azure/aks/machine_store.go
@@ -273,8 +273,6 @@ func (m *MachineStore) GetListOfVmsForSubscription() []*VirtualMachineInfo {
 }
 
 func (m *MachineStore) PopulateMachineStore(ctx context.Context) {
-	startTime := time.Now()
-
 	m.logger.Info("populating machine store")
 
 	clusterList, err := m.getClustersInSubscription(ctx)
@@ -373,7 +371,6 @@ func (m *MachineStore) PopulateMachineStore(ctx context.Context) {
 
 	m.MachineMap = vmInfoMap
 	m.logger.LogAttrs(m.context, slog.LevelInfo, "machine store populated",
-		slog.Duration("duration", time.Since(startTime)),
 		slog.Int("numOfMachines", len(m.MachineMap)),
 		slog.Int("numOfClusters", len(clusterList)),
 	)


### PR DESCRIPTION
We are logging the duration that it takes for some Prometheus collectors to complete. This is a duplicate of `scrape_duration_seconds`, a default Prometheus metrics that we already have. 

See Prometheus custom exporter docs about this here: https://prometheus.io/docs/instrumenting/writing_exporters/#metrics-about-the-scrape-itself

> Other scrape "meta" metrics should be avoided. For example, a counter for the number of scrapes, or a histogram of the scrape duration. Having the exporter track these metrics duplicate the [automatically generated metrics](https://prometheus.io/docs/concepts/jobs_instances/#automatically-generated-labels-and-time-series) of Prometheus itself. This adds to the storage cost of every exporter instance.