### PR TITLE
Revert "revert chart version to 1.0.8"

### DIFF
--- a/charts/cloudcost-exporter/Chart.yaml
+++ b/charts/cloudcost-exporter/Chart.yaml
@@ -5,10 +5,10 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.8
+version: 1.0.10
 
 # This is the version of cloudcost-exporter to be deployed, which should be incremented
 # with each release.
-appVersion: "0.12.0"
+appVersion: "0.22.0"
 
 home: https://github.com/grafana/cloudcost-exporter


### PR DESCRIPTION
Reverts grafana/cloudcost-exporter#798

The previous PR would have created a new Helm chart, but the workflows's release step was skipped since there was already a tag for it 👍 

From https://github.com/grafana/cloudcost-exporter/actions/runs/22184958712/job/64156009893#step:4:45 :
```
Running: ct list-changed --config /home/runner/work/cloudcost-exporter/cloudcost-exporter/source/charts/cloudcost-exporter/ct.yaml --since cloudcost-exporter-1.0.10 --target-branch main
charts/cloudcost-exporter
Tag  already exists, skipping release
```

`Chart.yaml` should correspond to the latest available Helm chart which is 1.0.10 as shown in the artifact hub: https://artifacthub.io/packages/helm/grafana/cloudcost-exporter