### PR TITLE
Upgrade Grafana Foundation SDK via build process

### DIFF
--- a/cloudcost-exporter-dashboards/grafana/cloudcost-exporter-operations-dashboard.json
+++ b/cloudcost-exporter-dashboards/grafana/cloudcost-exporter-operations-dashboard.json
@@ -6,7 +6,7 @@
   "graphTooltip": 1,
   "fiscalYearStartMonth": 0,
   "refresh": "30s",
-  "schemaVersion": 39,
+  "schemaVersion": 41,
   "panels": [
     {
       "type": "row",
@@ -19,7 +19,7 @@
         "y": 0
       },
       "id": 0,
-      "panels": null
+      "panels": []
     },
     {
       "type": "stat",
@@ -87,7 +87,7 @@
             }
           ]
         },
-        "overrides": null
+        "overrides": []
       }
     },
     {
@@ -157,7 +157,7 @@
             }
           }
         },
-        "overrides": null
+        "overrides": []
       }
     },
     {
@@ -171,7 +171,7 @@
         "y": 9
       },
       "id": 0,
-      "panels": null
+      "panels": []
     },
     {
       "type": "timeseries",
@@ -200,7 +200,7 @@
         "defaults": {
           "unit": "reqps"
         },
-        "overrides": null
+        "overrides": []
       }
     },
     {
@@ -231,7 +231,7 @@
         "defaults": {
           "unit": "s"
         },
-        "overrides": null
+        "overrides": []
       }
     },
     {
@@ -245,7 +245,7 @@
         "y": 16
       },
       "id": 0,
-      "panels": null
+      "panels": []
     },
     {
       "type": "timeseries",
@@ -275,7 +275,7 @@
         "defaults": {
           "unit": "reqps"
         },
-        "overrides": null
+        "overrides": []
       }
     },
     {
@@ -306,7 +306,7 @@
         "defaults": {
           "unit": "s"
         },
-        "overrides": null
+        "overrides": []
       }
     }
   ],

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.38.6
 	github.com/google/go-cmp v0.7.0
 	github.com/googleapis/gax-go/v2 v2.15.0
-	github.com/grafana/grafana-foundation-sdk/go v0.0.0-20241213004919-4516aa9d3732
+	github.com/grafana/grafana-foundation-sdk/go v0.0.0-20251008104447-4b342c01ab41
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.1

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.6 h1:GW/XbdyBFQ8Qe+YAmFU
 github.com/googleapis/enterprise-certificate-proxy v0.3.6/go.mod h1:MkHOF77EYAE7qfSuSS9PU6g4Nt4e11cnsDUowfwewLA=
 github.com/googleapis/gax-go/v2 v2.15.0 h1:SyjDc1mGgZU5LncH8gimWo9lW1DtIfPibOG81vgd/bo=
 github.com/googleapis/gax-go/v2 v2.15.0/go.mod h1:zVVkkxAQHa1RQpg9z2AUCMnKhi0Qld9rcmyfL1OZhoc=
-github.com/grafana/grafana-foundation-sdk/go v0.0.0-20241213004919-4516aa9d3732 h1:56xP7BiNykV3Zo1acyWZj+GTndkXFKTJVkbntoVZ3+M=
-github.com/grafana/grafana-foundation-sdk/go v0.0.0-20241213004919-4516aa9d3732/go.mod h1:48EA8jF85SrReYflLa39Sk34b6NpxwJPBwjF3TJgRpE=
+github.com/grafana/grafana-foundation-sdk/go v0.0.0-20251008104447-4b342c01ab41 h1:E6rjkhLvfCXXpP/seDA9fFzNWpV8JbbZ8UCE+mdDIqU=
+github.com/grafana/grafana-foundation-sdk/go v0.0.0-20251008104447-4b342c01ab41/go.mod h1:48EA8jF85SrReYflLa39Sk34b6NpxwJPBwjF3TJgRpE=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=


### PR DESCRIPTION
Closes #529 
Related to https://github.com/grafana/cloudcost-exporter/pull/676

This PR: 
* Embeds a Grafana Foundation SDK upgrade process
* Upgrades the Grafana Foundation SDK to v11.6.x