### PR TITLE
feat: add code coverage reporting to CI pipeline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build-lint-test:
     permissions:
-      pull-requests: read
+      pull-requests: write
       contents: read
     runs-on: ubuntu-latest
     steps:
@@ -28,7 +28,14 @@ jobs:
         with:
           version: v2.10.1
       - name: Test
-        run: go test -v ./...
+        run: go test -v -coverprofile=coverage.out -covermode=atomic ./...
+      - name: Coverage Report
+        uses: vladopajic/go-test-coverage@v2
+        with:
+          profile: coverage.out
+          local-prefix: github.com/grafana/cloudcost-exporter
+          git-token: ${{ github.ref_name == 'main' && secrets.GITHUB_TOKEN || '' }}
+          git-branch: badges
       - name: Install make
         run: sudo apt-get update && sudo apt-get install -y make
         shell: bash


### PR DESCRIPTION
Adds automated Go code coverage reporting to pull requests using the `vladopajic/go-test-coverage` action.

**Changes:**
- Upgrades `pull-requests` permission from `read` to `write` to allow the action to post coverage comments on PRs
- Updates the test command to generate a coverage profile (`-coverprofile=coverage.out -covermode=atomic`)
- Adds a **Coverage Report** step that runs `vladopajic/go-test-coverage@v2` to:
  - Parse the generated coverage profile
  - Post coverage summaries as PR comments
  - Update coverage badge data on the `badges` branch when merged to `main` (uses `GITHUB_TOKEN` only on the main branch)