### PR TITLE
fix(providers) context handling inconsistencies pt 2

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -214,7 +214,7 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 }
 
 func (a *AWS) RegisterCollectors(registry provider.Registry) error {
-	a.logger.LogAttrs(context.Background(), slog.LevelInfo, "registering collectors",
+	a.logger.LogAttrs(a.ctx, slog.LevelInfo, "registering collectors",
 		slog.Int("count", len(a.collectors)),
 	)
 	for _, c := range a.collectors {
@@ -231,7 +231,7 @@ func (a *AWS) Describe(ch chan<- *prometheus.Desc) {
 	ch <- collectorLastScrapeTime
 	for _, c := range a.collectors {
 		if err := c.Describe(ch); err != nil {
-			a.logger.LogAttrs(context.Background(), slog.LevelError, "failed to describe collector",
+			a.logger.LogAttrs(a.ctx, slog.LevelError, "failed to describe collector",
 				slog.String("message", err.Error()),
 				slog.String("collector", c.Name()),
 			)

--- a/pkg/azure/aks/aks.go
+++ b/pkg/azure/aks/aks.go
@@ -282,6 +282,7 @@ func (c *Collector) Name() string {
 }
 
 func (c *Collector) Register(_ provider.Registry) error {
+	// Register has no ctx parameter in the Collector interface, so context.Background() is intentional here.
 	c.logger.LogAttrs(context.Background(), slog.LevelInfo, "registering collector")
 	return nil
 }

--- a/pkg/google/gcp.go
+++ b/pkg/google/gcp.go
@@ -177,7 +177,7 @@ func (g *GCP) Describe(ch chan<- *prometheus.Desc) {
 	ch <- collectorLastScrapeTime
 	for _, c := range g.collectors {
 		if err := c.Describe(ch); err != nil {
-			g.logger.LogAttrs(context.Background(), slog.LevelError, "Error calling describe",
+			g.logger.LogAttrs(g.ctx, slog.LevelError, "Error calling describe",
 				slog.String("message", err.Error()),
 			)
 		}
@@ -199,7 +199,7 @@ func (g *GCP) Collect(ch chan<- prometheus.Metric) {
 			duration, hasError := gatherer.CollectWithGatherer(collectCtx, c, ch, g.logger)
 
 			if !hasError {
-				g.logger.LogAttrs(context.Background(), slog.LevelInfo, "Collect successful",
+				g.logger.LogAttrs(collectCtx, slog.LevelInfo, "Collect successful",
 					slog.String("collector", c.Name()),
 					slog.Duration("duration", time.Duration(duration*float64(time.Second))),
 				)

--- a/scripts/aws-spot-pricing/main.go
+++ b/scripts/aws-spot-pricing/main.go
@@ -16,7 +16,7 @@ func main() {
 	options := []func(*config.LoadOptions) error{config.WithEC2IMDSRegion()}
 	options = append(options, config.WithRegion("us-east-2"))
 	options = append(options, config.WithSharedConfigProfile(os.Getenv("AWS_PROFILE")))
-	cfg, err := config.LoadDefaultConfig(context.TODO(), options...)
+	cfg, err := config.LoadDefaultConfig(context.Background(), options...)
 	if err != nil {
 		log.Fatalf("unable to load SDK config, %v", err)
 	}
@@ -35,7 +35,7 @@ func main() {
 		EndTime:   &endTime,
 	}
 	for {
-		resp, err := client.DescribeSpotPriceHistory(context.TODO(), sphi)
+		resp, err := client.DescribeSpotPriceHistory(context.Background(), sphi)
 		if err != nil {
 			break
 		}


### PR DESCRIPTION
## Summary

Fixes the remaining `context.Background()` / `context.TODO()` violations identified in #831. Provider methods were using `context.Background()` for logging despite having a proper context available — either stored on the struct or derived earlier in the call.

- `pkg/aws/aws.go` — `RegisterCollectors` and `Describe` now use `a.ctx` instead of `context.Background()`
- `pkg/google/gcp.go` — `Describe` now uses `g.ctx`; `Collect` now uses the already-derived `collectCtx`
- `pkg/azure/aks/aks.go` — `Register` has no `ctx` parameter in the `Collector` interface, so `context.Background()` is kept but documented with a comment
- `scripts/aws-spot-pricing/main.go` — `context.TODO()` replaced with `context.Background()` to reflect intent

## Motivation

Stray `context.Background()` calls in logging won't cause correctness issues today, but will silently drop trace/span context if context-aware logging or trace propagation is ever added. Closes #831.

## Test plan

- [x] Existing tests pass