### PR TITLE
maint: Standardize Collector Config Structs, Constructors, and Error Handling

### DIFF
--- a/cmd/exporter/config/config.go
+++ b/cmd/exporter/config/config.go
@@ -25,7 +25,7 @@ type Config struct {
 		}
 		Azure struct {
 			Services       StringSliceFlag
-			SubscriptionId string
+			SubscriptionID string
 			Region         string
 		}
 	}

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -81,7 +81,7 @@ func providerFlags(fs *flag.FlagSet, cfg *config.Config) {
 	flag.StringVar(&cfg.Providers.AWS.RoleARN, "aws.roleARN", "", "Optional AWS role ARN to assume for cross-account access.")
 	// TODO - PUT PROJECT-ID UNDER GCP
 	flag.StringVar(&cfg.ProjectID, "project-id", "", "Project ID to target.")
-	flag.StringVar(&cfg.Providers.Azure.SubscriptionId, "azure.subscription-id", "", "Azure subscription ID to pull data from.")
+	flag.StringVar(&cfg.Providers.Azure.SubscriptionID, "azure.subscription-id", "", "Azure subscription ID to pull data from.")
 	flag.IntVar(&cfg.Providers.GCP.DefaultGCSDiscount, "gcp.default-discount", 19, "GCP default discount")
 }
 
@@ -241,7 +241,7 @@ func selectProviderWith(
 	case "azure":
 		return newAzure(ctx, &azure.Config{
 			Logger:           cfg.Logger,
-			SubscriptionId:   cfg.Providers.Azure.SubscriptionId,
+			SubscriptionID:   cfg.Providers.Azure.SubscriptionID,
 			ScrapeInterval:   cfg.Collector.ScrapeInterval,
 			Services:         strings.Split(cfg.Providers.Azure.Services.String(), ","),
 			CollectorTimeout: collectorTimeout,

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -242,11 +242,11 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 				PricingService: awsPricing.NewFromConfig(pricingConfig),
 			})
 			collector, err := elb.New(ctx, &elb.Config{
-				Regions:        regions,
-				PricingClient:  awsELBPricingClient,
-				RegionMap:      regionClients,
-				Logger:         logger,
-				AccountID:      config.AccountID,
+				Regions:       regions,
+				PricingClient: awsELBPricingClient,
+				RegionMap:     regionClients,
+				Logger:        logger,
+				AccountID:     config.AccountID,
 			})
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -160,8 +160,7 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 			collector, err := s3.New(ctx, &s3.Config{
 				ScrapeInterval: config.ScrapeInterval,
 				AccountID:      config.AccountID,
-				Logger:         logger,
-			}, awsClient)
+			}, logger, awsClient)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
 					slog.String("service", service),
@@ -172,11 +171,10 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 		case serviceEC2:
 			collector, err := ec2Collector.New(ctx, &ec2Collector.Config{
 				Regions:        regions,
-				Logger:         logger,
 				ScrapeInterval: config.ScrapeInterval,
 				RegionMap:      regionClients,
 				AccountID:      config.AccountID,
-			})
+			}, logger)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
 					slog.String("service", service),
@@ -204,8 +202,7 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 				RegionMap:      regionClients,
 				Client:         awsRDSClient,
 				AccountID:      config.AccountID,
-				Logger:         logger,
-			})
+			}, logger)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
 					slog.String("service", service),
@@ -216,11 +213,10 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 		case serviceNATGW:
 			collector, err := awsgwnat.New(ctx, &awsgwnat.Config{
 				ScrapeInterval: config.ScrapeInterval,
-				Logger:         logger,
 				Regions:        regions,
 				RegionMap:      regionClients,
 				AccountID:      config.AccountID,
-			})
+			}, logger)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
 					slog.String("service", service),
@@ -246,9 +242,8 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 				PricingClient:  awsELBPricingClient,
 				RegionMap:      regionClients,
 				ScrapeInterval: config.ScrapeInterval,
-				Logger:         logger,
 				AccountID:      config.AccountID,
-			})
+			}, logger)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
 					slog.String("service", service),
@@ -272,11 +267,10 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 			})
 			collector, err := awsvpc.New(ctx, &awsvpc.Config{
 				ScrapeInterval: config.ScrapeInterval,
-				Logger:         logger,
 				Regions:        regions,
 				Client:         awsVPCClient,
 				AccountID:      config.AccountID,
-			})
+			}, logger)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
 					slog.String("service", service),
@@ -292,9 +286,8 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 				Regions:   regions,
 				RegionMap: regionClients,
 				Client:    awsMSKClient,
-				Logger:    logger,
 				AccountID: config.AccountID,
-			})
+			}, logger)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
 					slog.String("service", service),

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -235,7 +235,7 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 				continue
 			}
 			awsELBPricingClient := client.NewAWSClient(client.Config{
-				PricingService: awsPricing.NewFromConfig(pricingConfig),
+				PricingService: awsPricing.NewFromConfig(elbPricingConfig),
 			})
 			collector, err := elb.New(ctx, &elb.Config{
 				Regions:        regions,

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -181,6 +181,15 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 			}
 			collectors = append(collectors, collector)
 		case serviceRDS:
+			// pricing API for RDS client needs to use always the same region
+			// as for RDS , the pricing data is only available in the us-east-1
+			pricingConfig, err := createAWSConfig(ctx, "us-east-1", config.Profile, config.RoleARN)
+			if err != nil {
+				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
+					slog.String("service", service),
+					slog.String("message", err.Error()))
+				continue
+			}
 			awsRDSClient := client.NewAWSClient(client.Config{
 				PricingService: awsPricing.NewFromConfig(pricingConfig),
 				RDSService:     rds.NewFromConfig(awsConfig),
@@ -222,6 +231,15 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 			})
 			collectors = append(collectors, collector)
 		case serviceVPC:
+			// pricing API for VPC client needs to use always the same region
+			// as for VPC, the pricing data is only available in the us-east-1
+			pricingConfig, err := createAWSConfig(ctx, "us-east-1", config.Profile, config.RoleARN)
+			if err != nil {
+				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
+					slog.String("service", service),
+					slog.String("message", err.Error()))
+				continue
+			}
 			awsVPCClient := client.NewAWSClient(client.Config{
 				PricingService: awsPricing.NewFromConfig(pricingConfig),
 				EC2Service:     ec2.NewFromConfig(pricingConfig),

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -184,7 +184,7 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 			collectors = append(collectors, collector)
 		case serviceRDS:
 			// pricing API for RDS client needs to use always the same region
-			// as for RDS , the pricing data is only available in the us-east-1
+			// as for RDS, the pricing data is only available in the us-east-1
 			pricingConfig, err := createAWSConfig(ctx, "us-east-1", config.Profile, config.RoleARN)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -157,7 +157,11 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 
 		switch service {
 		case serviceS3:
-			collector, err := s3.New(ctx, config.ScrapeInterval, awsClient, config.AccountID)
+			collector, err := s3.New(ctx, &s3.Config{
+				ScrapeInterval: config.ScrapeInterval,
+				AccountID:      config.AccountID,
+				Logger:         logger,
+			}, awsClient)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
 					slog.String("service", service),
@@ -194,13 +198,20 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 				PricingService: awsPricing.NewFromConfig(pricingConfig),
 				RDSService:     rds.NewFromConfig(awsConfig),
 			})
-			collector := rdsCollector.New(&rdsCollector.Config{
+			collector, err := rdsCollector.New(ctx, &rdsCollector.Config{
 				ScrapeInterval: config.ScrapeInterval,
 				Regions:        regions,
 				RegionMap:      regionClients,
 				Client:         awsRDSClient,
 				AccountID:      config.AccountID,
+				Logger:         logger,
 			})
+			if err != nil {
+				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
+					slog.String("service", service),
+					slog.String("message", err.Error()))
+				continue
+			}
 			collectors = append(collectors, collector)
 		case serviceNATGW:
 			collector, err := awsgwnat.New(ctx, &awsgwnat.Config{
@@ -218,17 +229,31 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 			}
 			collectors = append(collectors, collector)
 		case serviceELB:
+			// pricing API for ELB client needs to use always the same region
+			// as the pricing data is only available in us-east-1
+			elbPricingConfig, err := createAWSConfig(ctx, "us-east-1", config.Profile, config.RoleARN)
+			if err != nil {
+				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
+					slog.String("service", service),
+					slog.String("message", err.Error()))
+				continue
+			}
 			awsELBPricingClient := client.NewAWSClient(client.Config{
 				PricingService: awsPricing.NewFromConfig(pricingConfig),
 			})
-			collector := elb.New(&elb.Config{
+			collector, err := elb.New(ctx, &elb.Config{
 				Regions:        regions,
 				PricingClient:  awsELBPricingClient,
-				RegionClients:  regionClients,
-				ScrapeInterval: config.ScrapeInterval,
+				RegionMap:      regionClients,
 				Logger:         logger,
 				AccountID:      config.AccountID,
 			})
+			if err != nil {
+				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
+					slog.String("service", service),
+					slog.String("message", err.Error()))
+				continue
+			}
 			collectors = append(collectors, collector)
 		case serviceVPC:
 			// pricing API for VPC client needs to use always the same region

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -242,11 +242,12 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 				PricingService: awsPricing.NewFromConfig(pricingConfig),
 			})
 			collector, err := elb.New(ctx, &elb.Config{
-				Regions:       regions,
-				PricingClient: awsELBPricingClient,
-				RegionMap:     regionClients,
-				Logger:        logger,
-				AccountID:     config.AccountID,
+				Regions:        regions,
+				PricingClient:  awsELBPricingClient,
+				RegionMap:      regionClients,
+				ScrapeInterval: config.ScrapeInterval,
+				Logger:         logger,
+				AccountID:      config.AccountID,
 			})
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",

--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -76,14 +76,13 @@ type Collector struct {
 type Config struct {
 	ScrapeInterval time.Duration
 	Regions        []ec2Types.Region
-	Logger         *slog.Logger
 	RegionMap      map[string]client.Client
 	AccountID      string
 }
 
 // New creates an ec2 collector
-func New(ctx context.Context, config *Config) (*Collector, error) {
-	logger := config.Logger.With("collector", "ec2")
+func New(ctx context.Context, config *Config, logger *slog.Logger) (*Collector, error) {
+	logger = logger.With("collector", "ec2")
 	computeMap := NewComputePricingMap(logger, config)
 	storageMap := NewStoragePricingMap(logger, config)
 

--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -83,7 +83,7 @@ type Config struct {
 
 // New creates an ec2 collector
 func New(ctx context.Context, config *Config) (*Collector, error) {
-	logger := config.Logger.With("logger", "ec2")
+	logger := config.Logger.With("collector", "ec2")
 	computeMap := NewComputePricingMap(logger, config)
 	storageMap := NewStoragePricingMap(logger, config)
 

--- a/pkg/aws/ec2/ec2_test.go
+++ b/pkg/aws/ec2/ec2_test.go
@@ -28,10 +28,9 @@ var (
 func TestCollector_Name(t *testing.T) {
 	t.Run("Name should return the same name as the subsystem const", func(t *testing.T) {
 		collector, err := New(context.Background(), &Config{
-			Logger:         logger,
 			ScrapeInterval: time.Minute,
 			AccountID:      "123456789012",
-		})
+		}, logger)
 		require.NoError(t, err)
 		assert.Equal(t, subsystem, collector.Name())
 	})
@@ -42,11 +41,10 @@ func TestNew(t *testing.T) {
 	t.Run("New should return ClientNotFound error when RegionMap is empty", func(t *testing.T) {
 		_, err := New(context.Background(), &Config{
 			Regions:        regions,
-			Logger:         logger,
 			ScrapeInterval: time.Minute,
 			AccountID:      "123456789012",
 			RegionMap:      map[string]client.Client{}, // Empty map - no client
-		})
+		}, logger)
 		assert.ErrorIs(t, err, ErrClientNotFound)
 	})
 
@@ -57,13 +55,12 @@ func TestNew(t *testing.T) {
 
 		_, err := New(context.Background(), &Config{
 			Regions:        regions,
-			Logger:         logger,
 			ScrapeInterval: time.Minute,
 			AccountID:      "123456789012",
 			RegionMap: map[string]client.Client{
 				"us-east-1": mock,
 			},
-		})
+		}, logger)
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, ErrListOnDemandPrices)
 	})
@@ -79,13 +76,12 @@ func TestNew(t *testing.T) {
 
 		_, err := New(context.Background(), &Config{
 			Regions:        regions,
-			Logger:         logger,
 			ScrapeInterval: time.Minute,
 			AccountID:      "123456789012",
 			RegionMap: map[string]client.Client{
 				"us-east-1": mock,
 			},
-		})
+		}, logger)
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, ErrListStoragePrices)
 	})
@@ -103,13 +99,12 @@ func TestNew(t *testing.T) {
 
 		collector, err := New(context.Background(), &Config{
 			Regions:        regions,
-			Logger:         logger,
 			ScrapeInterval: time.Minute,
 			AccountID:      "123456789012",
 			RegionMap: map[string]client.Client{
 				"us-east-1": mock,
 			},
-		})
+		}, logger)
 		require.NoError(t, err)
 		assert.NotNil(t, collector)
 
@@ -128,10 +123,9 @@ func TestCollector_Collect(t *testing.T) {
 	}
 	t.Run("Collect should return no error", func(t *testing.T) {
 		collector, err := New(context.Background(), &Config{
-			Logger:         logger,
 			ScrapeInterval: time.Minute,
 			AccountID:      "123456789012",
-		})
+		}, logger)
 		require.NoError(t, err)
 		ch := make(chan prometheus.Metric)
 		go func() {
@@ -234,13 +228,12 @@ func TestCollector_Collect(t *testing.T) {
 
 		collector, err := New(ctx, &Config{
 			Regions:        regions,
-			Logger:         logger,
 			ScrapeInterval: time.Minute,
 			AccountID:      "123456789012",
 			RegionMap: map[string]client.Client{
 				"us-east-1": c,
 			},
-		})
+		}, logger)
 		require.NoError(t, err)
 
 		ch := make(chan prometheus.Metric)
@@ -379,13 +372,12 @@ func Test_FetchVolumesData(t *testing.T) {
 
 		collector, err := New(context.Background(), &Config{
 			Regions:        []ec2Types.Region{region},
-			Logger:         logger,
 			ScrapeInterval: time.Minute,
 			AccountID:      "123456789012",
 			RegionMap: map[string]client.Client{
 				regionName: c,
 			},
-		})
+		}, logger)
 		require.NoError(t, err)
 
 		c.EXPECT().
@@ -434,13 +426,12 @@ func Test_EmitMetricsFromVolumesChannel(t *testing.T) {
 
 		collector, err := New(context.Background(), &Config{
 			Regions:        []ec2Types.Region{region},
-			Logger:         logger,
 			ScrapeInterval: time.Minute,
 			AccountID:      "123456789012",
 			RegionMap: map[string]client.Client{
 				regionName: c,
 			},
-		})
+		}, logger)
 		require.NoError(t, err)
 
 		collector.storagePricingMap = &StoragePricingMap{

--- a/pkg/aws/elb/elb.go
+++ b/pkg/aws/elb/elb.go
@@ -57,7 +57,7 @@ type Config struct {
 	// PricingClient must be a client configured for us-east-1: the AWS Pricing API
 	// is only available in us-east-1 and ap-south-1.
 	PricingClient client.Client
-	RegionClients map[string]client.Client
+	RegionMap     map[string]client.Client
 	Logger        *slog.Logger
 	AccountID     string
 }
@@ -87,17 +87,17 @@ type elbProduct struct {
 	}
 }
 
-func New(config *Config) *Collector {
-	logger := config.Logger.With("logger", serviceName)
+func New(_ context.Context, config *Config) (*Collector, error) {
+	logger := config.Logger.With("collector", serviceName)
 	return &Collector{
 		regions:            config.Regions,
 		ScrapeInterval:     config.ScrapeInterval,
 		pricingClient:      config.PricingClient,
-		awsRegionClientMap: config.RegionClients,
+		awsRegionClientMap: config.RegionMap,
 		logger:             logger,
 		pricingMap:         NewELBPricingMap(logger),
 		accountID:          config.AccountID,
-	}
+	}, nil
 }
 
 func (c *Collector) Register(_ provider.Registry) error {

--- a/pkg/aws/elb/elb.go
+++ b/pkg/aws/elb/elb.go
@@ -58,7 +58,6 @@ type Config struct {
 	// is only available in us-east-1 and ap-south-1.
 	PricingClient client.Client
 	RegionMap     map[string]client.Client
-	Logger        *slog.Logger
 	AccountID     string
 }
 
@@ -87,8 +86,8 @@ type elbProduct struct {
 	}
 }
 
-func New(_ context.Context, config *Config) (*Collector, error) {
-	logger := config.Logger.With("collector", serviceName)
+func New(_ context.Context, config *Config, logger *slog.Logger) (*Collector, error) {
+	logger = logger.With("collector", serviceName)
 	return &Collector{
 		regions:            config.Regions,
 		ScrapeInterval:     config.ScrapeInterval,

--- a/pkg/aws/elb/elb_test.go
+++ b/pkg/aws/elb/elb_test.go
@@ -31,11 +31,10 @@ func TestNew(t *testing.T) {
 		RegionMap: map[string]client.Client{
 			"us-east-1": mockClient,
 		},
-		Logger:    slog.Default(),
 		AccountID: "123456789012",
 	}
 
-	collector, err := New(context.Background(), config)
+	collector, err := New(context.Background(), config, slog.Default())
 	require.NoError(t, err)
 
 	assert.NotNil(t, collector)
@@ -51,10 +50,9 @@ func TestCollectorName(t *testing.T) {
 		ScrapeInterval: time.Minute,
 		Regions:        []ec2Types.Region{},
 		RegionMap:      map[string]client.Client{},
-		Logger:         slog.Default(),
 	}
 
-	collector, err := New(context.Background(), config)
+	collector, err := New(context.Background(), config, slog.Default())
 	require.NoError(t, err)
 	assert.Equal(t, subsystem, collector.Name())
 }
@@ -64,13 +62,12 @@ func TestCollectorDescribe(t *testing.T) {
 		ScrapeInterval: time.Minute,
 		Regions:        []ec2Types.Region{},
 		RegionMap:      map[string]client.Client{},
-		Logger:         slog.Default(),
 	}
 	expectedDescs := []string{
 		LoadBalancerUsageHourlyCostDesc.String(),
 		LoadBalancerCapacityUnitsUsageHourlyCostDesc.String(),
 	}
-	collector, err := New(context.Background(), config)
+	collector, err := New(context.Background(), config, slog.Default())
 	require.NoError(t, err)
 	ch := make(chan *prometheus.Desc, len(expectedDescs))
 
@@ -107,11 +104,10 @@ func TestCollectRegionLoadBalancers(t *testing.T) {
 		RegionMap: map[string]client.Client{
 			"us-east-1": mockClient,
 		},
-		Logger:    slog.Default(),
 		AccountID: "123456789012",
 	}
 
-	collector, err := New(context.Background(), config)
+	collector, err := New(context.Background(), config, slog.Default())
 	require.NoError(t, err)
 
 	// Set up mock pricing data

--- a/pkg/aws/elb/elb_test.go
+++ b/pkg/aws/elb/elb_test.go
@@ -1,6 +1,7 @@
 package elb
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	elbTypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/grafana/cloudcost-exporter/pkg/aws/client"
@@ -26,14 +28,15 @@ func TestNew(t *testing.T) {
 			{RegionName: stringPtr("us-east-1")},
 		},
 		PricingClient: mockClient,
-		RegionClients: map[string]client.Client{
+		RegionMap: map[string]client.Client{
 			"us-east-1": mockClient,
 		},
 		Logger:    slog.Default(),
 		AccountID: "123456789012",
 	}
 
-	collector := New(config)
+	collector, err := New(context.Background(), config)
+	require.NoError(t, err)
 
 	assert.NotNil(t, collector)
 	assert.Equal(t, config.ScrapeInterval, collector.ScrapeInterval)
@@ -47,11 +50,12 @@ func TestCollectorName(t *testing.T) {
 	config := &Config{
 		ScrapeInterval: time.Minute,
 		Regions:        []ec2Types.Region{},
-		RegionClients:  map[string]client.Client{},
+		RegionMap:      map[string]client.Client{},
 		Logger:         slog.Default(),
 	}
 
-	collector := New(config)
+	collector, err := New(context.Background(), config)
+	require.NoError(t, err)
 	assert.Equal(t, subsystem, collector.Name())
 }
 
@@ -59,17 +63,18 @@ func TestCollectorDescribe(t *testing.T) {
 	config := &Config{
 		ScrapeInterval: time.Minute,
 		Regions:        []ec2Types.Region{},
-		RegionClients:  map[string]client.Client{},
+		RegionMap:      map[string]client.Client{},
 		Logger:         slog.Default(),
 	}
 	expectedDescs := []string{
 		LoadBalancerUsageHourlyCostDesc.String(),
 		LoadBalancerCapacityUnitsUsageHourlyCostDesc.String(),
 	}
-	collector := New(config)
+	collector, err := New(context.Background(), config)
+	require.NoError(t, err)
 	ch := make(chan *prometheus.Desc, len(expectedDescs))
 
-	err := collector.Describe(ch)
+	err = collector.Describe(ch)
 	close(ch)
 
 	assert.NoError(t, err)
@@ -99,14 +104,15 @@ func TestCollectRegionLoadBalancers(t *testing.T) {
 	config := &Config{
 		ScrapeInterval: time.Minute,
 		Regions:        []ec2Types.Region{},
-		RegionClients: map[string]client.Client{
+		RegionMap: map[string]client.Client{
 			"us-east-1": mockClient,
 		},
 		Logger:    slog.Default(),
 		AccountID: "123456789012",
 	}
 
-	collector := New(config)
+	collector, err := New(context.Background(), config)
+	require.NoError(t, err)
 
 	// Set up mock pricing data
 	collector.pricingMap.SetRegionPricing("us-east-1", &RegionPricing{

--- a/pkg/aws/msk/msk.go
+++ b/pkg/aws/msk/msk.go
@@ -111,7 +111,7 @@ type clusterPricingData struct {
 func New(ctx context.Context, config *Config) (*Collector, error) {
 	logger := slog.Default()
 	if config.Logger != nil {
-		logger = config.Logger.With("logger", serviceName)
+		logger = config.Logger.With("collector", serviceName)
 	}
 
 	pricingStore, err := pricingstore.NewPricingStore(ctx, logger, config.Regions, newPriceFetcher(config.Client))

--- a/pkg/aws/msk/msk.go
+++ b/pkg/aws/msk/msk.go
@@ -96,7 +96,6 @@ type Config struct {
 	Regions   []ec2types.Region
 	RegionMap map[string]client.Client
 	Client    client.Client
-	Logger    *slog.Logger
 	AccountID string
 }
 
@@ -108,11 +107,8 @@ type clusterPricingData struct {
 	volumeSizeGiB int32
 }
 
-func New(ctx context.Context, config *Config) (*Collector, error) {
-	logger := slog.Default()
-	if config.Logger != nil {
-		logger = config.Logger.With("collector", serviceName)
-	}
+func New(ctx context.Context, config *Config, logger *slog.Logger) (*Collector, error) {
+	logger = logger.With("collector", serviceName)
 
 	pricingStore, err := pricingstore.NewPricingStore(ctx, logger, config.Regions, newPriceFetcher(config.Client))
 	if err != nil {

--- a/pkg/aws/msk/msk_test.go
+++ b/pkg/aws/msk/msk_test.go
@@ -117,8 +117,7 @@ func TestNewReturnsErrorWhenPricingLoadFails(t *testing.T) {
 		Regions:   []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		RegionMap: map[string]client.Client{},
 		Client:    pricingClient,
-		Logger:    testLogger(),
-	})
+	}, testLogger())
 	require.Error(t, err)
 }
 
@@ -140,8 +139,7 @@ func TestNewReturnsErrorWhenStoragePricingLoadFails(t *testing.T) {
 		Regions:   []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		RegionMap: map[string]client.Client{},
 		Client:    pricingClient,
-		Logger:    testLogger(),
-	})
+	}, testLogger())
 	require.Error(t, err)
 }
 
@@ -167,9 +165,8 @@ func TestCollectorCollectEmitsHourlyRateMetrics(t *testing.T) {
 		Regions:   []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		RegionMap: map[string]client.Client{"us-east-1": regionClient},
 		Client:    pricingClient,
-		Logger:    testLogger(),
 		AccountID: "123456789012",
-	})
+	}, testLogger())
 	require.NoError(t, err)
 
 	results, err := collectMetricResults(t, collector)
@@ -211,9 +208,8 @@ func TestCollectorCollectCachesPricingLookups(t *testing.T) {
 		Regions:   []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		RegionMap: map[string]client.Client{"us-east-1": regionClient},
 		Client:    pricingClient,
-		Logger:    testLogger(),
 		AccountID: "123456789012",
-	})
+	}, testLogger())
 	require.NoError(t, err)
 
 	results, err := collectMetricResults(t, collector)
@@ -242,9 +238,8 @@ func TestCollectorCollectContinuesWhenRegionClientMissing(t *testing.T) {
 			"us-west-2": regionClient,
 		},
 		Client:    pricingClient,
-		Logger:    testLogger(),
 		AccountID: "123456789012",
-	})
+	}, testLogger())
 	require.NoError(t, err)
 
 	results, err := collectMetricResults(t, collector)
@@ -276,9 +271,8 @@ func TestCollectorCollectContinuesWhenRegionListingFails(t *testing.T) {
 			"us-west-2": healthyRegionClient,
 		},
 		Client:    pricingClient,
-		Logger:    testLogger(),
 		AccountID: "123456789012",
-	})
+	}, testLogger())
 	require.NoError(t, err)
 
 	results, err := collectMetricResults(t, collector)
@@ -303,9 +297,8 @@ func TestCollectorCollectReturnsContextErrWhenContextCancelled(t *testing.T) {
 		Regions:   []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		RegionMap: map[string]client.Client{"us-east-1": regionClient},
 		Client:    pricingClient,
-		Logger:    testLogger(),
 		AccountID: "123456789012",
-	})
+	}, testLogger())
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -352,9 +345,8 @@ func TestCollectorCollectContinuesOnContextDeadlineExceeded(t *testing.T) {
 			"us-west-2": healthyClient,
 		},
 		Client:    pricingClient,
-		Logger:    testLogger(),
 		AccountID: "123456789012",
-	})
+	}, testLogger())
 	require.NoError(t, err)
 
 	results, err := collectMetricResults(t, collector)

--- a/pkg/aws/natgateway/natgateway.go
+++ b/pkg/aws/natgateway/natgateway.go
@@ -53,8 +53,8 @@ type Collector struct {
 	accountID string
 }
 
-func New(ctx context.Context, config *Config) (*Collector, error) {
-	logger := config.Logger.With("collector", serviceName)
+func New(ctx context.Context, config *Config, logger *slog.Logger) (*Collector, error) {
+	logger = logger.With("collector", serviceName)
 
 	pricingStore, err := pricingstore.NewPricingStore(ctx, logger, config.Regions, newPriceFetcher(config.RegionMap))
 	if err != nil {
@@ -89,7 +89,6 @@ func New(ctx context.Context, config *Config) (*Collector, error) {
 type Config struct {
 	ScrapeInterval time.Duration
 	Regions        []ec2Types.Region
-	Logger         *slog.Logger
 	RegionMap      map[string]awsclient.Client
 	AccountID      string
 }

--- a/pkg/aws/natgateway/natgateway.go
+++ b/pkg/aws/natgateway/natgateway.go
@@ -54,7 +54,7 @@ type Collector struct {
 }
 
 func New(ctx context.Context, config *Config) (*Collector, error) {
-	logger := config.Logger.With("logger", serviceName)
+	logger := config.Logger.With("collector", serviceName)
 
 	pricingStore, err := pricingstore.NewPricingStore(ctx, logger, config.Regions, newPriceFetcher(config.RegionMap))
 	if err != nil {

--- a/pkg/aws/natgateway/natgateway_test.go
+++ b/pkg/aws/natgateway/natgateway_test.go
@@ -67,12 +67,11 @@ func TestNew(t *testing.T) {
 			collector, err := natgateway.New(t.Context(), &natgateway.Config{
 				ScrapeInterval: tt.ScrapeInterval,
 				Regions:        []ec2Types.Region{{RegionName: aws.String(tt.regionName)}},
-				Logger:         tt.Logger,
 				RegionMap: map[string]awsclient.Client{
 					tt.regionName: tt.regionClient,
 				},
 				AccountID: "123456789012",
-			})
+			}, tt.Logger)
 			require.NoError(t, err)
 			assert.NotNil(t, collector)
 			assert.NotNil(t, collector.PricingStore)
@@ -93,11 +92,10 @@ func TestNew_ReturnsErrorWhenPricingAPIUnavailable(t *testing.T) {
 
 	collector, err := natgateway.New(t.Context(), &natgateway.Config{
 		Regions: []ec2Types.Region{{RegionName: aws.String("us-east-1")}},
-		Logger:  testLogger,
 		RegionMap: map[string]awsclient.Client{
 			"us-east-1": regionClient,
 		},
-	})
+	}, testLogger)
 
 	assert.Nil(t, collector)
 	assert.Error(t, err)
@@ -190,12 +188,11 @@ func TestCollector_Collect(t *testing.T) {
 			collector, err := natgateway.New(t.Context(), &natgateway.Config{
 				ScrapeInterval: 1 * time.Hour,
 				Regions:        []ec2Types.Region{{RegionName: aws.String(region)}},
-				Logger:         testLogger,
 				RegionMap: map[string]awsclient.Client{
 					region: tt.regionClient,
 				},
 				AccountID: "123456789012",
-			})
+			}, testLogger)
 			require.NoError(t, err)
 
 			ch := make(chan prometheus.Metric, len(tt.expectedMetrics))
@@ -240,12 +237,11 @@ func TestCollector_CollectAggregatesMultipleUsageTypesPerRegion(t *testing.T) {
 	collector, err := natgateway.New(t.Context(), &natgateway.Config{
 		ScrapeInterval: 1 * time.Hour,
 		Regions:        []ec2Types.Region{{RegionName: aws.String(region)}},
-		Logger:         testLogger,
 		RegionMap: map[string]awsclient.Client{
 			region: regionClient,
 		},
 		AccountID: "123456789012",
-	})
+	}, testLogger)
 	require.NoError(t, err)
 
 	ch := make(chan prometheus.Metric, 10)

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -37,6 +37,7 @@ type Collector struct {
 	Client         client.Client
 	pricingMap     *pricingMap
 	accountID      string
+	logger         *slog.Logger
 }
 
 type Config struct {
@@ -45,6 +46,7 @@ type Config struct {
 	Client         client.Client
 	ScrapeInterval time.Duration
 	AccountID      string
+	Logger         *slog.Logger
 }
 
 type listError struct {
@@ -58,7 +60,7 @@ const (
 )
 
 // New creates an rds collector
-func New(config *Config) *Collector {
+func New(_ context.Context, config *Config) (*Collector, error) {
 	return &Collector{
 		pricingMap:     newPricingMap(),
 		regions:        config.Regions,
@@ -66,12 +68,13 @@ func New(config *Config) *Collector {
 		scrapeInterval: config.ScrapeInterval,
 		Client:         config.Client,
 		accountID:      config.AccountID,
-	}
+		logger:         config.Logger.With("collector", serviceName),
+	}, nil
 }
 
 // Collect satisfies the provider.Collector interface.
 func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
-	logger := slog.With("logger", serviceName)
+	logger := c.logger
 	var instances = []rdsTypes.DBInstance{}
 	var regionErrors []listError
 	for _, region := range c.regions {

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -46,7 +46,6 @@ type Config struct {
 	Client         client.Client
 	ScrapeInterval time.Duration
 	AccountID      string
-	Logger         *slog.Logger
 }
 
 type listError struct {
@@ -60,7 +59,7 @@ const (
 )
 
 // New creates an rds collector
-func New(_ context.Context, config *Config) (*Collector, error) {
+func New(_ context.Context, config *Config, logger *slog.Logger) (*Collector, error) {
 	return &Collector{
 		pricingMap:     newPricingMap(),
 		regions:        config.Regions,
@@ -68,7 +67,7 @@ func New(_ context.Context, config *Config) (*Collector, error) {
 		scrapeInterval: config.ScrapeInterval,
 		Client:         config.Client,
 		accountID:      config.AccountID,
-		logger:         config.Logger.With("collector", serviceName),
+		logger:         logger.With("collector", serviceName),
 	}, nil
 }
 

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -56,7 +56,7 @@ type listError struct {
 }
 
 const (
-	serviceName = "rds"
+	serviceName = "RDS"
 )
 
 // New creates an rds collector

--- a/pkg/aws/rds/rds_test.go
+++ b/pkg/aws/rds/rds_test.go
@@ -1,6 +1,7 @@
 package rds
 
 import (
+	"log/slog"
 	"testing"
 	"time"
 
@@ -219,6 +220,7 @@ func TestCollector_Collect(t *testing.T) {
 				scrapeInterval: time.Minute,
 				Client:         mockClient,
 				accountID:      "123456789012",
+				logger:         slog.Default(),
 			}
 
 			ch := make(chan prometheus.Metric, 1)

--- a/pkg/aws/s3/s3.go
+++ b/pkg/aws/s3/s3.go
@@ -75,7 +75,6 @@ type Collector struct {
 type Config struct {
 	ScrapeInterval time.Duration
 	AccountID      string
-	Logger         *slog.Logger
 }
 
 // Describe is used to register the metrics with the Prometheus client
@@ -105,8 +104,8 @@ func (c *Collector) Collect(ctx context.Context, _ chan<- prometheus.Metric) err
 }
 
 // New creates a new Collector with a client and scrape interval defined.
-func New(ctx context.Context, cfg *Config, client client.Client) (*Collector, error) {
-	logger := cfg.Logger.With("collector", "S3")
+func New(ctx context.Context, cfg *Config, logger *slog.Logger, client client.Client) (*Collector, error) {
+	logger = logger.With("collector", "S3")
 	awsRegions, err := client.DescribeRegions(ctx, false)
 	if err != nil {
 		logger.Warn("failed to describe regions for S3 collector", "error", err)

--- a/pkg/aws/s3/s3.go
+++ b/pkg/aws/s3/s3.go
@@ -69,6 +69,13 @@ type Collector struct {
 	billingData *client.BillingData
 	m           sync.RWMutex
 	accountID   string
+	logger      *slog.Logger
+}
+
+type Config struct {
+	ScrapeInterval time.Duration
+	AccountID      string
+	Logger         *slog.Logger
 }
 
 // Describe is used to register the metrics with the Prometheus client
@@ -86,22 +93,23 @@ func (c *Collector) Collect(ctx context.Context, _ chan<- prometheus.Metric) err
 		startDate := endDate.AddDate(0, 0, -30)
 		billingData, err := c.client.GetBillingData(ctx, startDate, endDate)
 		if err != nil {
-			slog.Error("Error getting billing data", "error", err)
+			c.logger.Error("Error getting billing data", "error", err)
 			return err
 		}
 		c.billingData = billingData
 		c.nextScrape = time.Now().Add(c.interval)
 		c.metrics.NextScrapeGauge.Set(float64(c.nextScrape.Unix()))
 	}
-	exportMetrics(c.billingData, c.metrics, c.accountID)
+	exportMetrics(c.billingData, c.metrics, c.accountID, c.logger)
 	return nil
 }
 
 // New creates a new Collector with a client and scrape interval defined.
-func New(ctx context.Context, scrapeInterval time.Duration, client client.Client, accountID string) (*Collector, error) {
+func New(ctx context.Context, cfg *Config, client client.Client) (*Collector, error) {
+	logger := cfg.Logger.With("collector", "S3")
 	awsRegions, err := client.DescribeRegions(ctx, false)
 	if err != nil {
-		slog.Warn("failed to describe regions for S3 collector", "error", err)
+		logger.Warn("failed to describe regions for S3 collector", "error", err)
 	}
 	regions := make([]string, 0, len(awsRegions))
 	for _, r := range awsRegions {
@@ -112,12 +120,13 @@ func New(ctx context.Context, scrapeInterval time.Duration, client client.Client
 	return &Collector{
 		client:   client,
 		regions:  regions,
-		interval: scrapeInterval,
+		interval: cfg.ScrapeInterval,
 		// Initially Set nextScrape to the current time minus the scrape interval so that the first scrape will run immediately
-		nextScrape: time.Now().Add(-scrapeInterval),
+		nextScrape: time.Now().Add(-cfg.ScrapeInterval),
 		metrics:    NewMetrics(),
 		m:          sync.RWMutex{},
-		accountID:  accountID,
+		accountID:  cfg.AccountID,
+		logger:     logger,
 	}, nil
 }
 
@@ -140,8 +149,8 @@ func (c *Collector) Register(registry provider.Registry) error {
 }
 
 // exportMetrics will iterate over the S3BillingData and export the metrics to prometheus
-func exportMetrics(s3BillingData *client.BillingData, m Metrics, accountID string) {
-	slog.Info("Exporting metrics", "regions", len(s3BillingData.Regions))
+func exportMetrics(s3BillingData *client.BillingData, m Metrics, accountID string, logger *slog.Logger) {
+	logger.Info("Exporting metrics", "regions", len(s3BillingData.Regions))
 	for region, pricingModel := range s3BillingData.Regions {
 		for component, pricing := range pricingModel.Model {
 			switch component {

--- a/pkg/aws/s3/s3_test.go
+++ b/pkg/aws/s3/s3_test.go
@@ -43,8 +43,7 @@ func TestNewCollector(t *testing.T) {
 			got, err := New(context.Background(), &Config{
 				ScrapeInterval: tt.args.interval,
 				AccountID:      "123456789012",
-				Logger:         slog.Default(),
-			}, c)
+			}, slog.Default(), c)
 			assert.NoError(t, err)
 			assert.NotNil(t, got)
 			assert.Equal(t, tt.args.interval, got.interval)

--- a/pkg/aws/s3/s3_test.go
+++ b/pkg/aws/s3/s3_test.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -39,7 +40,11 @@ func TestNewCollector(t *testing.T) {
 			c := mock_client.NewMockClient(ctrl)
 			c.EXPECT().DescribeRegions(gomock.Any(), false).Return(nil, nil)
 
-			got, err := New(context.Background(), tt.args.interval, c, "123456789012")
+			got, err := New(context.Background(), &Config{
+				ScrapeInterval: tt.args.interval,
+				AccountID:      "123456789012",
+				Logger:         slog.Default(),
+			}, c)
 			assert.NoError(t, err)
 			assert.NotNil(t, got)
 			assert.Equal(t, tt.args.interval, got.interval)
@@ -284,6 +289,7 @@ cloudcost_aws_s3_storage_by_location_usd_per_gibyte_hour{account_id="12345678901
 				nextScrape: tc.nextScrape,
 				metrics:    NewMetrics(),
 				accountID:  "123456789012",
+				logger:     slog.Default(),
 			}
 			err := c.Collect(context.Background(), nil)
 			if tc.expectedResponse == 0 {
@@ -315,6 +321,7 @@ func TestCollector_MultipleCalls(t *testing.T) {
 			metrics:   NewMetrics(),
 			interval:  1 * time.Hour,
 			accountID: "123456789012",
+			logger:    slog.Default(),
 		}
 		err := c.Collect(context.Background(), nil)
 		require.NoError(t, err)
@@ -362,6 +369,7 @@ func TestCollector_MultipleCalls(t *testing.T) {
 			client:    ce,
 			metrics:   NewMetrics(),
 			accountID: "123456789012",
+			logger:    slog.Default(),
 		}
 
 		for i := 0; i < goroutines; i++ {

--- a/pkg/aws/vpc/vpc.go
+++ b/pkg/aws/vpc/vpc.go
@@ -72,8 +72,8 @@ type Collector struct {
 	accountID      string
 }
 
-func New(ctx context.Context, config *Config) (*Collector, error) {
-	logger := config.Logger.With("collector", serviceName)
+func New(ctx context.Context, config *Config, logger *slog.Logger) (*Collector, error) {
+	logger = logger.With("collector", serviceName)
 	pricingMap := NewVPCPricingMap(logger)
 
 	// Initial pricing data load using the dedicated us-east-1 pricing client
@@ -112,7 +112,6 @@ func New(ctx context.Context, config *Config) (*Collector, error) {
 type Config struct {
 	ScrapeInterval time.Duration
 	Regions        []ec2Types.Region
-	Logger         *slog.Logger
 	Client         awsclient.Client // Dedicated client with us-east-1 pricing service
 	AccountID      string
 }

--- a/pkg/aws/vpc/vpc.go
+++ b/pkg/aws/vpc/vpc.go
@@ -73,7 +73,7 @@ type Collector struct {
 }
 
 func New(ctx context.Context, config *Config) (*Collector, error) {
-	logger := config.Logger.With("logger", serviceName)
+	logger := config.Logger.With("collector", serviceName)
 	pricingMap := NewVPCPricingMap(logger)
 
 	// Initial pricing data load using the dedicated us-east-1 pricing client

--- a/pkg/aws/vpc/vpc_test.go
+++ b/pkg/aws/vpc/vpc_test.go
@@ -134,10 +134,9 @@ func TestNew(t *testing.T) {
 	collector, err := New(t.Context(), &Config{
 		ScrapeInterval: 1 * time.Hour,
 		Regions:        regions,
-		Logger:         logger,
 		Client:         mockClient, // Add the dedicated client
 		AccountID:      "123456789012",
-	})
+	}, logger)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, collector)

--- a/pkg/azure/aks/aks.go
+++ b/pkg/azure/aks/aks.go
@@ -99,7 +99,8 @@ var (
 // Collector is a prometheus collector that collects cost metrics from AKS clusters.
 // Provides comprehensive cost tracking for both virtual machines and persistent volumes.
 type Collector struct {
-	logger *slog.Logger
+	logger         *slog.Logger
+	subscriptionID string
 
 	VMPriceStore *VMPriceStore // Azure VM retail prices (not disk)
 	MachineStore *MachineStore // VM inventory store
@@ -174,7 +175,8 @@ func New(ctx context.Context, cfg *Config, azClientWrapper client.AzureClient) (
 	}(ctx)
 
 	return &Collector{
-		logger: logger,
+		logger:         logger,
+		subscriptionID: cfg.SubscriptionID,
 
 		VMPriceStore: vmPriceStore,
 		MachineStore: machineStore,

--- a/pkg/azure/aks/aks.go
+++ b/pkg/azure/aks/aks.go
@@ -108,12 +108,11 @@ type Collector struct {
 }
 
 type Config struct {
-	Logger         *slog.Logger
 	SubscriptionID string
 }
 
-func New(ctx context.Context, cfg *Config, azClientWrapper client.AzureClient) (*Collector, error) {
-	logger := cfg.Logger.With("collector", "aks")
+func New(ctx context.Context, cfg *Config, logger *slog.Logger, azClientWrapper client.AzureClient) (*Collector, error) {
+	logger = logger.With("collector", "aks")
 	vmPriceStore := NewVMPriceStore(logger, azClientWrapper)
 	machineStore, err := NewMachineStore(ctx, logger, azClientWrapper)
 	if err != nil {

--- a/pkg/azure/aks/aks.go
+++ b/pkg/azure/aks/aks.go
@@ -107,7 +107,8 @@ type Collector struct {
 }
 
 type Config struct {
-	Logger *slog.Logger
+	Logger         *slog.Logger
+	SubscriptionID string
 }
 
 func New(ctx context.Context, cfg *Config, azClientWrapper client.AzureClient) (*Collector, error) {

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -101,7 +101,8 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 		switch {
 		case strings.EqualFold(svc, "AKS"):
 			collector, err := aks.New(ctx, &aks.Config{
-				Logger: logger,
+				Logger:         logger,
+				SubscriptionID: config.SubscriptionId,
 			}, azClientWrapper)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -101,9 +101,8 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 		switch {
 		case strings.EqualFold(svc, "AKS"):
 			collector, err := aks.New(ctx, &aks.Config{
-				Logger:         logger,
 				SubscriptionID: config.SubscriptionID,
-			}, azClientWrapper)
+			}, logger, azClientWrapper)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
 					slog.String("service", svc),
@@ -113,10 +112,9 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 			collectors = append(collectors, collector)
 		case strings.EqualFold(svc, "blob"):
 			collector, err := blob.New(ctx, &blob.Config{
-				Logger:         logger,
 				SubscriptionID: config.SubscriptionID,
 				ScrapeInterval: config.ScrapeInterval,
-			})
+			}, logger)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
 					slog.String("service", svc),

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -112,9 +112,9 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 			}
 			collectors = append(collectors, collector)
 		case strings.EqualFold(svc, "blob"):
-			collector, err := blob.New(&blob.Config{
+			collector, err := blob.New(ctx, &blob.Config{
 				Logger:         logger,
-				SubscriptionId: config.SubscriptionId,
+				SubscriptionID: config.SubscriptionId,
 				ScrapeInterval: config.ScrapeInterval,
 			})
 			if err != nil {

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -54,7 +54,7 @@ type Azure struct {
 	context context.Context
 	logger  *slog.Logger
 
-	subscriptionId string
+	subscriptionID string
 	azCredentials  *azidentity.DefaultAzureCredential
 
 	collectorTimeout time.Duration
@@ -65,7 +65,7 @@ type Config struct {
 	Logger *slog.Logger
 	Region string
 
-	SubscriptionId string
+	SubscriptionID string
 	ScrapeInterval time.Duration
 
 	CollectorTimeout time.Duration
@@ -76,7 +76,7 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 	logger := config.Logger.With("provider", subsystem)
 	collectors := []provider.Collector{}
 
-	if config.SubscriptionId == "" {
+	if config.SubscriptionID == "" {
 		logger.LogAttrs(ctx, slog.LevelError, "subscription id was invalid")
 		return nil, errInvalidSubscriptionID
 	}
@@ -87,7 +87,7 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 		return nil, err
 	}
 
-	azClientWrapper, err := client.NewAzureClientWrapper(ctx, logger, config.SubscriptionId, creds)
+	azClientWrapper, err := client.NewAzureClientWrapper(ctx, logger, config.SubscriptionID, creds)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 		case strings.EqualFold(svc, "AKS"):
 			collector, err := aks.New(ctx, &aks.Config{
 				Logger:         logger,
-				SubscriptionID: config.SubscriptionId,
+				SubscriptionID: config.SubscriptionID,
 			}, azClientWrapper)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
@@ -114,7 +114,7 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 		case strings.EqualFold(svc, "blob"):
 			collector, err := blob.New(ctx, &blob.Config{
 				Logger:         logger,
-				SubscriptionID: config.SubscriptionId,
+				SubscriptionID: config.SubscriptionID,
 				ScrapeInterval: config.ScrapeInterval,
 			})
 			if err != nil {
@@ -133,7 +133,7 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 		context: ctx,
 		logger:  logger,
 
-		subscriptionId: config.SubscriptionId,
+		subscriptionID: config.SubscriptionID,
 		azCredentials:  creds,
 
 		collectorTimeout: config.CollectorTimeout,

--- a/pkg/azure/azure_test.go
+++ b/pkg/azure/azure_test.go
@@ -42,7 +42,7 @@ func Test_New(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			a, err := New(t.Context(), &Config{
 				Logger:         testLogger,
-				SubscriptionId: tc.subId,
+				SubscriptionID: tc.subId,
 			})
 			if tc.expectedErr != nil {
 				assert.ErrorIs(t, err, tc.expectedErr)

--- a/pkg/azure/blob/blob.go
+++ b/pkg/azure/blob/blob.go
@@ -44,12 +44,14 @@ type Collector struct {
 // Config holds settings for the blob collector.
 type Config struct {
 	Logger         *slog.Logger
-	SubscriptionId string
+	SubscriptionID string
 	ScrapeInterval time.Duration
 }
 
 // New builds a blob collector. It does not call Azure APIs yet; subscription and interval are stored for Cost Management integration.
-func New(cfg *Config) (*Collector, error) {
+// TODO: Add a provider client parameter (e.g. azClientWrapper) once Cost Management integration is implemented,
+// to match the standard Azure constructor signature: New(ctx, cfg, client).
+func New(ctx context.Context, cfg *Config) (*Collector, error) {
 	interval := cfg.ScrapeInterval
 	if interval <= 0 {
 		interval = time.Hour
@@ -57,7 +59,7 @@ func New(cfg *Config) (*Collector, error) {
 	return &Collector{
 		logger:         cfg.Logger.With("collector", "blob"),
 		metrics:        newMetrics(),
-		subscriptionID: cfg.SubscriptionId,
+		subscriptionID: cfg.SubscriptionID,
 		scrapeInterval: interval,
 	}, nil
 }

--- a/pkg/azure/blob/blob.go
+++ b/pkg/azure/blob/blob.go
@@ -43,7 +43,6 @@ type Collector struct {
 
 // Config holds settings for the blob collector.
 type Config struct {
-	Logger         *slog.Logger
 	SubscriptionID string
 	ScrapeInterval time.Duration
 }
@@ -51,13 +50,13 @@ type Config struct {
 // New builds a blob collector. It does not call Azure APIs yet; subscription and interval are stored for Cost Management integration.
 // TODO: Add a provider client parameter (e.g. azClientWrapper) once Cost Management integration is implemented,
 // to match the standard Azure constructor signature: New(ctx, cfg, client).
-func New(ctx context.Context, cfg *Config) (*Collector, error) {
+func New(ctx context.Context, cfg *Config, logger *slog.Logger) (*Collector, error) {
 	interval := cfg.ScrapeInterval
 	if interval <= 0 {
 		interval = time.Hour
 	}
 	return &Collector{
-		logger:         cfg.Logger.With("collector", "blob"),
+		logger:         logger.With("collector", "blob"),
 		metrics:        newMetrics(),
 		subscriptionID: cfg.SubscriptionID,
 		scrapeInterval: interval,

--- a/pkg/azure/blob/blob.go
+++ b/pkg/azure/blob/blob.go
@@ -48,8 +48,6 @@ type Config struct {
 }
 
 // New builds a blob collector. It does not call Azure APIs yet; subscription and interval are stored for Cost Management integration.
-// TODO: Add a provider client parameter (e.g. azClientWrapper) once Cost Management integration is implemented,
-// to match the standard Azure constructor signature: New(ctx, cfg, client).
 func New(ctx context.Context, cfg *Config, logger *slog.Logger) (*Collector, error) {
 	interval := cfg.ScrapeInterval
 	if interval <= 0 {

--- a/pkg/azure/blob/blob_test.go
+++ b/pkg/azure/blob/blob_test.go
@@ -22,7 +22,7 @@ func testCollectSink() chan prometheus.Metric {
 }
 
 func TestCollector_Describe(t *testing.T) {
-	c, err := New(context.Background(), &Config{Logger: testLogger})
+	c, err := New(context.Background(), &Config{}, testLogger)
 	require.NoError(t, err)
 	ch := make(chan *prometheus.Desc, 4)
 	require.NoError(t, c.Describe(ch))
@@ -38,14 +38,14 @@ func TestCollector_Describe(t *testing.T) {
 }
 
 func TestCollector_Register(t *testing.T) {
-	c, err := New(context.Background(), &Config{Logger: testLogger})
+	c, err := New(context.Background(), &Config{}, testLogger)
 	require.NoError(t, err)
 	// Register does not call registry.MustRegister on cost metrics (AKS pattern).
 	require.NoError(t, c.Register(nil))
 }
 
 func TestCollector_Collect_forwardsStorageGauge(t *testing.T) {
-	c, err := New(context.Background(), &Config{Logger: testLogger})
+	c, err := New(context.Background(), &Config{}, testLogger)
 	require.NoError(t, err)
 	ctx := context.Background()
 	require.NoError(t, c.Collect(ctx, testCollectSink()))
@@ -72,10 +72,9 @@ func TestNew_configPlumbing(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			c, err := New(context.Background(), &Config{
-				Logger:         testLogger,
 				SubscriptionID: tt.subscriptionID,
 				ScrapeInterval: tt.scrapeInterval,
-			})
+			}, testLogger)
 			require.NoError(t, err)
 			assert.Equal(t, tt.subscriptionID, c.subscriptionID)
 			assert.Equal(t, tt.wantInterval, c.scrapeInterval)

--- a/pkg/azure/blob/blob_test.go
+++ b/pkg/azure/blob/blob_test.go
@@ -22,7 +22,7 @@ func testCollectSink() chan prometheus.Metric {
 }
 
 func TestCollector_Describe(t *testing.T) {
-	c, err := New(&Config{Logger: testLogger})
+	c, err := New(context.Background(), &Config{Logger: testLogger})
 	require.NoError(t, err)
 	ch := make(chan *prometheus.Desc, 4)
 	require.NoError(t, c.Describe(ch))
@@ -38,14 +38,14 @@ func TestCollector_Describe(t *testing.T) {
 }
 
 func TestCollector_Register(t *testing.T) {
-	c, err := New(&Config{Logger: testLogger})
+	c, err := New(context.Background(), &Config{Logger: testLogger})
 	require.NoError(t, err)
 	// Register does not call registry.MustRegister on cost metrics (AKS pattern).
 	require.NoError(t, c.Register(nil))
 }
 
 func TestCollector_Collect_forwardsStorageGauge(t *testing.T) {
-	c, err := New(&Config{Logger: testLogger})
+	c, err := New(context.Background(), &Config{Logger: testLogger})
 	require.NoError(t, err)
 	ctx := context.Background()
 	require.NoError(t, c.Collect(ctx, testCollectSink()))
@@ -71,9 +71,9 @@ func TestNew_configPlumbing(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			c, err := New(&Config{
+			c, err := New(context.Background(), &Config{
 				Logger:         testLogger,
-				SubscriptionId: tt.subscriptionID,
+				SubscriptionID: tt.subscriptionID,
 				ScrapeInterval: tt.scrapeInterval,
 			})
 			require.NoError(t, err)

--- a/pkg/google/cloudsql/cloudsql.go
+++ b/pkg/google/cloudsql/cloudsql.go
@@ -88,7 +88,7 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
 }
 
 func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
-	logger := c.logger.With("logger", "cloudsql")
+	logger := c.logger.With("collector", "cloudsql")
 
 	instances, err := c.getAllCloudSQL(ctx)
 	if err != nil {

--- a/pkg/google/cloudsql/cloudsql.go
+++ b/pkg/google/cloudsql/cloudsql.go
@@ -18,7 +18,6 @@ import (
 type Config struct {
 	Projects       string
 	ScrapeInterval time.Duration
-	Logger         *slog.Logger
 }
 
 type Collector struct {
@@ -45,10 +44,10 @@ var (
 	)
 )
 
-func New(ctx context.Context, config *Config, gcpClient client.Client) (*Collector, error) {
-	pm := newPricingMap(config.Logger, gcpClient)
+func New(ctx context.Context, config *Config, logger *slog.Logger, gcpClient client.Client) (*Collector, error) {
+	pm := newPricingMap(logger, gcpClient)
 	projects := strings.Split(config.Projects, ",")
-	regions := client.RegionsForProjects(gcpClient, projects, config.Logger)
+	regions := client.RegionsForProjects(gcpClient, projects, logger)
 
 	if err := pm.getSKus(ctx); err != nil {
 		return nil, fmt.Errorf("failed to initialise Cloud SQL pricing: %w", err)
@@ -63,7 +62,7 @@ func New(ctx context.Context, config *Config, gcpClient client.Client) (*Collect
 				return
 			case <-ticker.C:
 				if err := pm.getSKus(ctx); err != nil {
-					config.Logger.Error("failed to refresh Cloud SQL pricing SKUs", "error", err)
+					logger.Error("failed to refresh Cloud SQL pricing SKUs", "error", err)
 				}
 			}
 		}
@@ -75,7 +74,7 @@ func New(ctx context.Context, config *Config, gcpClient client.Client) (*Collect
 		pricingMap: pm,
 		projects:   projects,
 		regions:    regions,
-		logger:     config.Logger,
+		logger:     logger,
 	}, nil
 }
 

--- a/pkg/google/cloudsql/cloudsql.go
+++ b/pkg/google/cloudsql/cloudsql.go
@@ -45,6 +45,7 @@ var (
 )
 
 func New(ctx context.Context, config *Config, logger *slog.Logger, gcpClient client.Client) (*Collector, error) {
+	logger = logger.With("collector", "cloudsql")
 	pm := newPricingMap(logger, gcpClient)
 	projects := strings.Split(config.Projects, ",")
 	regions := client.RegionsForProjects(gcpClient, projects, logger)
@@ -87,8 +88,6 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
 }
 
 func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
-	logger := c.logger.With("collector", "cloudsql")
-
 	instances, err := c.getAllCloudSQL(ctx)
 	if err != nil {
 		return err
@@ -97,7 +96,7 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 	for _, instance := range instances {
 		price, err := c.pricingMap.matchInstancePrice(instance)
 		if err != nil {
-			logger.Warn("failed to match price for instance",
+			c.logger.Warn("failed to match price for instance",
 				"name", instance.Name,
 				"region", instance.Region,
 				"tier", instance.Settings.Tier,

--- a/pkg/google/cloudsql/cloudsql_test.go
+++ b/pkg/google/cloudsql/cloudsql_test.go
@@ -125,9 +125,9 @@ func TestNew_FailsIfInitialSKUFetchFails(t *testing.T) {
 	require.NoError(t, err)
 
 	gcpClient := client.NewMock("test-project", 0, nil, nil, catalogClient, computeService, sqlAdminService, nil)
-	config := &Config{Projects: "test-project", Logger: slog.New(slog.NewTextHandler(os.Stdout, nil))}
+	config := &Config{Projects: "test-project"}
 
-	_, err = New(context.Background(), config, gcpClient)
+	_, err = New(context.Background(), config, slog.New(slog.NewTextHandler(os.Stdout, nil)), gcpClient)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "failed to initialise Cloud SQL pricing")
 }
@@ -199,9 +199,9 @@ func TestCollect_UsesCachedSKUs(t *testing.T) {
 	require.NoError(t, err)
 
 	gcpClient := client.NewMock("test-project", 0, nil, nil, catalogClient, computeService, sqlAdminService, nil)
-	config := &Config{Projects: "test-project", Logger: slog.New(slog.NewTextHandler(os.Stdout, nil))}
+	config := &Config{Projects: "test-project"}
 
-	collector, err := New(context.Background(), config, gcpClient)
+	collector, err := New(context.Background(), config, slog.New(slog.NewTextHandler(os.Stdout, nil)), gcpClient)
 	require.NoError(t, err)
 
 	// Disable the billing backend — Collect() must use SKUs cached at init
@@ -363,8 +363,8 @@ func TestCollector(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gcpClient := newTestGCPClient(t, tt.regionsHandlers, tt.sqlAdminHandlers, tt.skus)
-			config := &Config{Projects: "test-project", Logger: slog.New(slog.NewTextHandler(os.Stdout, nil))}
-			collector, err := New(context.Background(), config, gcpClient)
+			config := &Config{Projects: "test-project"}
+			collector, err := New(context.Background(), config, slog.New(slog.NewTextHandler(os.Stdout, nil)), gcpClient)
 			require.NoError(t, err)
 
 			ch := make(chan prometheus.Metric, 1)
@@ -442,8 +442,8 @@ func TestGetAllCloudSQL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gcpClient := newTestGCPClient(t, tt.regionsHandlers, tt.sqlAdminHandlers, nil)
-			config := &Config{Projects: "test-project", Logger: slog.New(slog.NewTextHandler(os.Stdout, nil))}
-			collector, err := New(context.Background(), config, gcpClient)
+			config := &Config{Projects: "test-project"}
+			collector, err := New(context.Background(), config, slog.New(slog.NewTextHandler(os.Stdout, nil)), gcpClient)
 			require.NoError(t, err)
 
 			instances, err := collector.getAllCloudSQL(context.Background())

--- a/pkg/google/gcp.go
+++ b/pkg/google/gcp.go
@@ -90,10 +90,11 @@ func New(ctx context.Context, config *Config) (*GCP, error) {
 		var collector provider.Collector
 		switch strings.ToUpper(service) {
 		case "GCS":
-			collector, err = gcs.New(&gcs.Config{
+			collector, err = gcs.New(ctx, &gcs.Config{
 				ProjectId:      config.ProjectId,
 				Projects:       config.Projects,
 				ScrapeInterval: config.ScrapeInterval,
+				Logger:         config.Logger,
 			}, gcpClient)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",

--- a/pkg/google/gcp.go
+++ b/pkg/google/gcp.go
@@ -94,8 +94,7 @@ func New(ctx context.Context, config *Config) (*GCP, error) {
 				ProjectId:      config.ProjectId,
 				Projects:       config.Projects,
 				ScrapeInterval: config.ScrapeInterval,
-				Logger:         config.Logger,
-			}, gcpClient)
+			}, logger, gcpClient)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
 					slog.String("service", service),
@@ -105,9 +104,8 @@ func New(ctx context.Context, config *Config) (*GCP, error) {
 		case "GKE":
 			collector, err = gke.New(ctx, &gke.Config{
 				Projects:       config.Projects,
-				Logger:         config.Logger,
 				ScrapeInterval: config.ScrapeInterval,
-			}, gcpClient)
+			}, logger, gcpClient)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
 					slog.String("service", service),
@@ -118,9 +116,8 @@ func New(ctx context.Context, config *Config) (*GCP, error) {
 			// CLB = Cloud Load Balancer, but we use forwarding rules to calculate price
 			collector, err = networking.New(ctx, &networking.Config{
 				ScrapeInterval: config.ScrapeInterval,
-				Logger:         config.Logger,
 				Projects:       config.Projects,
-			}, gcpClient)
+			}, logger, gcpClient)
 			logger.LogAttrs(ctx, slog.LevelInfo, "Creating collector",
 				slog.String("service", service),
 				slog.String("projects", config.Projects))
@@ -133,9 +130,8 @@ func New(ctx context.Context, config *Config) (*GCP, error) {
 		case "VPC":
 			collector, err = vpc.New(ctx, &vpc.Config{
 				Projects:       config.Projects,
-				Logger:         config.Logger,
 				ScrapeInterval: config.ScrapeInterval,
-			}, gcpClient)
+			}, logger, gcpClient)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
 					slog.String("service", service),
@@ -146,8 +142,7 @@ func New(ctx context.Context, config *Config) (*GCP, error) {
 			collector, err = cloudsql.New(ctx, &cloudsql.Config{
 				Projects:       config.Projects,
 				ScrapeInterval: config.ScrapeInterval,
-				Logger:         config.Logger,
-			}, gcpClient)
+			}, logger, gcpClient)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
 					slog.String("service", service),
@@ -158,8 +153,7 @@ func New(ctx context.Context, config *Config) (*GCP, error) {
 			collector, err = gcpmanagedkafka.New(ctx, &gcpmanagedkafka.Config{
 				Projects:       config.Projects,
 				ScrapeInterval: config.ScrapeInterval,
-				Logger:         config.Logger,
-			}, gcpClient)
+			}, logger, gcpClient)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
 					slog.String("service", service),

--- a/pkg/google/gcs/gcs.go
+++ b/pkg/google/gcs/gcs.go
@@ -86,6 +86,7 @@ type Collector struct {
 	nextScrape time.Time
 	metrics    *metrics.Metrics
 	gcpClient  client.Client
+	logger     *slog.Logger
 }
 
 func (c *Collector) Describe(_ chan<- *prometheus.Desc) error {
@@ -100,20 +101,23 @@ type Config struct {
 	ProjectId      string
 	Projects       string
 	ScrapeInterval time.Duration
+	Logger         *slog.Logger
 }
 
-func New(config *Config, gcpClient client.Client) (*Collector, error) {
+func New(ctx context.Context, config *Config, gcpClient client.Client) (*Collector, error) {
 	if config.ProjectId == "" {
 		return nil, fmt.Errorf("projectID cannot be empty")
 	}
 
+	logger := config.Logger.With("collector", collectorName)
+
 	projects := strings.Split(config.Projects, ",")
 	if len(projects) == 1 && projects[0] == "" {
-		slog.Info("No bucket projects specified, defaulting to project", "projectId", config.ProjectId)
+		logger.LogAttrs(ctx, slog.LevelInfo, "no bucket projects specified, defaulting to project", slog.String("projectId", config.ProjectId))
 		projects = []string{config.ProjectId}
 	}
 
-	regions := client.RegionsForProjects(gcpClient, projects, slog.Default())
+	regions := client.RegionsForProjects(gcpClient, projects, logger)
 
 	return &Collector{
 		Projects: projects,
@@ -123,6 +127,7 @@ func New(config *Config, gcpClient client.Client) (*Collector, error) {
 		nextScrape: time.Now().Add(-config.ScrapeInterval),
 		metrics:    metrics.NewMetrics(),
 		gcpClient:  gcpClient,
+		logger:     logger,
 	}, nil
 }
 
@@ -136,7 +141,7 @@ func (c *Collector) Name() string {
 
 // Register is called when the collector is created and is responsible for registering the metrics with the registry
 func (c *Collector) Register(registry provider.Registry) error {
-	slog.Info("Registering GCS metrics")
+	c.logger.Info("Registering GCS metrics")
 	registry.MustRegister(c.metrics.StorageGauge)
 	registry.MustRegister(c.metrics.StorageDiscountGauge)
 	registry.MustRegister(c.metrics.OperationsDiscountGauge)
@@ -150,7 +155,7 @@ func (c *Collector) Register(registry provider.Registry) error {
 
 // collectMetrics performs the actual collection work
 func (c *Collector) collectMetrics(ctx context.Context) error {
-	slog.Info("Collecting GCS metrics")
+	c.logger.Info("Collecting GCS metrics")
 	now := time.Now()
 
 	// If the nextScrape time is in the future, return nil and do not scrape
@@ -163,16 +168,16 @@ func (c *Collector) collectMetrics(ctx context.Context) error {
 	c.metrics.NextScrapeGauge.Set(float64(c.nextScrape.Unix()))
 	exporterOperationsDiscounts(c.metrics)
 	if err := c.gcpClient.ExportRegionalDiscounts(ctx, c.metrics); err != nil {
-		slog.Error("Error exporting regional discounts", "error", err)
+		c.logger.LogAttrs(ctx, slog.LevelError, "Error exporting regional discounts", slog.Any("error", err))
 	}
 
 	if err := c.gcpClient.ExportBucketInfo(ctx, c.Projects, c.metrics); err != nil {
-		slog.Error("Error exporting bucket info", "error", err)
+		c.logger.LogAttrs(ctx, slog.LevelError, "Error exporting bucket info", slog.Any("error", err))
 	}
 
 	serviceName, err := c.gcpClient.GetServiceName(ctx, "Cloud Storage")
 	if err != nil {
-		slog.Error("Error getting service name", "error", err)
+		c.logger.LogAttrs(ctx, slog.LevelError, "Error getting service name", slog.Any("error", err))
 		return err
 	}
 	c.gcpClient.ExportGCPCostData(ctx, serviceName, c.metrics)

--- a/pkg/google/gcs/gcs.go
+++ b/pkg/google/gcs/gcs.go
@@ -101,15 +101,14 @@ type Config struct {
 	ProjectId      string
 	Projects       string
 	ScrapeInterval time.Duration
-	Logger         *slog.Logger
 }
 
-func New(ctx context.Context, config *Config, gcpClient client.Client) (*Collector, error) {
+func New(ctx context.Context, config *Config, logger *slog.Logger, gcpClient client.Client) (*Collector, error) {
 	if config.ProjectId == "" {
 		return nil, fmt.Errorf("projectID cannot be empty")
 	}
 
-	logger := config.Logger.With("collector", collectorName)
+	logger = logger.With("collector", collectorName)
 
 	projects := strings.Split(config.Projects, ",")
 	if len(projects) == 1 && projects[0] == "" {

--- a/pkg/google/gcs/gcs.go
+++ b/pkg/google/gcs/gcs.go
@@ -140,7 +140,7 @@ func (c *Collector) Name() string {
 
 // Register is called when the collector is created and is responsible for registering the metrics with the registry
 func (c *Collector) Register(registry provider.Registry) error {
-	c.logger.Info("Registering GCS metrics")
+	c.logger.Info("registering GCS metrics")
 	registry.MustRegister(c.metrics.StorageGauge)
 	registry.MustRegister(c.metrics.StorageDiscountGauge)
 	registry.MustRegister(c.metrics.OperationsDiscountGauge)
@@ -154,7 +154,7 @@ func (c *Collector) Register(registry provider.Registry) error {
 
 // collectMetrics performs the actual collection work
 func (c *Collector) collectMetrics(ctx context.Context) error {
-	c.logger.Info("Collecting GCS metrics")
+	c.logger.Info("collecting GCS metrics")
 	now := time.Now()
 
 	// If the nextScrape time is in the future, return nil and do not scrape
@@ -167,16 +167,16 @@ func (c *Collector) collectMetrics(ctx context.Context) error {
 	c.metrics.NextScrapeGauge.Set(float64(c.nextScrape.Unix()))
 	exporterOperationsDiscounts(c.metrics)
 	if err := c.gcpClient.ExportRegionalDiscounts(ctx, c.metrics); err != nil {
-		c.logger.LogAttrs(ctx, slog.LevelError, "Error exporting regional discounts", slog.Any("error", err))
+		c.logger.LogAttrs(ctx, slog.LevelError, "error exporting regional discounts", slog.Any("error", err))
 	}
 
 	if err := c.gcpClient.ExportBucketInfo(ctx, c.Projects, c.metrics); err != nil {
-		c.logger.LogAttrs(ctx, slog.LevelError, "Error exporting bucket info", slog.Any("error", err))
+		c.logger.LogAttrs(ctx, slog.LevelError, "error exporting bucket info", slog.Any("error", err))
 	}
 
 	serviceName, err := c.gcpClient.GetServiceName(ctx, "Cloud Storage")
 	if err != nil {
-		c.logger.LogAttrs(ctx, slog.LevelError, "Error getting service name", slog.Any("error", err))
+		c.logger.LogAttrs(ctx, slog.LevelError, "error getting service name", slog.Any("error", err))
 		return err
 	}
 	c.gcpClient.ExportGCPCostData(ctx, serviceName, c.metrics)

--- a/pkg/google/gcs/gcs_test.go
+++ b/pkg/google/gcs/gcs_test.go
@@ -42,8 +42,7 @@ func TestNew(t *testing.T) {
 	t.Run("should return a non-nil client", func(t *testing.T) {
 		gcsCollector, err := New(context.Background(), &Config{
 			ProjectId: "project-1",
-			Logger:    slog.Default(),
-		}, gcpClient)
+		}, slog.Default(), gcpClient)
 		assert.NoError(t, err)
 		assert.NotNil(t, gcsCollector)
 	})
@@ -51,8 +50,7 @@ func TestNew(t *testing.T) {
 	t.Run("collectorName should be GCS", func(t *testing.T) {
 		gcsCollector, _ := New(context.Background(), &Config{
 			ProjectId: "project-1",
-			Logger:    slog.Default(),
-		}, gcpClient)
+		}, slog.Default(), gcpClient)
 		assert.Equal(t, "GCS", gcsCollector.Name())
 	})
 }
@@ -269,8 +267,7 @@ func TestCollector_Collect(t *testing.T) {
 	assert.NoError(t, err)
 	collector, err := New(context.Background(), &Config{
 		ProjectId: "project-1",
-		Logger:    slog.Default(),
-	}, gcpClient)
+	}, slog.Default(), gcpClient)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, collector)

--- a/pkg/google/gcs/gcs_test.go
+++ b/pkg/google/gcs/gcs_test.go
@@ -3,6 +3,7 @@ package gcs
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -39,16 +40,18 @@ func TestNew(t *testing.T) {
 	)
 
 	t.Run("should return a non-nil client", func(t *testing.T) {
-		gcsCollector, err := New(&Config{
+		gcsCollector, err := New(context.Background(), &Config{
 			ProjectId: "project-1",
+			Logger:    slog.Default(),
 		}, gcpClient)
 		assert.NoError(t, err)
 		assert.NotNil(t, gcsCollector)
 	})
 
 	t.Run("collectorName should be GCS", func(t *testing.T) {
-		gcsCollector, _ := New(&Config{
+		gcsCollector, _ := New(context.Background(), &Config{
 			ProjectId: "project-1",
+			Logger:    slog.Default(),
 		}, gcpClient)
 		assert.Equal(t, "GCS", gcsCollector.Name())
 	})
@@ -197,6 +200,7 @@ func TestGetServiceNameByReadableName(t *testing.T) {
 			l, err := net.Listen("tcp", "localhost:0")
 			assert.NoError(t, err)
 			gsrv := grpc.NewServer()
+			billingpb.RegisterCloudCatalogServer(gsrv, &fakeCloudBillingServer{})
 			defer gsrv.Stop()
 			go func() {
 				if err = gsrv.Serve(l); err != nil {
@@ -204,7 +208,6 @@ func TestGetServiceNameByReadableName(t *testing.T) {
 				}
 			}()
 
-			billingpb.RegisterCloudCatalogServer(gsrv, &fakeCloudBillingServer{})
 			catalogClient, err := billingv1.NewCloudCatalogClient(t.Context(),
 				option.WithEndpoint(l.Addr().String()),
 				option.WithoutAuthentication(),
@@ -249,13 +252,13 @@ func TestCollector_Collect(t *testing.T) {
 	assert.NoError(t, err)
 
 	gsrv := grpc.NewServer()
+	billingpb.RegisterCloudCatalogServer(gsrv, &fakeCloudBillingServer{})
 	defer gsrv.Stop()
 	go func() {
 		if err = gsrv.Serve(l); err != nil {
 			t.Errorf("failed to serve: %v", err)
 		}
 	}()
-	billingpb.RegisterCloudCatalogServer(gsrv, &fakeCloudBillingServer{})
 	cloudCatalogClient, err := billingv1.NewCloudCatalogClient(t.Context(),
 		option.WithEndpoint(l.Addr().String()),
 		option.WithoutAuthentication(),
@@ -264,8 +267,9 @@ func TestCollector_Collect(t *testing.T) {
 	gcpClient := client.NewMock("project-1", 0, regionsClient, storageClient, cloudCatalogClient, nil, nil, nil)
 
 	assert.NoError(t, err)
-	collector, err := New(&Config{
+	collector, err := New(context.Background(), &Config{
 		ProjectId: "project-1",
+		Logger:    slog.Default(),
 	}, gcpClient)
 
 	assert.NoError(t, err)

--- a/pkg/google/gke/gke.go
+++ b/pkg/google/gke/gke.go
@@ -57,7 +57,6 @@ var (
 type Config struct {
 	Projects       string
 	ScrapeInterval time.Duration
-	Logger         *slog.Logger
 }
 
 type Collector struct {
@@ -234,8 +233,8 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 	return nil
 }
 
-func New(ctx context.Context, config *Config, gcpClient client.Client) (*Collector, error) {
-	logger := config.Logger.With("collector", "gke")
+func New(ctx context.Context, config *Config, logger *slog.Logger, gcpClient client.Client) (*Collector, error) {
+	logger = logger.With("collector", "gke")
 
 	pm, err := NewPricingMap(ctx, gcpClient)
 	if err != nil {

--- a/pkg/google/gke/gke_test.go
+++ b/pkg/google/gke/gke_test.go
@@ -40,7 +40,6 @@ func TestCollector_Collect(t *testing.T) {
 		"Handle http error": {
 			config: &Config{
 				Projects: "testing",
-				Logger:   logger,
 			},
 			testServer: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
@@ -53,7 +52,6 @@ func TestCollector_Collect(t *testing.T) {
 			config: &Config{
 				Projects: "testing,testing-1",
 
-				Logger: logger,
 			},
 			collectResponse: 1.0,
 			expectedMetrics: []*utils.MetricResult{
@@ -485,7 +483,7 @@ func TestCollector_Collect(t *testing.T) {
 			require.NoError(t, err)
 
 			gcpClient := client.NewMock("testing", 0, nil, nil, cloudCatalogClient, computeService, nil, nil)
-			collector, _ := New(t.Context(), test.config, gcpClient)
+			collector, _ := New(t.Context(), test.config, logger, gcpClient)
 			require.NotNil(t, collector)
 			ch := make(chan prometheus.Metric)
 			go func() {
@@ -574,7 +572,7 @@ func TestCollector_ZoneConcurrencyLimit(t *testing.T) {
 	// that New() performs — it is irrelevant for a concurrency test.
 	collector := &Collector{
 		gcpClient: fakeClient,
-		config:    &Config{Logger: logger},
+		config:    &Config{},
 		projects:  []string{"proj1"},
 		pricingMap: &PricingMap{
 			compute: map[string]*FamilyPricing{},

--- a/pkg/google/gke/gke_test.go
+++ b/pkg/google/gke/gke_test.go
@@ -51,7 +51,6 @@ func TestCollector_Collect(t *testing.T) {
 		"Parse our regular response": {
 			config: &Config{
 				Projects: "testing,testing-1",
-
 			},
 			collectResponse: 1.0,
 			expectedMetrics: []*utils.MetricResult{

--- a/pkg/google/managedkafka/managedkafka.go
+++ b/pkg/google/managedkafka/managedkafka.go
@@ -46,7 +46,6 @@ var (
 type Config struct {
 	Projects       string
 	ScrapeInterval time.Duration
-	Logger         *slog.Logger
 }
 
 type Collector struct {
@@ -65,8 +64,8 @@ type clusterPricingData struct {
 	memoryGiB   float64
 }
 
-func New(ctx context.Context, config *Config, gcpClient client.Client) (*Collector, error) {
-	logger := config.Logger.With("collector", collectorName)
+func New(ctx context.Context, config *Config, logger *slog.Logger, gcpClient client.Client) (*Collector, error) {
+	logger = logger.With("collector", collectorName)
 
 	pm, err := newPricingMap(ctx, logger, gcpClient)
 	if err != nil {

--- a/pkg/google/managedkafka/managedkafka_test.go
+++ b/pkg/google/managedkafka/managedkafka_test.go
@@ -114,8 +114,7 @@ func TestBuildClusterPricingData(t *testing.T) {
 func TestNewFailsIfInitialPricingFetchFails(t *testing.T) {
 	_, err := New(t.Context(), &Config{
 		Projects: "test-project",
-		Logger:   testLogger(),
-	}, &stubClient{
+	}, testLogger(), &stubClient{
 		serviceNameErr: fmt.Errorf("billing API unavailable"),
 	})
 
@@ -126,8 +125,7 @@ func TestNewFailsIfInitialPricingFetchFails(t *testing.T) {
 func TestNewFailsIfPricingContainsMultipleComputePricesForRegion(t *testing.T) {
 	_, err := New(t.Context(), &Config{
 		Projects: "test-project",
-		Logger:   testLogger(),
-	}, &stubClient{
+	}, testLogger(), &stubClient{
 		serviceName: "services/managed-kafka",
 		skus: []*billingpb.Sku{
 			newSKU("Managed Service for Apache Kafka CPU+RAM", "us-central1", 0, 90000000, ""),
@@ -142,8 +140,7 @@ func TestNewFailsIfPricingContainsMultipleComputePricesForRegion(t *testing.T) {
 func TestNewAllowsDuplicateComputePriceForRegionWhenValuesMatch(t *testing.T) {
 	_, err := New(t.Context(), &Config{
 		Projects: "test-project",
-		Logger:   testLogger(),
-	}, &stubClient{
+	}, testLogger(), &stubClient{
 		serviceName: "services/managed-kafka",
 		skus: []*billingpb.Sku{
 			newSKU("Managed Service for Apache Kafka CPU+RAM", "us-central1", 0, 90000000, ""),
@@ -177,8 +174,7 @@ func TestCollectorCollectEmitsHourlyRateMetrics(t *testing.T) {
 
 	collector, err := New(t.Context(), &Config{
 		Projects: "test-project",
-		Logger:   testLogger(),
-	}, gcpClient)
+	}, testLogger(), gcpClient)
 	require.NoError(t, err)
 
 	results, err := collectMetricResults(t, collector)
@@ -223,8 +219,7 @@ func TestCollectorCollectEmitsHourlyRateMetricsFromCurrentBillingCatalogSKUs(t *
 
 	collector, err := New(t.Context(), &Config{
 		Projects: "test-project",
-		Logger:   testLogger(),
-	}, gcpClient)
+	}, testLogger(), gcpClient)
 	require.NoError(t, err)
 
 	results, err := collectMetricResults(t, collector)
@@ -262,8 +257,7 @@ func TestCollectorCollectContinuesWhenLocationListingFails(t *testing.T) {
 
 	collector, err := New(t.Context(), &Config{
 		Projects: "test-project",
-		Logger:   testLogger(),
-	}, gcpClient)
+	}, testLogger(), gcpClient)
 	require.NoError(t, err)
 
 	results, err := collectMetricResults(t, collector)

--- a/pkg/google/networking/forwarding_rule.go
+++ b/pkg/google/networking/forwarding_rule.go
@@ -49,7 +49,6 @@ var (
 )
 
 type Config struct {
-	Logger         *slog.Logger
 	ScrapeInterval time.Duration
 	Projects       string
 }
@@ -80,8 +79,8 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
 	return nil
 }
 
-func New(ctx context.Context, config *Config, gcpClient client.Client) (*Collector, error) {
-	logger := config.Logger.With("collector", "forwarding_rule")
+func New(ctx context.Context, config *Config, logger *slog.Logger, gcpClient client.Client) (*Collector, error) {
+	logger = logger.With("collector", "forwarding_rule")
 
 	pm, err := newPricingMap(ctx, logger, gcpClient)
 	if err != nil {

--- a/pkg/google/vpc/vpc.go
+++ b/pkg/google/vpc/vpc.go
@@ -67,7 +67,6 @@ var (
 type Config struct {
 	Projects       string
 	ScrapeInterval time.Duration
-	Logger         *slog.Logger
 }
 
 // Collector implements provider.Collector for GCP VPC metrics
@@ -81,8 +80,8 @@ type Collector struct {
 }
 
 // New creates a new VPC collector and starts periodic pricing refresh
-func New(ctx context.Context, config *Config, gcpClient client.Client) (*Collector, error) {
-	logger := config.Logger.With("collector", "vpc")
+func New(ctx context.Context, config *Config, logger *slog.Logger, gcpClient client.Client) (*Collector, error) {
+	logger = logger.With("collector", "vpc")
 
 	pricingMap := NewVPCPricingMap(logger, gcpClient)
 

--- a/pkg/google/vpc/vpc_test.go
+++ b/pkg/google/vpc/vpc_test.go
@@ -24,10 +24,9 @@ func TestNew(t *testing.T) {
 	config := &Config{
 		Projects:       "test-project-1,test-project-2",
 		ScrapeInterval: 5 * time.Minute,
-		Logger:         logger,
 	}
 
-	collector, err := New(t.Context(), config, mockClient)
+	collector, err := New(t.Context(), config, logger, mockClient)
 	if err != nil {
 		t.Fatalf("Failed to create VPC collector: %v", err)
 	}

--- a/pkg/provider/mocks/provider.go
+++ b/pkg/provider/mocks/provider.go
@@ -206,44 +206,6 @@ func (mr *MockCollectorMockRecorder) Register(r any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockCollector)(nil).Register), r)
 }
 
-// MockRegionsProvider is a mock of RegionsProvider interface.
-type MockRegionsProvider struct {
-	ctrl     *gomock.Controller
-	recorder *MockRegionsProviderMockRecorder
-	isgomock struct{}
-}
-
-// MockRegionsProviderMockRecorder is the mock recorder for MockRegionsProvider.
-type MockRegionsProviderMockRecorder struct {
-	mock *MockRegionsProvider
-}
-
-// NewMockRegionsProvider creates a new mock instance.
-func NewMockRegionsProvider(ctrl *gomock.Controller) *MockRegionsProvider {
-	mock := &MockRegionsProvider{ctrl: ctrl}
-	mock.recorder = &MockRegionsProviderMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockRegionsProvider) EXPECT() *MockRegionsProviderMockRecorder {
-	return m.recorder
-}
-
-// Regions mocks base method.
-func (m *MockRegionsProvider) Regions() []string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Regions")
-	ret0, _ := ret[0].([]string)
-	return ret0
-}
-
-// Regions indicates an expected call of Regions.
-func (mr *MockRegionsProviderMockRecorder) Regions() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Regions", reflect.TypeOf((*MockRegionsProvider)(nil).Regions))
-}
-
 // MockProvider is a mock of Provider interface.
 type MockProvider struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
Standardizes collector constructors, `Config` structs, and error handling across AWS, GCP, and Azure collectors.

## Changes

**Constructor signatures**
- Standardize all collector constructors to `New(ctx context.Context, cfg *Config, ...) (*Collector, error)`.
- Applies to: `s3`, `rds`, `elb` (AWS), `gcs` (GCP), `blob` (Azure).

**Structured logging**
- Add `Logger *slog.Logger` to collector `Config` structs for `s3`, `rds`, `elb`, `gcs`, and `aks`.
- Replace package-level `slog` calls with instance loggers scoped with a `"collector"` attribute.

**Naming**
- Rename `SubscriptionId` to `SubscriptionID` per Go acronym conventions across `azure`, `blob`, and `aks`.
- Rename `elb.Config.RegionClients` to `RegionMap` for consistency with other collectors.
- Capitalize `rds.serviceName` from `"rds"` to `"RDS"`.

**Error handling**
- Change AWS provider to log and skip collectors that fail to initialize (`rds`, `elb`, `vpc` pricing config), rather than returning an error that kills the whole provider. This matches the existing pattern for other AWS collectors.

**Test fixes**
- Fix race condition in GCS tests by registering the gRPC service before calling `Serve`.