### PR TITLE
Upgrade cloudcost-exporter-gh-runners helm chart to the latest version

### DIFF
--- a/charts/cloudcost-exporter/Chart.yaml
+++ b/charts/cloudcost-exporter/Chart.yaml
@@ -5,10 +5,10 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.9
+version: 1.0.10
 
 # This is the version of cloudcost-exporter to be deployed, which should be incremented
 # with each release.
-appVersion: "0.16.0"
+appVersion: "0.22.0"
 
 home: https://github.com/grafana/cloudcost-exporter


### PR DESCRIPTION
Part of https://github.com/grafana/cloudcost-exporter/issues/743