### PR TITLE
revert chart version to 1.0.8

### DIFF
--- a/charts/cloudcost-exporter/Chart.yaml
+++ b/charts/cloudcost-exporter/Chart.yaml
@@ -5,10 +5,10 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.10
+version: 1.0.8
 
 # This is the version of cloudcost-exporter to be deployed, which should be incremented
 # with each release.
-appVersion: "0.22.0"
+appVersion: "0.12.0"
 
 home: https://github.com/grafana/cloudcost-exporter


### PR DESCRIPTION
Due to image pull backoff errors starting on appVersion = 1.15.1, we need to temporarily rollback the helm chart version to 1.0.8