### PR TITLE
Upgrade Helm chart to upgrade the `appVersion` to 0.24.0

### DIFF
--- a/charts/cloudcost-exporter/Chart.yaml
+++ b/charts/cloudcost-exporter/Chart.yaml
@@ -5,10 +5,10 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.0
+version: 1.1.1
 
 # This is the version of cloudcost-exporter to be deployed, which should be incremented
 # with each release.
-appVersion: "0.22.0"
+appVersion: "0.24.0"
 
 home: https://github.com/grafana/cloudcost-exporter


### PR DESCRIPTION
Part of https://github.com/grafana/cloudcost-exporter/issues/743

Upgrading the Helm chart's `appVersion` to 0.24.0 so that the CCE Helm chart is at parity with the latest version of the CCE application. 

A patch upgrade to the Helm chart is acceptable since https://github.com/grafana/cloudcost-exporter/pull/817 's `v` change (in `Chart.yaml`) is a cosmetic change of what was actually handled in the in the Deployment itself, which we did a minor bump for with `1.1.0` 👍 

Opting to skip `0.23.0` in order to reach parity.