### PR TITLE
fix(rds): skip instance if availability zone not set

### DIFF
--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -110,6 +110,11 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 
 	for _, instance := range instances {
 		// we need to get the region from the availability zone as there is no field for region
+		if instance.AvailabilityZone == nil {
+			// sometimes the availability zone is empty, possibly when an RDS instance is introduced or being removed, skipping them for the time being
+			logger.Warn("no availability zone found for RDS instance")
+			continue
+		}
 		var az = *instance.AvailabilityZone
 		var region = az[:len(az)-1]
 		depOption := multiOrSingleAZ(*instance.MultiAZ)


### PR DESCRIPTION
We're seeing:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x2849525]

goroutine 2119 [running]:
github.com/grafana/cloudcost-exporter/pkg/aws/rds.(*Collector).Collect(0xc003209d40, {0x4b8e708, 0xc00030a5b0}, 0xc0004ccaf0)
    /app/pkg/aws/rds/rds.go:113 +0x5c5
github.com/grafana/cloudcost-exporter/pkg/aws.(*AWS).Collect.func1({0x4b98700, 0xc003209d40})
    /app/pkg/aws/aws.go:253 +0xf1
created by github.com/grafana/cloudcost-exporter/pkg/aws.(*AWS).Collect in goroutine 2131
    /app/pkg/aws/aws.go:249 +0x98
```

Current hypothesis is that these instances are being created or deleted when we try to scrape that info. More fields might show this panic but we can't know for sure in what state an RDS instance is right now.
