### PR TITLE
Use Oberve histogram method to properly populate histogram buckets

### DIFF
--- a/pkg/gatherer/gatherer.go
+++ b/pkg/gatherer/gatherer.go
@@ -8,7 +8,6 @@ import (
 	cloudcost_exporter "github.com/grafana/cloudcost-exporter"
 	"github.com/grafana/cloudcost-exporter/pkg/provider"
 	"github.com/prometheus/client_golang/prometheus"
-	io_prometheus_client "github.com/prometheus/client_model/go"
 )
 
 var gathererDurationHistogramVec = prometheus.NewHistogramVec(
@@ -38,26 +37,13 @@ var gathererTotalCounterVec = prometheus.NewCounterVec(
 )
 
 func emitHistogramMetric(ch chan<- prometheus.Metric, collectorName string, duration float64) {
-	ch <- prometheus.MustNewConstHistogram(
-		gathererDurationHistogramVec.WithLabelValues(collectorName).(prometheus.Histogram).Desc(),
-		1,
-		duration,
-		nil,
-		collectorName,
-	)
+	h := gathererDurationHistogramVec.WithLabelValues(collectorName).(prometheus.Histogram)
+	h.Observe(duration)
+	ch <- h
 
 	counter := gathererTotalCounterVec.WithLabelValues(collectorName)
 	counter.Inc()
-
-	m := &io_prometheus_client.Metric{}
-	if err := counter.Write(m); err == nil && m.Counter != nil {
-		ch <- prometheus.MustNewConstMetric(
-			gathererTotalCounterVec.WithLabelValues(collectorName).Desc(),
-			prometheus.CounterValue,
-			m.GetCounter().GetValue(),
-			collectorName,
-		)
-	}
+	ch <- counter
 }
 
 // CollectWithGatherer collects metrics from a collector and uses the Gatherer interface to detect errors.
@@ -94,16 +80,7 @@ func CollectWithGatherer(ctx context.Context, c provider.Collector, ch chan<- pr
 		)
 		errorCounter := gathererErrorCounterVec.WithLabelValues(c.Name())
 		errorCounter.Inc()
-
-		m := &io_prometheus_client.Metric{}
-		if err := errorCounter.Write(m); err == nil && m.Counter != nil {
-			ch <- prometheus.MustNewConstMetric(
-				gathererErrorCounterVec.WithLabelValues(c.Name()).Desc(),
-				prometheus.CounterValue,
-				m.GetCounter().GetValue(),
-				c.Name(),
-			)
-		}
+		ch <- errorCounter
 	}
 
 	emitHistogramMetric(ch, c.Name(), duration)


### PR DESCRIPTION
## Why
Histograms were already defined as native histograms (no need to predefine buckets), but because the `.Observe` method wasn't used, buckets weren't properly filled (see https://ops.grafana-ops.net/goto/bfflc9hkbco3kc?orgId=stacks-27821) and always defaulting to prometheus default value, `+Inf`

Using the [Observe method](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus?utm_source=godoc#Histogram) fixes that.

Part of https://github.com/grafana/deployment_tools/issues/413121