### PR TITLE
Trigger Helm chart release from changes to Chart.yaml

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -1,5 +1,10 @@
 name: Release Helm Chart
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'charts/cloudcost-exporter/Chart.yaml'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
We upgrade a Helm chart's version and the appVersion it uses by making changes to Chart.yaml.

Example: https://github.com/grafana/cloudcost-exporter/pull/793

Make sure that the GH workflow that creates the Helm chart is triggered when there are changes to this file.