### PR TITLE
[cloudcost-exporter] Only consider semver tags in automated releases (tag push)

### DIFF
--- a/.github/workflows/release-on-tag-push.yml
+++ b/.github/workflows/release-on-tag-push.yml
@@ -22,6 +22,15 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Validate tag is semver
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Tag '$TAG' is not a valid semver tag. This workflow only processes image release tags (e.g. v0.21.0). Helm chart tags (e.g. vcloudcost-exporter-1.2.0) are ignored."
+            exit 1
+          fi
+          echo "Tag '$TAG' is valid semver"
+
       - name: Extract version
         id: version
         run: |


### PR DESCRIPTION
**Changes in this PR**
- Adds safeguards in the automated release workflow when tags are pushed to ensure a release is only cut when the tags follow semver. 
- Non-semver tags (ie, `vcloudcost-exporter-1.2.0`) are for the helm chart and should not trigger image releases

**Background**
- Now that tags for helm charts are being pushed to this repo, we should put safeguards in place to make sure we keep those separate from docker image tag pushes