### PR TITLE
fix(aws): skip failing RDS and VPC collectors instead of aborting provider

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -165,7 +165,10 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 			// as for RDS , the pricing data is only available in the us-east-1
 			pricingConfig, err := createAWSConfig(ctx, "us-east-1", config.Profile, config.RoleARN)
 			if err != nil {
-				return nil, err
+				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
+					slog.String("service", service),
+					slog.String("message", err.Error()))
+				continue
 			}
 			awsRDSClient := client.NewAWSClient(client.Config{
 				PricingService: awsPricing.NewFromConfig(pricingConfig),
@@ -199,7 +202,10 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 			// as for VPC, the pricing data is only available in the us-east-1
 			pricingConfig, err := createAWSConfig(ctx, "us-east-1", config.Profile, config.RoleARN)
 			if err != nil {
-				return nil, err
+				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
+					slog.String("service", service),
+					slog.String("message", err.Error()))
+				continue
 			}
 			awsVPCClient := client.NewAWSClient(client.Config{
 				PricingService: awsPricing.NewFromConfig(pricingConfig),


### PR DESCRIPTION
## Summary

- RDS and VPC collector init failures previously returned `nil, err`, killing the entire AWS provider and dropping all metrics from every other service
- Aligns RDS and VPC error handling with S3 and EC2: log the error at ERROR level and `continue` so remaining collectors stay intact

Fixes #716

## Test plan

- [x] `make test` passes
- [ ] Verify that a pricing config error for RDS/VPC no longer prevents S3/EC2 metrics from being exported