### PR TITLE
Persist credentials to allow for pushing tags in CI

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Get PR information
         id: pr-info


### PR DESCRIPTION
**Changes in this PR**
- Persist credentials to allow for pushing tags in CI
