### PR TITLE
Remove sku label for cloudsql metric

### DIFF
--- a/pkg/google/cloudsql/cloudsql.go
+++ b/pkg/google/cloudsql/cloudsql.go
@@ -39,8 +39,8 @@ var (
 		cloudcost_exporter.MetricPrefix,
 		subsystem,
 		"cost_usd_per_hour",
-		"Hourly cost of GCP cloudsql instances by instance name, region and sku. Cost represented in USD/hour",
-		[]string{"instance", "region", "sku"},
+		"Hourly cost of GCP cloudsql instances by instance name and region. Cost represented in USD/hour",
+		[]string{"instance", "region"},
 	)
 )
 
@@ -83,18 +83,12 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 			continue
 		}
 
-		skuLabel := price.skuID
-		if price.isCustom {
-			skuLabel = "custom"
-		}
-
 		metric := prometheus.MustNewConstMetric(
 			HourlyGaugeDesc,
 			prometheus.GaugeValue,
 			price.pricePerHour,
 			instance.ConnectionName,
 			instance.Region,
-			skuLabel,
 		)
 		ch <- metric
 	}


### PR DESCRIPTION
Removing the sku label so it doesn't clash with the sku label from the work being done [for Unit Cost Rules](https://docs.google.com/document/d/1V_tbqra7Wrqi-K_oeUG4KrSsT_OhagVz5wdaiDdXZlY/edit?tab=t.0).

Besides, it helps to decrease the cardinality.