### PR TITLE
[cloudcost-exporter] Add gh action to check for labels to create new release tag

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -42,6 +42,24 @@ jobs:
           echo "pr-url=$PR_URL" >> $GITHUB_OUTPUT
           echo "PR Labels: $LABELS"
           
+          # Extract release labels and count them
+          RELEASE_LABELS=$(echo "$LABELS" | grep -oE 'release:(major|minor|patch)' || true)
+          # Count release labels (handle empty string case)
+          if [ -z "$RELEASE_LABELS" ]; then
+            LABEL_COUNT=0
+          else
+            LABEL_COUNT=$(echo "$RELEASE_LABELS" | wc -l | tr -d ' ')
+          fi
+          
+          # Safeguard: Fail if multiple release labels are present
+          if [ "$LABEL_COUNT" -gt 1 ]; then
+            echo "ERROR: Multiple release labels found:"
+            echo "$RELEASE_LABELS" | sed 's/^/  - /'
+            echo "Please use only ONE release label per PR: release:major, release:minor, or release:patch"
+            exit 1
+          fi
+          
+          # Determine version bump based on single label (priority: major > minor > patch)
           if echo "$LABELS" | grep -q "release:major"; then
             echo "bump=major" >> $GITHUB_OUTPUT
             echo "should-release=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**Changes in this PR**
- Creates a new github action workflow to automate releases through PR labels
- To create a new release, add `release:major`, `release:minor`, or `release:patch` labels to PRs

**Why are we making this change?**
- Having this workflow allows for explicit, easy to audit, releases and works with the existing `GoReleaser` workflow
- Mitigates incorrect semver versioning by having the workflow determine the exact next version based on the label used
- Removes the need to manually create and push tags through the command line improving visibility on releases

**Next steps**
- Create the labels in the repo

**Issue Ref**
- https://github.com/grafana/deployment_tools/issues/472948