### PR TITLE
Only log that instance type is in pricing map in debug mode

### DIFF
--- a/pkg/aws/ec2/pricing_map.go
+++ b/pkg/aws/ec2/pricing_map.go
@@ -115,8 +115,15 @@ func (cpm *ComputePricingMap) GenerateComputePricingMap(ondemandPrices []string,
 				}
 				err = cpm.AddToComputePricingMap(price, productInfo.Product.Attributes)
 				if err != nil {
-					cpm.logger.Error(fmt.Sprintf("error adding to pricing map: %s", err))
-					continue
+					switch {
+					case errors.Is(err, ErrInstanceTypeAlreadyExists):
+						// Only warn in debug mode about this error, since we only want one price per instance type
+						cpm.logger.Debug(fmt.Sprintf("skipping addition to pricing map: %s", err))
+						continue
+					default:
+						cpm.logger.Error(fmt.Sprintf("error adding to pricing map: %s", err))
+						continue
+					}
 				}
 				cpm.AddInstanceDetails(productInfo.Product.Attributes)
 			}


### PR DESCRIPTION
This is a very frequent log that might hide other, actually important error messages.

At scale, this log level can reach large log volumes, which adds unnecessary storage costs for logs.