### PR TITLE
perf(ec2): add parallel pagination by availability zone

### DIFF
--- a/pkg/aws/client/compute.go
+++ b/pkg/aws/client/compute.go
@@ -2,16 +2,19 @@ package client
 
 import (
 	"context"
+	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsEc2 "github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/cloudcost-exporter/pkg/aws/services/ec2"
 )
 
 const maxResults = 1000
 const eksPVTagName = "kubernetes.io/created-for/pv/name"
+const maxConcurrentAZFetches = 5
 
 var clusterTags = []string{"cluster", "eks:cluster-name", "aws:eks:cluster-name"}
 
@@ -33,10 +36,58 @@ func (e *compute) describeRegions(ctx context.Context, allRegions bool) ([]types
 }
 
 func (e *compute) listComputeInstances(ctx context.Context) ([]types.Reservation, error) {
+	azs, err := e.getAvailabilityZones(ctx)
+	if err != nil {
+		return e.listComputeInstancesSequential(ctx, nil)
+	}
+
+	if len(azs) <= 1 {
+		return e.listComputeInstancesSequential(ctx, nil)
+	}
+
+	// Fetch instances from each AZ in parallel to improve performance
+	var mu sync.Mutex
+	var allInstances []types.Reservation
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.SetLimit(maxConcurrentAZFetches)
+
+	for _, az := range azs {
+		az := az
+		eg.Go(func() error {
+			filter := []types.Filter{
+				{
+					Name:   aws.String("availability-zone"),
+					Values: []string{az},
+				},
+			}
+			instances, err := e.listComputeInstancesSequential(egCtx, filter)
+			if err != nil {
+				return err
+			}
+
+			mu.Lock()
+			allInstances = append(allInstances, instances...)
+			mu.Unlock()
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	return allInstances, nil
+}
+
+func (e *compute) listComputeInstancesSequential(ctx context.Context, filters []types.Filter) ([]types.Reservation, error) {
 	dii := &awsEc2.DescribeInstancesInput{
-		// 1000 max results was decided arbitrarily. This can likely be tuned.
 		MaxResults: aws.Int32(maxResults),
 	}
+	if len(filters) > 0 {
+		dii.Filters = filters
+	}
+
 	var instances []types.Reservation
 	for {
 		resp, err := e.client.DescribeInstances(ctx, dii)
@@ -51,6 +102,29 @@ func (e *compute) listComputeInstances(ctx context.Context) ([]types.Reservation
 	}
 
 	return instances, nil
+}
+
+func (e *compute) getAvailabilityZones(ctx context.Context) ([]string, error) {
+	resp, err := e.client.DescribeAvailabilityZones(ctx, &awsEc2.DescribeAvailabilityZonesInput{
+		Filters: []types.Filter{
+			{
+				Name:   aws.String("state"),
+				Values: []string{"available"},
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	azs := make([]string, 0, len(resp.AvailabilityZones))
+	for _, az := range resp.AvailabilityZones {
+		if az.ZoneName != nil {
+			azs = append(azs, *az.ZoneName)
+		}
+	}
+
+	return azs, nil
 }
 
 // DISK

--- a/pkg/aws/client/compute_test.go
+++ b/pkg/aws/client/compute_test.go
@@ -14,34 +14,56 @@ import (
 
 func TestListComputeInstances(t *testing.T) {
 	tests := map[string]struct {
-		ctx               context.Context
-		DescribeInstances func(ctx context.Context, e *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
-		err               error
-		want              []types.Reservation
-		expectedCalls     int
+		ctx                       context.Context
+		DescribeInstances         func(ctx context.Context, e *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
+		DescribeAvailabilityZones func(ctx context.Context, input *ec2.DescribeAvailabilityZonesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeAvailabilityZonesOutput, error)
+		err                       error
+		want                      []types.Reservation
+		expectedCalls             int
 	}{
 		"No instance should return nothing": {
 			ctx: t.Context(),
 			DescribeInstances: func(ctx context.Context, e *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
 				return &ec2.DescribeInstancesOutput{}, nil
 			},
+			DescribeAvailabilityZones: func(ctx context.Context, input *ec2.DescribeAvailabilityZonesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeAvailabilityZonesOutput, error) {
+				return &ec2.DescribeAvailabilityZonesOutput{
+					AvailabilityZones: []types.AvailabilityZone{
+						{ZoneName: aws.String("us-east-1a")},
+						{ZoneName: aws.String("us-east-1b")},
+					},
+				}, nil
+			},
 			err:           nil,
 			want:          nil,
-			expectedCalls: 1,
+			expectedCalls: 2,
 		},
 		"Single instance should return a single instance": {
 			ctx: t.Context(),
 			DescribeInstances: func(ctx context.Context, e *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
-				return &ec2.DescribeInstancesOutput{
-					Reservations: []types.Reservation{
-						{
-							Instances: []types.Instance{
-								{
-									InstanceId:   aws.String("i-1234567890abcdef0"),
-									InstanceType: types.InstanceTypeA1Xlarge,
+				// Check which AZ filter is applied and return appropriate instances
+				if len(e.Filters) > 0 && e.Filters[0].Values[0] == "us-east-1a" {
+					return &ec2.DescribeInstancesOutput{
+						Reservations: []types.Reservation{
+							{
+								Instances: []types.Instance{
+									{
+										InstanceId:   aws.String("i-1234567890abcdef0"),
+										InstanceType: types.InstanceTypeA1Xlarge,
+									},
 								},
 							},
 						},
+					}, nil
+				}
+				// Return empty for us-east-1b
+				return &ec2.DescribeInstancesOutput{}, nil
+			},
+			DescribeAvailabilityZones: func(ctx context.Context, input *ec2.DescribeAvailabilityZonesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeAvailabilityZonesOutput, error) {
+				return &ec2.DescribeAvailabilityZonesOutput{
+					AvailabilityZones: []types.AvailabilityZone{
+						{ZoneName: aws.String("us-east-1a")},
+						{ZoneName: aws.String("us-east-1b")},
 					},
 				}, nil
 			},
@@ -56,12 +78,20 @@ func TestListComputeInstances(t *testing.T) {
 					},
 				},
 			},
-			expectedCalls: 1,
+			expectedCalls: 2,
 		},
 		"Ensure errors propagate": {
 			ctx: t.Context(),
 			DescribeInstances: func(ctx context.Context, e *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+				// Return error for any AZ
 				return nil, assert.AnError
+			},
+			DescribeAvailabilityZones: func(ctx context.Context, input *ec2.DescribeAvailabilityZonesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeAvailabilityZonesOutput, error) {
+				return &ec2.DescribeAvailabilityZonesOutput{
+					AvailabilityZones: []types.AvailabilityZone{
+						{ZoneName: aws.String("us-east-1a")},
+					},
+				}, nil
 			},
 			err:           assert.AnError,
 			want:          nil,
@@ -70,14 +100,30 @@ func TestListComputeInstances(t *testing.T) {
 		"NextToken should return multiple instances": {
 			ctx: t.Context(),
 			DescribeInstances: func(ctx context.Context, e *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
-				if e.NextToken == nil {
+				// Check which AZ filter is applied
+				if len(e.Filters) > 0 && e.Filters[0].Values[0] == "us-east-1a" {
+					// For us-east-1a, return instances with pagination
+					if e.NextToken == nil {
+						return &ec2.DescribeInstancesOutput{
+							NextToken: aws.String("token"),
+							Reservations: []types.Reservation{
+								{
+									Instances: []types.Instance{
+										{
+											InstanceId:   aws.String("i-1234567890abcdef0"),
+											InstanceType: types.InstanceTypeA1Xlarge,
+										},
+									},
+								},
+							},
+						}, nil
+					}
 					return &ec2.DescribeInstancesOutput{
-						NextToken: aws.String("token"),
 						Reservations: []types.Reservation{
 							{
 								Instances: []types.Instance{
 									{
-										InstanceId:   aws.String("i-1234567890abcdef0"),
+										InstanceId:   aws.String("i-1234567890abcdef1"),
 										InstanceType: types.InstanceTypeA1Xlarge,
 									},
 								},
@@ -85,16 +131,14 @@ func TestListComputeInstances(t *testing.T) {
 						},
 					}, nil
 				}
-				return &ec2.DescribeInstancesOutput{
-					Reservations: []types.Reservation{
-						{
-							Instances: []types.Instance{
-								{
-									InstanceId:   aws.String("i-1234567890abcdef0"),
-									InstanceType: types.InstanceTypeA1Xlarge,
-								},
-							},
-						},
+				// Return empty for us-east-1b
+				return &ec2.DescribeInstancesOutput{}, nil
+			},
+			DescribeAvailabilityZones: func(ctx context.Context, input *ec2.DescribeAvailabilityZonesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeAvailabilityZonesOutput, error) {
+				return &ec2.DescribeAvailabilityZonesOutput{
+					AvailabilityZones: []types.AvailabilityZone{
+						{ZoneName: aws.String("us-east-1a")},
+						{ZoneName: aws.String("us-east-1b")},
 					},
 				}, nil
 			},
@@ -112,19 +156,29 @@ func TestListComputeInstances(t *testing.T) {
 				{
 					Instances: []types.Instance{
 						{
-							InstanceId:   aws.String("i-1234567890abcdef0"),
+							InstanceId:   aws.String("i-1234567890abcdef1"),
 							InstanceType: types.InstanceTypeA1Xlarge,
 						},
 					},
 				},
 			},
-			expectedCalls: 2,
+			expectedCalls: 3,
 		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			client := mocks.NewMockEC2(ctrl)
+
+			// Mock DescribeAvailabilityZones call
+			if tt.DescribeAvailabilityZones != nil {
+				client.EXPECT().
+					DescribeAvailabilityZones(gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(tt.DescribeAvailabilityZones).
+					Times(1)
+			}
+
+			// Mock DescribeInstances calls
 			client.EXPECT().
 				DescribeInstances(gomock.Any(), gomock.Any(), gomock.Any()).
 				DoAndReturn(tt.DescribeInstances).

--- a/pkg/aws/services/ec2/ec2.go
+++ b/pkg/aws/services/ec2/ec2.go
@@ -13,4 +13,5 @@ type EC2 interface {
 	DescribeRegions(ctx context.Context, e *ec2.DescribeRegionsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeRegionsOutput, error)
 	DescribeSpotPriceHistory(ctx context.Context, input *ec2.DescribeSpotPriceHistoryInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSpotPriceHistoryOutput, error)
 	DescribeVolumes(context.Context, *ec2.DescribeVolumesInput, ...func(*ec2.Options)) (*ec2.DescribeVolumesOutput, error)
+	DescribeAvailabilityZones(ctx context.Context, input *ec2.DescribeAvailabilityZonesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeAvailabilityZonesOutput, error)
 }

--- a/pkg/aws/services/mocks/ec2.go
+++ b/pkg/aws/services/mocks/ec2.go
@@ -41,6 +41,26 @@ func (m *MockEC2) EXPECT() *MockEC2MockRecorder {
 	return m.recorder
 }
 
+// DescribeAvailabilityZones mocks base method.
+func (m *MockEC2) DescribeAvailabilityZones(ctx context.Context, input *ec2.DescribeAvailabilityZonesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeAvailabilityZonesOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, input}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeAvailabilityZones", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeAvailabilityZonesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeAvailabilityZones indicates an expected call of DescribeAvailabilityZones.
+func (mr *MockEC2MockRecorder) DescribeAvailabilityZones(ctx, input any, optFns ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, input}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAvailabilityZones", reflect.TypeOf((*MockEC2)(nil).DescribeAvailabilityZones), varargs...)
+}
+
 // DescribeInstances mocks base method.
 func (m *MockEC2) DescribeInstances(ctx context.Context, e *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Part of https://github.com/orgs/grafana/projects/513/views/15?pane=issue&itemId=159323629&issue=grafana%7Cdeployment_tools%7C492510.

Implements parallel pagination by availability zone for EC2 instance collection to reduce scrape latency. This potentially fixes the PromScrapeFailed alerts in prod-us-east-2 for the GitHub runners environment.

## Problem

The EC2 collector scrape latency was reaching 10s in regions with high instance counts, causing Prometheus scrape timeouts and triggering PromScrapeFailed alerts. The root cause was sequential pagination through all instances in a region using `DescribeInstances` API calls.

## Solution

Partition the workload by availability zone and fetch instances from each AZ in parallel:
- Query all availability zones in the region
- Fetch instances from each AZ concurrently using `errgroup` (limited to 5 concurrent requests)
- Fall back to sequential mode if AZ discovery fails or only 1 AZ exists