### PR TITLE
ci: multi-arch docker builds

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -30,6 +30,11 @@ jobs:
 
     runs-on: ${{ matrix.runnerType }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
       - name: Should we push?
         id: setup
         run: |
@@ -38,10 +43,6 @@ jobs:
           else
             echo "should-push=false" | tee -a "$GITHUB_OUTPUT"
           fi
-
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          persist-credentials: false
 
       - name: Build and Push Image
         id: build


### PR DESCRIPTION
This pull request significantly refactors `.github/workflows/build-and-deploy.yml` to introduce multi-arch docker builds, as well as a few other changes. 

The changes include:
- the adoption of a multi-architecture build matrix to build `arm` and `amd` images on the GitHub hosted `ubuntu-24.04` and `ubuntu-24.04-arm` runners
- a switch from `build-push-to-dockerhub` to `docker-build-push-image` (a requirement for multi-arch builds)
- an updated trigger so the workflow runs for all push events, but only pushes Docker images on `main` and for new versions. This helps to more quickly identify breaking changes to the build process.
- switched from `ubuntu-latest` to `ubuntu-24.04` runners to match the arm runners (`ubuntu-latest-arm` isn't a thing unfortunately).


Here is an [example of the new workflow.](https://github.com/grafana/cloudcost-exporter/actions/runs/19184386450)

To verify full functionality I setup a [test pipeline](https://github.com/grafana/cloudcost-exporter/actions/runs/19182656686) that also [pushed an image to DockerHub](https://hub.docker.com/repository/docker/grafana/cloudcost-exporter/tags/multi-arch-test/sha256:ebd799fc0fd529334496bcf02e319db1e510d19d949d631e09de787291b829fe). I verified that that image could be pulled and that its labels matched `grafana/cloudcost-exporter:latest`.

Related to https://github.com/grafana/shared-workflows/issues/45