### PR TITLE
[cloudcost-exporter] Update dashboard with make build-dashboards

### DIFF
--- a/cloudcost-exporter-dashboards/grafana/cloudcost-exporter-operations-dashboard.json
+++ b/cloudcost-exporter-dashboards/grafana/cloudcost-exporter-operations-dashboard.json
@@ -45,6 +45,7 @@
         "x": 0,
         "y": 1
       },
+      "repeatDirection": "h",
       "options": {
         "graphMode": "area",
         "colorMode": "value",
@@ -114,6 +115,7 @@
         "x": 12,
         "y": 1
       },
+      "repeatDirection": "h",
       "options": {
         "legend": {
           "displayMode": "table",
@@ -196,6 +198,7 @@
         "x": 0,
         "y": 10
       },
+      "repeatDirection": "h",
       "fieldConfig": {
         "defaults": {
           "unit": "reqps"
@@ -227,6 +230,7 @@
         "x": 12,
         "y": 10
       },
+      "repeatDirection": "h",
       "fieldConfig": {
         "defaults": {
           "unit": "s"
@@ -271,6 +275,7 @@
         "x": 0,
         "y": 17
       },
+      "repeatDirection": "h",
       "fieldConfig": {
         "defaults": {
           "unit": "reqps"
@@ -302,6 +307,7 @@
         "x": 12,
         "y": 17
       },
+      "repeatDirection": "h",
       "fieldConfig": {
         "defaults": {
           "unit": "s"

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.5
 	github.com/google/go-cmp v0.7.0
 	github.com/googleapis/gax-go/v2 v2.15.0
-	github.com/grafana/grafana-foundation-sdk/go v0.0.0-20251008104447-4b342c01ab41
+	github.com/grafana/grafana-foundation-sdk/go v0.0.0-20260129154346-aba721fdefde
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.3

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.6 h1:GW/XbdyBFQ8Qe+YAmFU
 github.com/googleapis/enterprise-certificate-proxy v0.3.6/go.mod h1:MkHOF77EYAE7qfSuSS9PU6g4Nt4e11cnsDUowfwewLA=
 github.com/googleapis/gax-go/v2 v2.15.0 h1:SyjDc1mGgZU5LncH8gimWo9lW1DtIfPibOG81vgd/bo=
 github.com/googleapis/gax-go/v2 v2.15.0/go.mod h1:zVVkkxAQHa1RQpg9z2AUCMnKhi0Qld9rcmyfL1OZhoc=
-github.com/grafana/grafana-foundation-sdk/go v0.0.0-20251008104447-4b342c01ab41 h1:E6rjkhLvfCXXpP/seDA9fFzNWpV8JbbZ8UCE+mdDIqU=
-github.com/grafana/grafana-foundation-sdk/go v0.0.0-20251008104447-4b342c01ab41/go.mod h1:48EA8jF85SrReYflLa39Sk34b6NpxwJPBwjF3TJgRpE=
+github.com/grafana/grafana-foundation-sdk/go v0.0.0-20260129154346-aba721fdefde h1:nAXbdOSfcusrQ7V3CbPH+vaHJgBjZXhXh7hGmL7bzMU=
+github.com/grafana/grafana-foundation-sdk/go v0.0.0-20260129154346-aba721fdefde/go.mod h1:48EA8jF85SrReYflLa39Sk34b6NpxwJPBwjF3TJgRpE=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=


### PR DESCRIPTION
**Changes in this PR**
- Runs `make build-dashboards`
- Dashboard drift due not updating the dashboard is resulting in CI failing in other PRs ([example](https://github.com/grafana/cloudcost-exporter/actions/runs/21519786124/job/62007491498))