### PR TITLE
Azure: Add blob collector stub

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ cmd/exporter/exporter.go             # Entrypoint: flags, provider selection, HT
 pkg/provider/provider.go             # Provider, Collector, Registry interfaces
 pkg/aws/aws.go                       # AWS: S3, EC2, RDS, NATGATEWAY, ELB, VPC
 pkg/google/gcp.go                    # GCP: GCS, GKE, CLB, SQL, VPC
-pkg/azure/azure.go                   # Azure: AKS
+pkg/azure/azure.go                   # Azure: AKS, blob
 pkg/gatherer/gatherer.go             # Wraps Collect(): duration, errors, metadata metrics
 pkg/utils/consts.go                  # Shared metric suffixes, HoursInMonth, GenerateDesc()
 cmd/dashboards/main.go               # Dashboard generation (grafana-foundation-sdk)
@@ -58,7 +58,8 @@ Rule: Never push to `main`.
 ```bash
 go run cmd/exporter/exporter.go -provider gcp -project-id=$GCP_PROJECT_ID -gcp.services GKE,GCS
 go run cmd/exporter/exporter.go -provider aws -aws.profile $AWS_PROFILE -aws.services EC2,S3
-go run cmd/exporter/exporter.go -provider azure -azure.subscription-id $AZ_SUBSCRIPTION_ID
+go run cmd/exporter/exporter.go -provider azure -azure.subscription-id $AZ_SUBSCRIPTION_ID -azure.services AKS
+go run cmd/exporter/exporter.go -provider azure -azure.subscription-id $AZ_SUBSCRIPTION_ID -azure.services blob
 ```
 
 ### Adding a collector

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -224,19 +224,6 @@ func selectProvider(ctx context.Context, cfg *config.Config) (provider.Provider,
 
 type newProviderFunc[T any] func(context.Context, T) (provider.Provider, error)
 
-// expandAzureServices flattens repeated -azure.services values and comma-separated tokens (parity with AWS/GCP flags).
-func expandAzureServices(flags config.StringSliceFlag) []string {
-	var out []string
-	for _, s := range flags {
-		for _, part := range strings.Split(s, ",") {
-			if t := strings.TrimSpace(part); t != "" {
-				out = append(out, t)
-			}
-		}
-	}
-	return out
-}
-
 func selectProviderWith(
 	ctx context.Context,
 	cfg *config.Config,
@@ -256,7 +243,7 @@ func selectProviderWith(
 			Logger:           cfg.Logger,
 			SubscriptionId:   cfg.Providers.Azure.SubscriptionId,
 			ScrapeInterval:   cfg.Collector.ScrapeInterval,
-			Services:         expandAzureServices(cfg.Providers.Azure.Services),
+			Services:         strings.Split(cfg.Providers.Azure.Services.String(), ","),
 			CollectorTimeout: collectorTimeout,
 		})
 	case "aws":

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -75,7 +75,7 @@ func providerFlags(fs *flag.FlagSet, cfg *config.Config) {
 	fs.Var(config.NewDeprecatedStringSliceFlag(&cfg.Providers.GCP.Projects, &cfg.Providers.GCP.BucketProjectsDeprecated), "gcp.bucket-projects", "GCP project(s). (deprecated: use --gcp.projects instead)")
 	fs.Var(&cfg.Providers.AWS.Services, "aws.services", "AWS service(s).")
 	fs.Var(&cfg.Providers.AWS.ExcludeRegions, "aws.exclude-regions", "AWS region(s) to exclude from cost collection.")
-	fs.Var(&cfg.Providers.Azure.Services, "azure.services", "Azure service(s).")
+	fs.Var(&cfg.Providers.Azure.Services, "azure.services", "Azure service(s): AKS, blob (comma-separated and/or repeat flag; case-insensitive).")
 	fs.Var(&cfg.Providers.GCP.Services, "gcp.services", "GCP service(s).")
 	flag.StringVar(&cfg.Providers.AWS.Region, "aws.region", "", "AWS region")
 	flag.StringVar(&cfg.Providers.AWS.RoleARN, "aws.roleARN", "", "Optional AWS role ARN to assume for cross-account access.")
@@ -224,6 +224,19 @@ func selectProvider(ctx context.Context, cfg *config.Config) (provider.Provider,
 
 type newProviderFunc[T any] func(context.Context, T) (provider.Provider, error)
 
+// expandAzureServices flattens repeated -azure.services values and comma-separated tokens (parity with AWS/GCP flags).
+func expandAzureServices(flags config.StringSliceFlag) []string {
+	var out []string
+	for _, s := range flags {
+		for _, part := range strings.Split(s, ",") {
+			if t := strings.TrimSpace(part); t != "" {
+				out = append(out, t)
+			}
+		}
+	}
+	return out
+}
+
 func selectProviderWith(
 	ctx context.Context,
 	cfg *config.Config,
@@ -243,7 +256,7 @@ func selectProviderWith(
 			Logger:           cfg.Logger,
 			SubscriptionId:   cfg.Providers.Azure.SubscriptionId,
 			ScrapeInterval:   cfg.Collector.ScrapeInterval,
-			Services:         cfg.Providers.Azure.Services,
+			Services:         expandAzureServices(cfg.Providers.Azure.Services),
 			CollectorTimeout: collectorTimeout,
 		})
 	case "aws":

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -242,6 +242,7 @@ func selectProviderWith(
 		return newAzure(ctx, &azure.Config{
 			Logger:           cfg.Logger,
 			SubscriptionId:   cfg.Providers.Azure.SubscriptionId,
+			ScrapeInterval:   cfg.Collector.ScrapeInterval,
 			Services:         cfg.Providers.Azure.Services,
 			CollectorTimeout: collectorTimeout,
 		})

--- a/cmd/exporter/exporter_test.go
+++ b/cmd/exporter/exporter_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 	"time"
 
@@ -135,6 +136,27 @@ func Test_selectProvider(t *testing.T) {
 			}
 			if tc.wantCollectorTimeout != 0 && capturedTimeout != tc.wantCollectorTimeout {
 				t.Errorf("collectorTimeout = %v, want %v", capturedTimeout, tc.wantCollectorTimeout)
+			}
+		})
+	}
+}
+
+func Test_expandAzureServices(t *testing.T) {
+	tests := map[string]struct {
+		in   config.StringSliceFlag
+		want []string
+	}{
+		"empty":                       {in: nil, want: nil},
+		"single token":                {in: config.StringSliceFlag{"blob"}, want: []string{"blob"}},
+		"comma separated in one flag": {in: config.StringSliceFlag{"AKS, blob"}, want: []string{"AKS", "blob"}},
+		"repeat flag":                 {in: config.StringSliceFlag{"AKS", "blob"}, want: []string{"AKS", "blob"}},
+		"trims and skips empty":       {in: config.StringSliceFlag{" AKS , ", ""}, want: []string{"AKS"}},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := expandAzureServices(tt.in)
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("expandAzureServices(%#v) = %#v, want %#v", tt.in, got, tt.want)
 			}
 		})
 	}

--- a/cmd/exporter/exporter_test.go
+++ b/cmd/exporter/exporter_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"slices"
 	"testing"
 	"time"
 
@@ -136,27 +135,6 @@ func Test_selectProvider(t *testing.T) {
 			}
 			if tc.wantCollectorTimeout != 0 && capturedTimeout != tc.wantCollectorTimeout {
 				t.Errorf("collectorTimeout = %v, want %v", capturedTimeout, tc.wantCollectorTimeout)
-			}
-		})
-	}
-}
-
-func Test_expandAzureServices(t *testing.T) {
-	tests := map[string]struct {
-		in   config.StringSliceFlag
-		want []string
-	}{
-		"empty":                       {in: nil, want: nil},
-		"single token":                {in: config.StringSliceFlag{"blob"}, want: []string{"blob"}},
-		"comma separated in one flag": {in: config.StringSliceFlag{"AKS, blob"}, want: []string{"AKS", "blob"}},
-		"repeat flag":                 {in: config.StringSliceFlag{"AKS", "blob"}, want: []string{"AKS", "blob"}},
-		"trims and skips empty":       {in: config.StringSliceFlag{" AKS , ", ""}, want: []string{"AKS"}},
-	}
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			got := expandAzureServices(tt.in)
-			if !slices.Equal(got, tt.want) {
-				t.Fatalf("expandAzureServices(%#v) = %#v, want %#v", tt.in, got, tt.want)
 			}
 		})
 	}

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,6 @@
   - [Providers](metrics/providers.md)
   - **AWS:** [EC2](metrics/aws/ec2.md), [S3](metrics/aws/s3.md), [RDS](metrics/aws/rds.md), [MSK](metrics/aws/msk.md), [ELB](metrics/aws/elb.md), [NAT Gateway](metrics/aws/natgateway.md), [VPC](metrics/aws/vpc.md)
   - **GCP:** [GKE](metrics/gcp/gke.md), [GCS](metrics/gcp/gcs.md), [Cloud SQL](metrics/gcp/cloudsql.md), [Managed Kafka](metrics/gcp/managedkafka.md), [CLB](metrics/gcp/clb.md), [VPC](metrics/gcp/vpc.md)
-  - **Azure:** [AKS](metrics/azure/aks.md), [Blob](metrics/azure/blob.md)
+  - **Azure:** [AKS](metrics/azure/aks.md), [blob](metrics/azure/blob.md)
 - [Deploying](deploying/aws/README.md) - Run the exporter
   - [AWS](deploying/aws/README.md) — IRSA, Helm, cross-account access

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,6 @@
   - [Providers](metrics/providers.md)
   - **AWS:** [EC2](metrics/aws/ec2.md), [S3](metrics/aws/s3.md), [RDS](metrics/aws/rds.md), [MSK](metrics/aws/msk.md), [ELB](metrics/aws/elb.md), [NAT Gateway](metrics/aws/natgateway.md), [VPC](metrics/aws/vpc.md)
   - **GCP:** [GKE](metrics/gcp/gke.md), [GCS](metrics/gcp/gcs.md), [Cloud SQL](metrics/gcp/cloudsql.md), [Managed Kafka](metrics/gcp/managedkafka.md), [CLB](metrics/gcp/clb.md), [VPC](metrics/gcp/vpc.md)
-  - **Azure:** [AKS](metrics/azure/aks.md)
+  - **Azure:** [AKS](metrics/azure/aks.md), [Blob](metrics/azure/blob.md)
 - [Deploying](deploying/aws/README.md) - Run the exporter
   - [AWS](deploying/aws/README.md) — IRSA, Helm, cross-account access

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -22,4 +22,4 @@
 ## Azure Services
 
 - **[AKS](./azure/aks.md)** - Azure Kubernetes Service VM instances and managed disks
-- **[Blob](./azure/blob.md)** - Azure Blob Storage (stub; Cost Management integration planned)
+- **[Blob](./azure/blob.md)** - Azure Blob Storage (cost metrics registered; no series until Cost Management)

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -22,3 +22,4 @@
 ## Azure Services
 
 - **[AKS](./azure/aks.md)** - Azure Kubernetes Service VM instances and managed disks
+- **[Blob](./azure/blob.md)** - Azure Blob Storage (stub; Cost Management integration planned)

--- a/docs/metrics/azure/blob.md
+++ b/docs/metrics/azure/blob.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-The `BLOB` service is registered when you pass `BLOB` in `--azure.services`. The collector **does not query Azure Cost Management yet**. One storage cost `GaugeVec` is **registered** and appears in `Describe`, but **there are no samples** because **`Collect` does not call `Set`** until that integration exists.
+The `BLOB` service is registered when you pass `BLOB` in `--azure.services`. The collector **does not query Azure Cost Management yet**. The storage cost `GaugeVec` appears in `Describe` but is **not** `MustRegister`'d on the root registry (same pattern as `azure_aks`); **`Collect` forwards** `StorageGauge.Collect(ch)` to the parent Azure gatherer. **There are no samples** until **`Collect` calls `Set`** on label values (not implemented yet).
 
 ## Planned behavior (see issue #54):
 
@@ -20,6 +20,7 @@ The `BLOB` service is registered when you pass `BLOB` in `--azure.services`. The
 ### Provider operational metrics
 
 - **`cloudcost_exporter_collector_*` with `collector="azure_blob"`** — same mechanism as other Azure collectors (e.g. `azure_aks`) via `pkg/azure/azure.go` and the shared gatherer pattern.
+- **Registry:** Blob cost `GaugeVec`s are not registered separately on the Prometheus registry; `Describe` lists them for the parent Azure collector, and **`Collect` forwards** `StorageGauge.Collect(ch)` so metric descriptors are not duplicated.
 
 ## Cost metrics
 

--- a/docs/metrics/azure/blob.md
+++ b/docs/metrics/azure/blob.md
@@ -8,4 +8,4 @@ The collector defines a storage cost `GaugeVec` that the Azure provider includes
 
 | Metric name | Metric type | Description | Labels |
 |-------------|-------------|-------------|--------|
-| cloudcost_azure_blob_storage_by_location_usd_per_gibyte_hour | Gauge | Storage cost rate for Blob Storage by region and class. Cost represented in USD/(GiB*h) | |
+| cloudcost_azure_blob_storage_by_location_usd_per_gibyte_hour | Gauge | Storage cost rate for Blob Storage by region and class. Cost represented in USD/(GiB*h) | `region`=&lt;Azure region&gt; <br/> `class`=&lt;Azure Blob storage class or access tier&gt; |

--- a/docs/metrics/azure/blob.md
+++ b/docs/metrics/azure/blob.md
@@ -2,14 +2,14 @@
 
 ## Status
 
-The `BLOB` service is registered when you pass `BLOB` in `--azure.services`. The collector **does not query Azure Cost Management yet**. The storage cost `GaugeVec` appears in `Describe` but is **not** `MustRegister`'d on the root registry (same pattern as `azure_aks`); **`Collect` forwards** `StorageGauge.Collect(ch)` to the parent Azure gatherer. **There are no samples** until **`Collect` calls `Set`** on label values (not implemented yet).
+The Blob Collector is registered when you pass `blob` in `--azure.services` (matching is case-insensitive). The collector **does not query Azure Cost Management yet**. The storage cost `GaugeVec` appears in `Describe` but is **not** `MustRegister`'d on the root registry (same pattern as `azure_aks`); **`Collect` forwards** `StorageGauge.Collect(ch)` to the parent Azure gatherer. **There are no samples** until **`Collect` calls `Set`** on label values (not implemented yet).
 
 ## Planned behavior (see issue #54):
 
 ### Metric shape (AWS S3 and GCP GCS in this repo)
 
 - **Storage rate:** Same naming pattern as S3 and GCS: `storage_by_location_usd_per_gibyte_hour` under the service subsystem (here `azure_blob` → `cloudcost_azure_blob_storage_by_location_usd_per_gibyte_hour`). Implemented today as `cloudcost_aws_s3_*` in `pkg/aws/s3/s3.go` and `cloudcost_gcp_gcs_*` in `pkg/google/metrics/metrics.go`.
-- **Operations rate (optional):** S3 and GCS also define `operation_by_location_usd_per_krequest` (`pkg/aws/s3/s3.go`, `pkg/google/metrics/metrics.go`). **Not registered in the exporter yet** (see Planned future work under [Cost metrics](#cost-metrics)). A Blob collector may expose an analogous gauge when the chosen Azure dataset supports it.
+- **Operations rate (optional):** S3 and GCS also define `operation_by_location_usd_per_krequest` (`pkg/aws/s3/s3.go`, `pkg/google/metrics/metrics.go`). **Not registered in the exporter yet** (see Planned future work under [Cost metrics](#cost-metrics)). A Blob Collector may expose an analogous gauge when the chosen Azure dataset supports it.
 - **Labels:** S3 uses `region` and `class` for storage (and `tier` for operations); GCS uses `location` and `storage_class` (and operation class labels for ops). Azure label sets would follow whatever dimensions the Cost Management query returns; the above collectors show the cross-cloud “by location + storage class/tier” pattern only.
 
 ### Azure Cost Management

--- a/docs/metrics/azure/blob.md
+++ b/docs/metrics/azure/blob.md
@@ -1,31 +1,11 @@
 # Azure Blob Storage metrics
 
-## Status
+Pass `blob` in `--azure.services` to enable this collector. Matching is case-insensitive.
 
-The Blob Collector is registered when you pass `blob` in `--azure.services` (matching is case-insensitive). The collector **does not query Azure Cost Management yet**. The storage cost `GaugeVec` appears in `Describe` but is **not** `MustRegister`'d on the root registry (same pattern as `azure_aks`); **`Collect` forwards** `StorageGauge.Collect(ch)` to the parent Azure gatherer. **There are no samples** until **`Collect` calls `Set`** on label values (not implemented yet).
-
-## Planned behavior (see issue #54):
-
-### Metric shape (AWS S3 and GCP GCS in this repo)
-
-- **Storage rate:** Same naming pattern as S3 and GCS: `storage_by_location_usd_per_gibyte_hour` under the service subsystem (here `azure_blob` → `cloudcost_azure_blob_storage_by_location_usd_per_gibyte_hour`). Implemented today as `cloudcost_aws_s3_*` in `pkg/aws/s3/s3.go` and `cloudcost_gcp_gcs_*` in `pkg/google/metrics/metrics.go`.
-- **Operations rate (optional):** S3 and GCS also define `operation_by_location_usd_per_krequest` (`pkg/aws/s3/s3.go`, `pkg/google/metrics/metrics.go`). **Not registered in the exporter yet** (see Planned future work under [Cost metrics](#cost-metrics)). A Blob Collector may expose an analogous gauge when the chosen Azure dataset supports it.
-- **Labels:** S3 uses `region` and `class` for storage (and `tier` for operations); GCS uses `location` and `storage_class` (and operation class labels for ops). Azure label sets would follow whatever dimensions the Cost Management query returns; the above collectors show the cross-cloud “by location + storage class/tier” pattern only.
-
-### Azure Cost Management
-
-- **Query API:** Azure documentation mentions `POST https://management.azure.com/{scope}/providers/Microsoft.CostManagement/query` and states that `{scope}` includes **`/subscriptions/{subscriptionId}/`** for subscription scope. Sample responses in that snapshot include cost columns such as **`PreTaxCost`** alongside dimensions like **`ResourceLocation`** in example filters.
-- **Permissions:** Azure documentation states that you must have **Cost Management permissions at the appropriate scope** to use Cost Management APIs (the captured article links to Microsoft’s assign-access documentation for details). No specific Azure role name is asserted here.
-
-### Provider operational metrics
-
-- **`cloudcost_exporter_collector_*` with `collector="azure_blob"`** — same mechanism as other Azure collectors (e.g. `azure_aks`) via `pkg/azure/azure.go` and the shared gatherer pattern.
-- **Registry:** Blob cost `GaugeVec`s are not registered separately on the Prometheus registry; `Describe` lists them for the parent Azure collector, and **`Collect` forwards** `StorageGauge.Collect(ch)` so metric descriptors are not duplicated.
+The collector defines a storage cost `GaugeVec` that the Azure provider includes in its `Describe` and `Collect` fan-out (same gatherer pattern as `azure_aks`). The parent Azure collector forwards `StorageGauge.Collect(ch)` so blob cost metrics share one registration path with the rest of the Azure exporter. Scrape instrumentation publishes `cloudcost_exporter_collector_*` with label `collector="azure_blob"`.
 
 ## Cost metrics
 
-| Metric name | Type | Labels | Samples |
-|-------------|------|--------|---------|
-| `cloudcost_azure_blob_storage_by_location_usd_per_gibyte_hour` | Gauge | `region`, `class` | None; exporter does not populate this metric yet (no billing API calls in `Collect`) |
-
-**Planned future work:** `cloudcost_azure_blob_operation_by_location_usd_per_krequest` (Gauge; `region`, `class`, `tier`) — parity with S3/GCS operation metrics; commented out in `pkg/azure/blob/blob.go` until operation pricing is implemented. How we group cost rows into labels is TBD when we add the API integration.
+| Metric name | Metric type | Description | Labels |
+|-------------|-------------|-------------|--------|
+| cloudcost_azure_blob_storage_by_location_usd_per_gibyte_hour | Gauge | Storage cost rate for Blob Storage by region and class. Cost represented in USD/(GiB*h) | |

--- a/docs/metrics/azure/blob.md
+++ b/docs/metrics/azure/blob.md
@@ -1,0 +1,26 @@
+# Azure Blob Storage metrics
+
+## Status
+
+The `BLOB` service is registered when you pass `BLOB` in `--azure.services`. The collector is a **stub**: it does not call Azure APIs for cost data yet and emits **no** `cloudcost_azure_blob_*` cost gauges.
+
+## Planned behavior (see issue #54):
+
+### Metric shape (AWS S3 and GCP GCS in this repo)
+
+- **Storage rate:** Same naming pattern as S3 and GCS: `storage_by_location_usd_per_gibyte_hour` under the service subsystem (here `azure_blob` → `cloudcost_azure_blob_storage_by_location_usd_per_gibyte_hour`). Implemented today as `cloudcost_aws_s3_*` in `pkg/aws/s3/s3.go` and `cloudcost_gcp_gcs_*` in `pkg/google/metrics/metrics.go`.
+- **Operations rate (optional):** S3 and GCS also define `operation_by_location_usd_per_krequest` (`pkg/aws/s3/s3.go`, `pkg/google/metrics/metrics.go`). A Blob collector may expose an analogous gauge only if the chosen Azure dataset supports it.
+- **Labels:** S3 uses `region` and `class` for storage (and `tier` for operations); GCS uses `location` and `storage_class` (and operation class labels for ops). Azure label sets would follow whatever dimensions the Cost Management query returns; the above collectors show the cross-cloud “by location + storage class/tier” pattern only.
+
+### Azure Cost Management
+
+- **Query API:** Azure documentation mentions `POST https://management.azure.com/{scope}/providers/Microsoft.CostManagement/query` and states that `{scope}` includes **`/subscriptions/{subscriptionId}/`** for subscription scope. Sample responses in that snapshot include cost columns such as **`PreTaxCost`** alongside dimensions like **`ResourceLocation`** in example filters.
+- **Permissions:** Azure documentation states that you must have **Cost Management permissions at the appropriate scope** to use Cost Management APIs (the captured article links to Microsoft’s assign-access documentation for details). No specific Azure role name is asserted here.
+
+### Provider operational metrics
+
+- **`cloudcost_exporter_collector_*` with `collector="azure_blob"`** — same mechanism as other Azure collectors (e.g. `azure_aks`) via `pkg/azure/azure.go` and the shared gatherer pattern.
+
+## Cost metrics
+
+None yet.

--- a/docs/metrics/azure/blob.md
+++ b/docs/metrics/azure/blob.md
@@ -2,14 +2,14 @@
 
 ## Status
 
-The `BLOB` service is registered when you pass `BLOB` in `--azure.services`. The collector is a **stub**: it does not call Azure APIs for cost data yet and emits **no** `cloudcost_azure_blob_*` cost gauges.
+The `BLOB` service is registered when you pass `BLOB` in `--azure.services`. The collector **does not query Azure Cost Management yet**. One storage cost `GaugeVec` is **registered** and appears in `Describe`, but **there are no samples** because **`Collect` does not call `Set`** until that integration exists.
 
 ## Planned behavior (see issue #54):
 
 ### Metric shape (AWS S3 and GCP GCS in this repo)
 
 - **Storage rate:** Same naming pattern as S3 and GCS: `storage_by_location_usd_per_gibyte_hour` under the service subsystem (here `azure_blob` → `cloudcost_azure_blob_storage_by_location_usd_per_gibyte_hour`). Implemented today as `cloudcost_aws_s3_*` in `pkg/aws/s3/s3.go` and `cloudcost_gcp_gcs_*` in `pkg/google/metrics/metrics.go`.
-- **Operations rate (optional):** S3 and GCS also define `operation_by_location_usd_per_krequest` (`pkg/aws/s3/s3.go`, `pkg/google/metrics/metrics.go`). A Blob collector may expose an analogous gauge only if the chosen Azure dataset supports it.
+- **Operations rate (optional):** S3 and GCS also define `operation_by_location_usd_per_krequest` (`pkg/aws/s3/s3.go`, `pkg/google/metrics/metrics.go`). **Not registered in the exporter yet** (see Planned future work under [Cost metrics](#cost-metrics)). A Blob collector may expose an analogous gauge when the chosen Azure dataset supports it.
 - **Labels:** S3 uses `region` and `class` for storage (and `tier` for operations); GCS uses `location` and `storage_class` (and operation class labels for ops). Azure label sets would follow whatever dimensions the Cost Management query returns; the above collectors show the cross-cloud “by location + storage class/tier” pattern only.
 
 ### Azure Cost Management
@@ -23,4 +23,8 @@ The `BLOB` service is registered when you pass `BLOB` in `--azure.services`. The
 
 ## Cost metrics
 
-None yet.
+| Metric name | Type | Labels | Samples |
+|-------------|------|--------|---------|
+| `cloudcost_azure_blob_storage_by_location_usd_per_gibyte_hour` | Gauge | `region`, `class` | None; exporter does not populate this metric yet (no billing API calls in `Collect`) |
+
+**Planned future work:** `cloudcost_azure_blob_operation_by_location_usd_per_krequest` (Gauge; `region`, `class`, `tier`) — parity with S3/GCS operation metrics; commented out in `pkg/azure/blob/blob.go` until operation pricing is implemented. How we group cost rows into labels is TBD when we add the API integration.

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -66,6 +66,7 @@ type Config struct {
 	Region string
 
 	SubscriptionId string
+	ScrapeInterval time.Duration
 
 	CollectorTimeout time.Duration
 	Services         []string
@@ -104,7 +105,9 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 			collectors = append(collectors, collector)
 		case "BLOB":
 			collector, err := blob.New(&blob.Config{
-				Logger: logger,
+				Logger:         logger,
+				SubscriptionId: config.SubscriptionId,
+				ScrapeInterval: config.ScrapeInterval,
 			})
 			if err != nil {
 				return nil, err

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/cloudcost-exporter/pkg/azure/aks"
+	"github.com/grafana/cloudcost-exporter/pkg/azure/blob"
 	"github.com/grafana/cloudcost-exporter/pkg/azure/client"
 	"github.com/grafana/cloudcost-exporter/pkg/collectormetrics"
 	"github.com/grafana/cloudcost-exporter/pkg/provider"
@@ -97,6 +98,14 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 			collector, err := aks.New(ctx, &aks.Config{
 				Logger: logger,
 			}, azClientWrapper)
+			if err != nil {
+				return nil, err
+			}
+			collectors = append(collectors, collector)
+		case "BLOB":
+			collector, err := blob.New(&blob.Config{
+				Logger: logger,
+			})
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -101,7 +101,10 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 				Logger: logger,
 			}, azClientWrapper)
 			if err != nil {
-				return nil, err
+				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
+					slog.String("service", svc),
+					slog.String("message", err.Error()))
+				continue
 			}
 			collectors = append(collectors, collector)
 		case strings.EqualFold(svc, "blob"):
@@ -111,7 +114,10 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 				ScrapeInterval: config.ScrapeInterval,
 			})
 			if err != nil {
-				return nil, err
+				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
+					slog.String("service", svc),
+					slog.String("message", err.Error()))
+				continue
 			}
 			collectors = append(collectors, collector)
 		default:

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -95,6 +95,9 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 	// Collector Registration (--azure.services matching is case-insensitive).
 	for _, svc := range config.Services {
 		svc = strings.TrimSpace(svc)
+		if svc == "" {
+			continue
+		}
 		switch {
 		case strings.EqualFold(svc, "AKS"):
 			collector, err := aks.New(ctx, &aks.Config{

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -92,10 +92,11 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 		return nil, err
 	}
 
-	// Collector Registration
+	// Collector Registration (--azure.services matching is case-insensitive).
 	for _, svc := range config.Services {
-		switch strings.ToUpper(svc) {
-		case "AKS":
+		svc = strings.TrimSpace(svc)
+		switch {
+		case strings.EqualFold(svc, "AKS"):
 			collector, err := aks.New(ctx, &aks.Config{
 				Logger: logger,
 			}, azClientWrapper)
@@ -103,7 +104,7 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 				return nil, err
 			}
 			collectors = append(collectors, collector)
-		case "BLOB":
+		case strings.EqualFold(svc, "blob"):
 			collector, err := blob.New(&blob.Config{
 				Logger:         logger,
 				SubscriptionId: config.SubscriptionId,

--- a/pkg/azure/blob/blob.go
+++ b/pkg/azure/blob/blob.go
@@ -1,0 +1,51 @@
+package blob
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/grafana/cloudcost-exporter/pkg/provider"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const subsystem = "azure_blob"
+
+// Collector implements provider.Collector for Azure Blob Storage cost metrics.
+// Cost Management integration is not implemented yet; Collect emits no cost series.
+type Collector struct {
+	logger *slog.Logger
+}
+
+// Config holds settings for the blob collector.
+type Config struct {
+	Logger *slog.Logger
+}
+
+// New builds a blob collector. It does not call Azure APIs.
+func New(cfg *Config) (*Collector, error) {
+	return &Collector{
+		logger: cfg.Logger.With("collector", "blob"),
+	}, nil
+}
+
+// Collect satisfies provider.Collector. No Prometheus samples are sent until Cost Management is wired in.
+func (c *Collector) Collect(ctx context.Context, _ chan<- prometheus.Metric) error {
+	c.logger.LogAttrs(ctx, slog.LevelInfo, "collecting metrics")
+	return nil
+}
+
+// Describe satisfies provider.Collector. No metric descriptors until cost gauges are implemented.
+func (c *Collector) Describe(_ chan<- *prometheus.Desc) error {
+	return nil
+}
+
+// Name returns the collector subsystem name for operational metrics.
+func (c *Collector) Name() string {
+	return subsystem
+}
+
+// Register satisfies provider.Collector.
+func (c *Collector) Register(_ provider.Registry) error {
+	c.logger.LogAttrs(context.Background(), slog.LevelInfo, "registering collector")
+	return nil
+}

--- a/pkg/azure/blob/blob.go
+++ b/pkg/azure/blob/blob.go
@@ -3,6 +3,7 @@ package blob
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"github.com/grafana/cloudcost-exporter/pkg/provider"
 	"github.com/prometheus/client_golang/prometheus"
@@ -43,20 +44,30 @@ func newMetrics() metrics {
 // Collector implements provider.Collector for Azure Blob Storage cost metrics.
 // Cost Management integration is not implemented yet; registered metrics emit no series until Collect sets label values.
 type Collector struct {
-	logger  *slog.Logger
-	metrics metrics
+	logger         *slog.Logger
+	metrics        metrics
+	subscriptionID string
+	scrapeInterval time.Duration
 }
 
 // Config holds settings for the blob collector.
 type Config struct {
-	Logger *slog.Logger
+	Logger         *slog.Logger
+	SubscriptionId string
+	ScrapeInterval time.Duration
 }
 
-// New builds a blob collector. It does not call Azure APIs.
+// New builds a blob collector. It does not call Azure APIs yet; subscription and interval are stored for Cost Management integration.
 func New(cfg *Config) (*Collector, error) {
+	interval := cfg.ScrapeInterval
+	if interval <= 0 {
+		interval = time.Hour
+	}
 	return &Collector{
-		logger:  cfg.Logger.With("collector", "blob"),
-		metrics: newMetrics(),
+		logger:         cfg.Logger.With("collector", "blob"),
+		metrics:        newMetrics(),
+		subscriptionID: cfg.SubscriptionId,
+		scrapeInterval: interval,
 	}, nil
 }
 

--- a/pkg/azure/blob/blob.go
+++ b/pkg/azure/blob/blob.go
@@ -25,7 +25,7 @@ func newMetrics() metrics {
 	m := metrics{
 		StorageGauge: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: prometheus.BuildFQName(cloudcost_exporter.MetricPrefix, subsystem, "storage_by_location_usd_per_gibyte_hour"),
-			Help: "Storage cost of Blob objects by region and class. Cost represented in USD/(GiB*h). No samples until Cost Management is integrated.",
+			Help: "Storage cost of blob objects by region and class. Cost represented in USD/(GiB*h). No samples until Cost Management is integrated.",
 		},
 			[]string{"region", "class"},
 		),
@@ -34,7 +34,7 @@ func newMetrics() metrics {
 	// Planned future work: register operation cost per 1k requests (labels region, class, tier) when Cost Management dimensions support it.
 	// m.OperationsGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	// 	Name: prometheus.BuildFQName(cloudcost_exporter.MetricPrefix, subsystem, "operation_by_location_usd_per_krequest"),
-	// 	Help: "Operation cost of Blob objects by region, class, and tier. Cost represented in USD/(1k req). No samples until Cost Management is integrated.",
+	// 	Help: "Operation cost of blob objects by region, class, and tier. Cost represented in USD/(1k req). No samples until Cost Management is integrated.",
 	// },
 	// 	[]string{"region", "class", "tier"},
 	// )

--- a/pkg/azure/blob/blob.go
+++ b/pkg/azure/blob/blob.go
@@ -13,7 +13,8 @@ import (
 
 const subsystem = "azure_blob"
 
-// metrics holds Prometheus collectors for blob cost rates. Vectors stay empty until Cost Management data exists (no Set calls yet).
+// metrics holds Prometheus collectors for blob cost rates. Vectors are not registered on the root registry;
+// Azure's top-level Collector gathers them via Collect → GaugeVec.Collect (same pattern as pkg/azure/aks).
 type metrics struct {
 	StorageGauge *prometheus.GaugeVec
 	// Planned future work: operation request rate (parity with S3/GCS cloudcost_*_operation_by_location_usd_per_krequest).
@@ -42,7 +43,7 @@ func newMetrics() metrics {
 }
 
 // Collector implements provider.Collector for Azure Blob Storage cost metrics.
-// Cost Management integration is not implemented yet; registered metrics emit no series until Collect sets label values.
+// Cost Management integration is not implemented yet; there are no labeled series until Collect calls Set on the vec.
 type Collector struct {
 	logger         *slog.Logger
 	metrics        metrics
@@ -71,9 +72,10 @@ func New(cfg *Config) (*Collector, error) {
 	}, nil
 }
 
-// Collect satisfies provider.Collector. Does not call Set on cost vectors yet (no labeled series).
-func (c *Collector) Collect(ctx context.Context, _ chan<- prometheus.Metric) error {
+// Collect satisfies provider.Collector. Does not call Set on cost vectors yet; still forwards the vec on ch for the parent gatherer.
+func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
 	c.logger.LogAttrs(ctx, slog.LevelInfo, "collecting metrics")
+	c.metrics.StorageGauge.Collect(ch)
 	return nil
 }
 
@@ -89,10 +91,9 @@ func (c *Collector) Name() string {
 	return subsystem
 }
 
-// Register satisfies provider.Collector.
-func (c *Collector) Register(registry provider.Registry) error {
-	registry.MustRegister(c.metrics.StorageGauge)
-	// Planned future work: registry.MustRegister(c.metrics.OperationsGauge)
+// Register satisfies provider.Collector. Does not register cost metrics on the registry (avoids duplicate Desc
+// with Azure's Describe fan-out; metrics are collected via Collect → StorageGauge.Collect).
+func (c *Collector) Register(_ provider.Registry) error {
 	c.logger.LogAttrs(context.Background(), slog.LevelInfo, "registering collector")
 	return nil
 }

--- a/pkg/azure/blob/blob.go
+++ b/pkg/azure/blob/blob.go
@@ -6,14 +6,45 @@ import (
 
 	"github.com/grafana/cloudcost-exporter/pkg/provider"
 	"github.com/prometheus/client_golang/prometheus"
+
+	cloudcost_exporter "github.com/grafana/cloudcost-exporter"
 )
 
 const subsystem = "azure_blob"
 
+// metrics holds Prometheus collectors for blob cost rates. Vectors stay empty until Cost Management data exists (no Set calls yet).
+type metrics struct {
+	StorageGauge *prometheus.GaugeVec
+	// Planned future work: operation request rate (parity with S3/GCS cloudcost_*_operation_by_location_usd_per_krequest).
+	// OperationsGauge *prometheus.GaugeVec
+}
+
+func newMetrics() metrics {
+	m := metrics{
+		StorageGauge: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: prometheus.BuildFQName(cloudcost_exporter.MetricPrefix, subsystem, "storage_by_location_usd_per_gibyte_hour"),
+			Help: "Storage cost of Blob objects by region and class. Cost represented in USD/(GiB*h). No samples until Cost Management is integrated.",
+		},
+			[]string{"region", "class"},
+		),
+	}
+
+	// Planned future work: register operation cost per 1k requests (labels region, class, tier) when Cost Management dimensions support it.
+	// m.OperationsGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	// 	Name: prometheus.BuildFQName(cloudcost_exporter.MetricPrefix, subsystem, "operation_by_location_usd_per_krequest"),
+	// 	Help: "Operation cost of Blob objects by region, class, and tier. Cost represented in USD/(1k req). No samples until Cost Management is integrated.",
+	// },
+	// 	[]string{"region", "class", "tier"},
+	// )
+
+	return m
+}
+
 // Collector implements provider.Collector for Azure Blob Storage cost metrics.
-// Cost Management integration is not implemented yet; Collect emits no cost series.
+// Cost Management integration is not implemented yet; registered metrics emit no series until Collect sets label values.
 type Collector struct {
-	logger *slog.Logger
+	logger  *slog.Logger
+	metrics metrics
 }
 
 // Config holds settings for the blob collector.
@@ -24,18 +55,21 @@ type Config struct {
 // New builds a blob collector. It does not call Azure APIs.
 func New(cfg *Config) (*Collector, error) {
 	return &Collector{
-		logger: cfg.Logger.With("collector", "blob"),
+		logger:  cfg.Logger.With("collector", "blob"),
+		metrics: newMetrics(),
 	}, nil
 }
 
-// Collect satisfies provider.Collector. No Prometheus samples are sent until Cost Management is wired in.
+// Collect satisfies provider.Collector. Does not call Set on cost vectors yet (no labeled series).
 func (c *Collector) Collect(ctx context.Context, _ chan<- prometheus.Metric) error {
 	c.logger.LogAttrs(ctx, slog.LevelInfo, "collecting metrics")
 	return nil
 }
 
-// Describe satisfies provider.Collector. No metric descriptors until cost gauges are implemented.
-func (c *Collector) Describe(_ chan<- *prometheus.Desc) error {
+// Describe satisfies provider.Collector.
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
+	c.metrics.StorageGauge.Describe(ch)
+	// Planned future work: c.metrics.OperationsGauge.Describe(ch)
 	return nil
 }
 
@@ -45,7 +79,9 @@ func (c *Collector) Name() string {
 }
 
 // Register satisfies provider.Collector.
-func (c *Collector) Register(_ provider.Registry) error {
+func (c *Collector) Register(registry provider.Registry) error {
+	registry.MustRegister(c.metrics.StorageGauge)
+	// Planned future work: registry.MustRegister(c.metrics.OperationsGauge)
 	c.logger.LogAttrs(context.Background(), slog.LevelInfo, "registering collector")
 	return nil
 }

--- a/pkg/azure/blob/blob.go
+++ b/pkg/azure/blob/blob.go
@@ -17,8 +17,6 @@ const subsystem = "azure_blob"
 // Azure's top-level Collector gathers them via Collect → GaugeVec.Collect (same pattern as pkg/azure/aks).
 type metrics struct {
 	StorageGauge *prometheus.GaugeVec
-	// Planned future work: operation request rate (parity with S3/GCS cloudcost_*_operation_by_location_usd_per_krequest).
-	// OperationsGauge *prometheus.GaugeVec
 }
 
 func newMetrics() metrics {
@@ -30,14 +28,6 @@ func newMetrics() metrics {
 			[]string{"region", "class"},
 		),
 	}
-
-	// Planned future work: register operation cost per 1k requests (labels region, class, tier) when Cost Management dimensions support it.
-	// m.OperationsGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-	// 	Name: prometheus.BuildFQName(cloudcost_exporter.MetricPrefix, subsystem, "operation_by_location_usd_per_krequest"),
-	// 	Help: "Operation cost of blob objects by region, class, and tier. Cost represented in USD/(1k req). No samples until Cost Management is integrated.",
-	// },
-	// 	[]string{"region", "class", "tier"},
-	// )
 
 	return m
 }
@@ -82,7 +72,6 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 // Describe satisfies provider.Collector.
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
 	c.metrics.StorageGauge.Describe(ch)
-	// Planned future work: c.metrics.OperationsGauge.Describe(ch)
 	return nil
 }
 

--- a/pkg/azure/blob/blob_test.go
+++ b/pkg/azure/blob/blob_test.go
@@ -37,7 +37,6 @@ func TestCollector_Describe(t *testing.T) {
 	assert.Contains(t, joined, prefix+"storage_by_location_usd_per_gibyte_hour")
 }
 
-// #TODO: remove when we have more functionality in place
 func TestCollector_Register(t *testing.T) {
 	c, err := New(&Config{Logger: testLogger})
 	require.NoError(t, err)
@@ -45,7 +44,6 @@ func TestCollector_Register(t *testing.T) {
 	require.NoError(t, c.Register(nil))
 }
 
-// #TODO: remove when we have more functionality in place
 func TestCollector_Collect_forwardsStorageGauge(t *testing.T) {
 	c, err := New(&Config{Logger: testLogger})
 	require.NoError(t, err)

--- a/pkg/azure/blob/blob_test.go
+++ b/pkg/azure/blob/blob_test.go
@@ -1,22 +1,25 @@
 package blob
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
-	mock_provider "github.com/grafana/cloudcost-exporter/pkg/provider/mocks"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
 
 	cloudcost_exporter "github.com/grafana/cloudcost-exporter"
 )
 
 var testLogger = slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+func testCollectSink() chan prometheus.Metric {
+	return make(chan prometheus.Metric, 8)
+}
 
 func TestCollector_Describe(t *testing.T) {
 	c, err := New(&Config{Logger: testLogger})
@@ -35,14 +38,17 @@ func TestCollector_Describe(t *testing.T) {
 }
 
 func TestCollector_Register(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
-	reg := mock_provider.NewMockRegistry(ctrl)
-	reg.EXPECT().MustRegister(gomock.Any()).Times(1)
-
 	c, err := New(&Config{Logger: testLogger})
-	assert.NoError(t, err)
-	assert.NoError(t, c.Register(reg))
+	require.NoError(t, err)
+	// Register does not call registry.MustRegister on cost metrics (AKS pattern).
+	require.NoError(t, c.Register(nil))
+}
+
+func TestCollector_Collect_forwardsStorageGauge(t *testing.T) {
+	c, err := New(&Config{Logger: testLogger})
+	require.NoError(t, err)
+	ctx := context.Background()
+	require.NoError(t, c.Collect(ctx, testCollectSink()))
 }
 
 func TestNew_configPlumbing(t *testing.T) {

--- a/pkg/azure/blob/blob_test.go
+++ b/pkg/azure/blob/blob_test.go
@@ -1,0 +1,45 @@
+package blob
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	mock_provider "github.com/grafana/cloudcost-exporter/pkg/provider/mocks"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	cloudcost_exporter "github.com/grafana/cloudcost-exporter"
+)
+
+var testLogger = slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+func TestCollector_Describe(t *testing.T) {
+	c, err := New(&Config{Logger: testLogger})
+	require.NoError(t, err)
+	ch := make(chan *prometheus.Desc, 4)
+	require.NoError(t, c.Describe(ch))
+	close(ch)
+	var got []string
+	for d := range ch {
+		got = append(got, d.String())
+	}
+	require.Len(t, got, 1)
+	joined := strings.Join(got, " ")
+	prefix := cloudcost_exporter.MetricPrefix + "_azure_blob_"
+	assert.Contains(t, joined, prefix+"storage_by_location_usd_per_gibyte_hour")
+}
+
+func TestCollector_Register(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	reg := mock_provider.NewMockRegistry(ctrl)
+	reg.EXPECT().MustRegister(gomock.Any()).Times(1)
+
+	c, err := New(&Config{Logger: testLogger})
+	assert.NoError(t, err)
+	assert.NoError(t, c.Register(reg))
+}

--- a/pkg/azure/blob/blob_test.go
+++ b/pkg/azure/blob/blob_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	mock_provider "github.com/grafana/cloudcost-exporter/pkg/provider/mocks"
 	"github.com/prometheus/client_golang/prometheus"
@@ -42,4 +43,36 @@ func TestCollector_Register(t *testing.T) {
 	c, err := New(&Config{Logger: testLogger})
 	assert.NoError(t, err)
 	assert.NoError(t, c.Register(reg))
+}
+
+func TestNew_configPlumbing(t *testing.T) {
+	const subUUID = "11111111-1111-1111-1111-111111111111"
+	tests := map[string]struct {
+		subscriptionID string
+		scrapeInterval time.Duration
+		wantInterval   time.Duration
+	}{
+		"zero scrape interval defaults to one hour": {
+			subscriptionID: "sub-1",
+			scrapeInterval: 0,
+			wantInterval:   time.Hour,
+		},
+		"explicit subscription and interval": {
+			subscriptionID: subUUID,
+			scrapeInterval: 30 * time.Minute,
+			wantInterval:   30 * time.Minute,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			c, err := New(&Config{
+				Logger:         testLogger,
+				SubscriptionId: tt.subscriptionID,
+				ScrapeInterval: tt.scrapeInterval,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.subscriptionID, c.subscriptionID)
+			assert.Equal(t, tt.wantInterval, c.scrapeInterval)
+		})
+	}
 }

--- a/pkg/azure/blob/blob_test.go
+++ b/pkg/azure/blob/blob_test.go
@@ -37,6 +37,7 @@ func TestCollector_Describe(t *testing.T) {
 	assert.Contains(t, joined, prefix+"storage_by_location_usd_per_gibyte_hour")
 }
 
+// #TODO: remove when we have more functionality in place
 func TestCollector_Register(t *testing.T) {
 	c, err := New(&Config{Logger: testLogger})
 	require.NoError(t, err)
@@ -44,6 +45,7 @@ func TestCollector_Register(t *testing.T) {
 	require.NoError(t, c.Register(nil))
 }
 
+// #TODO: remove when we have more functionality in place
 func TestCollector_Collect_forwardsStorageGauge(t *testing.T) {
 	c, err := New(&Config{Logger: testLogger})
 	require.NoError(t, err)


### PR DESCRIPTION
For https://github.com/grafana/cloudcost-exporter/issues/54

Adds an Azure blob cost collector behind `-azure.services blob`, including metrics wiring that follows the same gatherer pattern as AKS (cost vec collected via Collect rather than separate registration). Azure startup now skips collectors that fail to construct—logging the error and continuing—matching AWS behavior so one bad service does not stop the whole provider.

How to check it locally:

First run the exporter:

```
go run ./cmd/exporter/exporter.go \
  -provider azure \
  -azure.subscription-id "$(az account show --query id -o tsv)" \
  -azure.services blob \
  -log.level=info \
  -log.type=text
```

Then scrape the metrics:
```
curl -s localhost:8080/metrics | grep -E 'azure_blob|collector='
```