### PR TITLE
Remove v from appVersion in Chart.yaml

### DIFF
--- a/charts/cloudcost-exporter/Chart.yaml
+++ b/charts/cloudcost-exporter/Chart.yaml
@@ -9,6 +9,6 @@ version: 1.1.0
 
 # This is the version of cloudcost-exporter to be deployed, which should be incremented
 # with each release.
-appVersion: "v0.22.0"
+appVersion: "0.22.0"
 
 home: https://github.com/grafana/cloudcost-exporter


### PR DESCRIPTION
Right now it is producing the following image: https://github.com/grafana/kube-manifests/compare/master...pr-491952#diff-36d183dca9a324bc0ae149228a9215e0ac60953804a397d2489f26a86c970b00L36

So we can remove this `v`
Part of https://github.com/grafana/cloudcost-exporter/issues/743