### PR TITLE
Bootstrap local renovate config file

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>grafana/grafana-renovate-config//presets/base"]
+  "extends": ["github>grafana/grafana-renovate-config//presets/base"],
+  "ignoreUnstable": true
 }


### PR DESCRIPTION
Renovate manages the project's dependencies. There is a global configuration, and this PR adds a local configuration file to override or extend this configuration. 

### Ignore unstable (non-semver) versions
For example, Renovate didn’t handle the [github.com/grafana/grafana-foundation-sdk/go](http://github.com/grafana/grafana-foundation-sdk/go) upgrade too well here: https://github.com/grafana/cloudcost-exporter/pull/529/files

This is because the Grafana Foundation SDK doesn't have semver versioning (yet). We can handle upgrading it a different way for now: https://github.com/grafana/cloudcost-exporter/pull/677

In the meantime, let's tell Renovate to not create more PRs that try (and fail) to upgrade it. 