### PR TITLE
fix(cloudsql): cache SKUs at startup with background refresh to prevent OOM

### DIFF
--- a/pkg/google/cloudsql/cloudsql.go
+++ b/pkg/google/cloudsql/cloudsql.go
@@ -2,6 +2,7 @@ package cloudsql
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -44,10 +45,30 @@ var (
 	)
 )
 
-func New(config *Config, gcpClient client.Client) (*Collector, error) {
+func New(ctx context.Context, config *Config, gcpClient client.Client) (*Collector, error) {
 	pm := newPricingMap(config.Logger, gcpClient)
 	projects := strings.Split(config.Projects, ",")
 	regions := client.RegionsForProjects(gcpClient, projects, config.Logger)
+
+	if err := pm.getSKus(ctx); err != nil {
+		return nil, fmt.Errorf("failed to initialise Cloud SQL pricing: %w", err)
+	}
+
+	go func() {
+		ticker := time.NewTicker(CostRefreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := pm.getSKus(ctx); err != nil {
+					config.Logger.Error("failed to refresh Cloud SQL pricing SKUs", "error", err)
+				}
+			}
+		}
+	}()
+
 	return &Collector{
 		gcpClient:  gcpClient,
 		config:     config,
@@ -68,11 +89,6 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
 
 func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
 	logger := c.logger.With("logger", "cloudsql")
-
-	if err := c.pricingMap.getSKus(ctx); err != nil {
-		logger.Error("failed to load pricing SKUs", "error", err)
-		return err
-	}
 
 	instances, err := c.getAllCloudSQL(ctx)
 	if err != nil {

--- a/pkg/google/cloudsql/cloudsql_test.go
+++ b/pkg/google/cloudsql/cloudsql_test.go
@@ -202,7 +202,7 @@ func TestCollector(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gcpClient := newTestGCPClient(t, tt.regionsHandlers, tt.sqlAdminHandlers, tt.skus)
 			config := &Config{Projects: "test-project", Logger: slog.New(slog.NewTextHandler(os.Stdout, nil))}
-			collector, err := New(config, gcpClient)
+			collector, err := New(context.Background(), config, gcpClient)
 			require.NoError(t, err)
 
 			ch := make(chan prometheus.Metric, 1)
@@ -280,8 +280,8 @@ func TestGetAllCloudSQL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gcpClient := newTestGCPClient(t, tt.regionsHandlers, tt.sqlAdminHandlers, nil)
-			config := &Config{Projects: "test-project"}
-			collector, err := New(config, gcpClient)
+			config := &Config{Projects: "test-project", Logger: slog.New(slog.NewTextHandler(os.Stdout, nil))}
+			collector, err := New(context.Background(), config, gcpClient)
 			require.NoError(t, err)
 
 			instances, err := collector.getAllCloudSQL(context.Background())

--- a/pkg/google/gcp.go
+++ b/pkg/google/gcp.go
@@ -141,7 +141,7 @@ func New(ctx context.Context, config *Config) (*GCP, error) {
 				continue
 			}
 		case "SQL":
-			collector, err = cloudsql.New(&cloudsql.Config{
+			collector, err = cloudsql.New(ctx, &cloudsql.Config{
 				Projects:       config.Projects,
 				ScrapeInterval: config.ScrapeInterval,
 				Logger:         config.Logger,


### PR DESCRIPTION
## Summary

`getSKus()` was called on every Prometheus scrape, making two GCP Billing API requests and materialising the full Cloud SQL SKU catalog into memory each time. 

By moving the fetch to `New()`, failing fast on error, and refresh every 24h via a background goroutine (matching the GKE pattern) we drastically reduce the likely hood of running out of memory. `CostRefreshInterval` was already defined so I made use of it, it is now the refresh period.

## Plan

- Move Cloud SQL pricing SKU fetching from `Collect()` to `New()`, so SKUs are fetched once at collector initialisation rather than on every scrape
- Add a background goroutine in `New()` that refreshes SKUs on a `CostRefreshInterval` ticker, with context cancellation support
- Pass `context.Context` as the first argument to `cloudsql.New()` (and update call sites and tests accordingly)

## Motivation

Fetching pricing SKUs on every scrape caused memory spikes that led to OOMs. By fetching eagerly at startup and refreshing periodically in the background, the collector amortises the cost of SKU hydration and keeps memory usage predictable between scrapes.

## Test plan

- [x] Existing `TestCollector` and `TestGetAllCloudSQL` tests pass with updated `New(context.Background(), ...)` signatures
- [ ] Verify `New()` returns an error immediately if initial SKU fetch fails (fail-fast at startup)
- [ ] Verify the collector continues to serve cached pricing data between refresh intervals
- [x] Run `make test` to confirm no regressions
