### PR TITLE
New chart version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.1.0
+          version: v2.10.1
       - name: Test
         run: go test -v ./...
       - name: Install make

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	cloud.google.com/go/billing v1.21.0
 	cloud.google.com/go/compute v1.54.0
-	cloud.google.com/go/monitoring v1.24.3
+	cloud.google.com/go/monitoring v1.24.3 // indirect
 	cloud.google.com/go/storage v1.59.2
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7 v7.3.0
@@ -33,7 +33,7 @@ require (
 	google.golang.org/api v0.266.0
 	google.golang.org/genproto v0.0.0-20260217215200-42d3e9bedb6d
 	google.golang.org/grpc v1.78.0
-	google.golang.org/protobuf v1.36.11
+	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/matryer/try.v1 v1.0.0-20150601225556-312d2599e12e
 )
 


### PR DESCRIPTION
Bumping the chart version to reflect breaking change from `<semver>` to `v<semver>`

Image: https://hub.docker.com/layers/grafana/cloudcost-exporter/v0.22.0/images/sha256-47a0449dcedce50b2feba4bc92af6fb3cea456d60a7068c698664410e55340ef

https://github.com/grafana/cloudcost-exporter/issues/743