### PR TITLE
Update deployment to pull the correct image tag format

### DIFF
--- a/charts/cloudcost-exporter/templates/deployment.yaml
+++ b/charts/cloudcost-exporter/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: {{ include "cloudcost-exporter.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           {{- range .Values.containerArgs }}

--- a/cr.yaml
+++ b/cr.yaml
@@ -3,3 +3,4 @@ owner: grafana
 git-repo: helm-charts
 skip-existing: true
 release-name-template: "{{ .Name }}-{{ .Version }}"
+git-tag-template: "{{ .Name }}-{{ .Version }}"


### PR DESCRIPTION
After https://github.com/grafana/cloudcost-exporter/pull/636 and https://github.com/grafana/cloudcost-exporter/pull/637, cloudcost-exporter-gh-runners image tag changed from `<semver>` to  `v<semver>`.
This happened in appVersion 0.15.1 and we can see it changed from [0.15.0](https://hub.docker.com/layers/grafana/cloudcost-exporter/0.15.0/images/sha256-e61b8ee4a0d84d6e392a3fed9cd053c8d182ec673c409316847ae08c74c24ec1) to [v0.15.1](https://hub.docker.com/layers/grafana/cloudcost-exporter/v0.15.1/images/sha256-706b160a32912e55174307b18d6557a1729ae92a9bb4031cdb4095151799b71d).

 We need to update the deployment to pull the image in the updated format.

Part of https://github.com/grafana/cloudcost-exporter/issues/743