### PR TITLE
Instrument memory profiling

### DIFF
--- a/cmd/exporter/config/config.go
+++ b/cmd/exporter/config/config.go
@@ -35,9 +35,10 @@ type Config struct {
 	}
 
 	Server struct {
-		Address string
-		Path    string
-		Timeout time.Duration
+		Address      string
+		Path         string
+		Timeout      time.Duration
+		DebugAddress string
 	}
 	LoggerOpts struct {
 		Level  string // Maps to slog levels: debug, info, warn, error

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"strings"
@@ -95,6 +96,7 @@ func operationalFlags(cfg *config.Config) {
 	flag.StringVar(&cfg.LoggerOpts.Level, "log.level", "info", "Log level: debug, info, warn, error")
 	flag.StringVar(&cfg.LoggerOpts.Output, "log.output", "stdout", "Log output stream: stdout, stderr, file")
 	flag.StringVar(&cfg.LoggerOpts.Type, "log.type", "text", "Log type: json, text")
+	flag.StringVar(&cfg.Server.DebugAddress, "debug.address", ":6060", "Address for the pprof debug server (e.g. :6060). Disabled when empty.")
 }
 
 // setupLogger is a helper method that is responsible for creating a structured logger that is used throughout the application.
@@ -104,8 +106,25 @@ func setupLogger(level string, output string, logtype string) *slog.Logger {
 	return slog.New(handler)
 }
 
+// startDebugServer starts a pprof HTTP server on cfg.Server.DebugAddress.
+// It is a no-op when DebugAddress is empty.
+func startDebugServer(ctx context.Context, cfg *config.Config, log *slog.Logger) {
+	if cfg.Server.DebugAddress == "" {
+		return
+	}
+	log.LogAttrs(ctx, slog.LevelInfo, "Starting pprof debug server", slog.String("address", cfg.Server.DebugAddress))
+	go func() {
+		// http.DefaultServeMux has pprof routes registered via the blank import.
+		if err := http.ListenAndServe(cfg.Server.DebugAddress, http.DefaultServeMux); err != nil {
+			log.LogAttrs(ctx, slog.LevelError, "pprof debug server stopped", slog.String("message", err.Error()))
+		}
+	}()
+}
+
 // runServer is a helper method that is responsible for starting the metrics server and handling shutdown signals.
 func runServer(ctx context.Context, cfg *config.Config, csp provider.Provider, log *slog.Logger) error {
+	startDebugServer(ctx, cfg, log)
+
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/", web.HomePageHandler(cfg.Server.Path)) // landing page


### PR DESCRIPTION
Adds a `--debug.address` flag that starts a separate HTTP server exposing Go's standard net/http/pprof endpoints. The server is disabled by default and only starts when the flag is set (e.g. --debug.address :6060).

The process already exports go_memstats_* via collectors.NewGoCollector(), which covers live heap and GC pressure as time-series metrics. The pprof server complements this: when those metrics signal a problem, the heap endpoint (/debug/pprof/heap) provides full allocation stack traces and can be used with go tool pprof to identify the source.

Per-collector allocation metrics were considered but rejected. `runtime.ReadMemStats` stops the world to gather stats, making it expensive to call on every scrape. More critically, providers fan out Collect() concurrently, so a before/after delta per collector would be corrupted by interleaved allocations from other collectors running in parallel.

Sample memory profiling:
```
heap profile: 9: 49888 [10: 49952] @ heap/1048576
0: 0 [0: 0] @ 0x1027cb8bc 0x10275a2ac 0x10275a2a1 0x10276020c 0x102c41c7c 0x1027a87a4 0x1027987d8 0x1027986bd 0x1027d6424
#	0x102c41c7b	github.com/aws/aws-sdk-go-v2/service/sts/internal/endpoints.init+0x179b	<redacted>/.gvm/pkgsets/go1.25.0/global/pkg/mod/github.com/aws/aws-sdk-go-v2/service/sts@v1.41.9/internal/endpoints/endpoints.go:459
#	0x1027a87a3	runtime.doInit1+0xc3							<redacted>/.gvm/gos/go1.25.0/src/runtime/proc.go:7656
#	0x1027987d7	runtime.doInit+0x337							<redacted>/.gvm/gos/go1.25.0/src/runtime/proc.go:7623
#	0x1027986bc	runtime.main+0x21c							<redacted>/.gvm/gos/go1.25.0/src/runtime/proc.go:256

0: 0 [1: 64] @ 0x102a54e18 0x102a580a8 0x102a652c0 0x102a652b9 0x102a65d10 0x102a65d01 0x103ed7cfc 0x1027a87a4 0x1027987d8 0x1027986bd 0x1027d6424
#	0x102a54e17	regexp/syntax.(*parser).push+0x2a7					<redacted>/.gvm/gos/go1.25.0/src/regexp/syntax/parse.go:325
#	0x102a580a7	regexp/syntax.parse+0x727						<redacted>/.gvm/gos/go1.25.0/src/regexp/syntax/parse.go:1071
#	0x102a652bf	regexp/syntax.Parse+0x2f						<redacted>/.gvm/gos/go1.25.0/src/regexp/syntax/parse.go:888
#	0x102a652b8	regexp.compile+0x28							<redacted>/.gvm/gos/go1.25.0/src/regexp/regexp.go:168
#	0x102a65d0f	regexp.Compile+0x2f							<redacted>/.gvm/gos/go1.25.0/src/regexp/regexp.go:131
#	0x102a65d00	regexp.MustCompile+0x20							<redacted>/.gvm/gos/go1.25.0/src/regexp/regexp.go:311
#	0x103ed7cfb	github.com/aws/aws-sdk-go-v2/service/rds/internal/endpoints.init+0x19b	<redacted>/.gvm/pkgsets/go1.25.0/global/pkg/mod/github.com/aws/aws-sdk-go-v2/service/rds@v1.116.3/internal/endpoints/endpoints.go:105
#	0x1027a87a3	runtime.doInit1+0xc3							<redacted>/.gvm/gos/go1.25.0/src/runtime/proc.go:7656
#	0x1027987d7	runtime.doInit+0x337							<redacted>/.gvm/gos/go1.25.0/src/runtime/proc.go:7623
#	0x1027986bc	runtime.main+0x21c	
```

Fixes https://github.com/grafana/deployment_tools/issues/497060