### PR TITLE
Update Helm chart versions from cloudcost-exporter releases

### DIFF
--- a/.github/workflows/update-helm-chart-on-release.yml
+++ b/.github/workflows/update-helm-chart-on-release.yml
@@ -17,8 +17,9 @@ jobs:
       pull-requests: write
     steps:
       - name: Validate tag is semver
+        env:
+          TAG: ${{ github.event.release.tag_name }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
           if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Tag '$TAG' is not a valid semver tag (expected vMAJOR.MINOR.PATCH). Skipping."
             exit 1


### PR DESCRIPTION
part of https://github.com/grafana/cloudcost-exporter/issues/743

When a new cloudcost-exporter release is published, we need to update `Chart.yaml` with the new `appVersion` that the chart should use. This triggers the Helm chart release automation.

This workflow takes the new release's version, uses `yq` to set it as the `appVersion`, bumps the patch for the Helm chart, and creates a PR using the `peter-evans/create-pull-request` (which I verified we use in other Grafana repos). The PR requires a human approval but could be automated to auto-merge in the future once we get this up and running. 
