### PR TITLE
Convert error-level log to warning-level log to reduce log volume

### DIFF
--- a/pkg/aws/ec2/pricing_map.go
+++ b/pkg/aws/ec2/pricing_map.go
@@ -146,8 +146,15 @@ func (cpm *ComputePricingMap) GenerateComputePricingMap(ondemandPrices []string,
 		}
 		err = cpm.AddToComputePricingMap(price, spotProductTerm)
 		if err != nil {
-			cpm.logger.Error(fmt.Sprintf("error adding to pricing map: %s", err))
-			continue
+			switch {
+			case errors.Is(err, ErrInstanceTypeAlreadyExists):
+				// Only warn in debug mode about this error, since we only want one price per instance type
+				cpm.logger.Debug(fmt.Sprintf("skipping addition to pricing map: %s", err))
+				continue
+			default:
+				cpm.logger.Error(fmt.Sprintf("error adding to pricing map: %s", err))
+				continue
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
There is an unnecessary log volume being created by this err-level log that should be a warning. We converted it to a warning for other EC2 instances, let's do the same for spots. Benefits include saving on storage cost & reducing log noise. :)