### PR TITLE
Update grafana-foundation-sdk to v0.0.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.6
 	github.com/google/go-cmp v0.7.0
 	github.com/googleapis/gax-go/v2 v2.16.0
-	github.com/grafana/grafana-foundation-sdk/go v0.0.0-20260206104800-90adda0adb54
+	github.com/grafana/grafana-foundation-sdk/go v0.0.6
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.11 h1:vAe81Msw+8tKUxi2Dq
 github.com/googleapis/enterprise-certificate-proxy v0.3.11/go.mod h1:RFV7MUdlb7AgEq2v7FmMCfeSMCllAzWxFgRdusoGks8=
 github.com/googleapis/gax-go/v2 v2.16.0 h1:iHbQmKLLZrexmb0OSsNGTeSTS0HO4YvFOG8g5E4Zd0Y=
 github.com/googleapis/gax-go/v2 v2.16.0/go.mod h1:o1vfQjjNZn4+dPnRdl/4ZD7S9414Y4xA+a/6Icj6l14=
-github.com/grafana/grafana-foundation-sdk/go v0.0.0-20260206104800-90adda0adb54 h1:+evb4AFiUfetigAhEcuGHVNzVRXFB6NNUL4iU1Cs4Ic=
-github.com/grafana/grafana-foundation-sdk/go v0.0.0-20260206104800-90adda0adb54/go.mod h1:48EA8jF85SrReYflLa39Sk34b6NpxwJPBwjF3TJgRpE=
+github.com/grafana/grafana-foundation-sdk/go v0.0.6 h1:FG3vaIQ5Kvxuv3vvS9uZAeBS+HnCzbXqwLjZSIqGC+4=
+github.com/grafana/grafana-foundation-sdk/go v0.0.6/go.mod h1:48EA8jF85SrReYflLa39Sk34b6NpxwJPBwjF3TJgRpE=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=


### PR DESCRIPTION
The Makefile's build-dashboards target uses `@latest` which now resolves to v0.0.6. This PR updates go.mod and go.sum to match what make build-dashboards generates, fixing the CI drift check.

Follows the docs instructions which say to use `0.6.0`: https://grafana.github.io/grafana-foundation-sdk/go/Installing/