### PR TITLE
(fix): Make dashboard output traversal resistant

### DIFF
--- a/cmd/dashboards/main.go
+++ b/cmd/dashboards/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
@@ -29,6 +28,16 @@ func main() {
 }
 
 func run(dashes []*dashboard.DashboardBuilder, output *string, outputDir *string) error {
+	var root *os.Root
+	if *output != "console" {
+		var err error
+		root, err = os.OpenRoot(*outputDir)
+		if err != nil {
+			return fmt.Errorf("open output directory: %w", err)
+		}
+		defer root.Close()
+	}
+
 	for _, dash := range dashes {
 		build, err := dash.Build()
 		if err != nil {
@@ -59,8 +68,7 @@ func run(dashes []*dashboard.DashboardBuilder, output *string, outputDir *string
 			return err
 		}
 		slug := sluggify(*build.Title)
-		path := filepath.Join(*outputDir, slug+".json")
-		if err := os.WriteFile(path, data, 0644); err != nil {
+		if err := root.WriteFile(slug+".json", data, 0644); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
A path traversal vulnerability arises when an attacker can trick a program into writing a file to another place than the one it intended. This change will allow for path sanitization and only allow the file to be written to a local directory.

This will only allow our dashboard generator to generate to user-owned directories.

Source: https://go.dev/blog/osroot
