### PR TITLE
Surface provider in operational metrics.

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -325,7 +325,7 @@ func (a *AWS) Collect(ch chan<- prometheus.Metric) {
 	g.SetLimit(collectConcurrencyLimit)
 	for _, c := range a.collectors {
 		g.Go(func() error {
-			duration, hasError := collectormetrics.Collect(collectCtx, c, ch, a.logger)
+			duration, hasError := collectormetrics.Collect(collectCtx, c, ch, a.logger, subsystem)
 
 			//TODO: remove collectorErrors once we have the new metrics
 			collectorErrors := 0.0

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -137,11 +137,16 @@ func New(ctx context.Context, config *Config) (*AWS, error) {
 		return nil, err
 	}
 
-	return newWithDependencies(ctx, config, awsClient, awsClientPerRegion, regions, ac)
+	pricingConfig, err := createAWSConfig(ctx, "us-east-1", config.Profile, config.RoleARN)
+	if err != nil {
+		return nil, err
+	}
+
+	return newWithDependencies(ctx, config, awsClient, awsClientPerRegion, regions, ac, pricingConfig)
 }
 
 // newWithDependencies creates an AWS provider with all dependencies injected as parameters
-func newWithDependencies(ctx context.Context, config *Config, awsClient client.Client, regionClients map[string]client.Client, regions []types.Region, awsConfig aws.Config) (*AWS, error) {
+func newWithDependencies(ctx context.Context, config *Config, awsClient client.Client, regionClients map[string]client.Client, regions []types.Region, awsConfig aws.Config, pricingConfig aws.Config) (*AWS, error) {
 	var collectors []provider.Collector
 	logger := config.Logger.With("provider", subsystem)
 
@@ -174,12 +179,6 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 			}
 			collectors = append(collectors, collector)
 		case serviceRDS:
-			// pricing API for RDS client needs to use always the same region
-			// as for RDS , the pricing data is only available in the us-east-1
-			pricingConfig, err := createAWSConfig(ctx, "us-east-1", config.Profile, config.RoleARN)
-			if err != nil {
-				return nil, err
-			}
 			awsRDSClient := client.NewAWSClient(client.Config{
 				PricingService: awsPricing.NewFromConfig(pricingConfig),
 				RDSService:     rds.NewFromConfig(awsConfig),
@@ -208,14 +207,8 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 			}
 			collectors = append(collectors, collector)
 		case serviceELB:
-			// pricing API for ELB client needs to use always the same region
-			// as the pricing data is only available in us-east-1
-			elbPricingConfig, err := createAWSConfig(ctx, "us-east-1", config.Profile, config.RoleARN)
-			if err != nil {
-				return nil, err
-			}
 			awsELBPricingClient := client.NewAWSClient(client.Config{
-				PricingService: awsPricing.NewFromConfig(elbPricingConfig),
+				PricingService: awsPricing.NewFromConfig(pricingConfig),
 			})
 			collector := elb.New(&elb.Config{
 				Regions:        regions,
@@ -227,12 +220,6 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 			})
 			collectors = append(collectors, collector)
 		case serviceVPC:
-			// pricing API for VPC client needs to use always the same region
-			// as for VPC, the pricing data is only available in the us-east-1
-			pricingConfig, err := createAWSConfig(ctx, "us-east-1", config.Profile, config.RoleARN)
-			if err != nil {
-				return nil, err
-			}
 			awsVPCClient := client.NewAWSClient(client.Config{
 				PricingService: awsPricing.NewFromConfig(pricingConfig),
 				EC2Service:     ec2.NewFromConfig(pricingConfig),
@@ -252,13 +239,8 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 			}
 			collectors = append(collectors, collector)
 		case serviceMSK:
-			// The AWS Pricing API is only available in us-east-1 and ap-south-1.
-			// Copy the already-loaded config and pin the region to us-east-1 so
-			// MSK pricing lookups succeed regardless of the collector's configured regions.
-			mskPricingConfig := awsConfig.Copy()
-			mskPricingConfig.Region = "us-east-1"
 			awsMSKClient := client.NewAWSClient(client.Config{
-				PricingService: awsPricing.NewFromConfig(mskPricingConfig),
+				PricingService: awsPricing.NewFromConfig(pricingConfig),
 			})
 			collector, err := mskCollector.New(ctx, &mskCollector.Config{
 				Regions:   regions,

--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -150,6 +150,26 @@ func Test_NewWithDependencies(t *testing.T) {
 			expectedCollectors: 1,
 		},
 		{
+			name:     "RDS service creates RDS collector",
+			services: []string{"RDS"},
+			regions: []types.Region{
+				{RegionName: stringPtr("us-east-1")},
+			},
+			setupRegionClients: map[string]client.Client{
+				"us-east-1": nil,
+			},
+			expectedCollectors: 1,
+		},
+		{
+			name:     "VPC service creates VPC collector",
+			services: []string{"VPC"},
+			regions: []types.Region{
+				{RegionName: stringPtr("us-east-1")},
+			},
+			setupRegionClients: map[string]client.Client{},
+			expectedCollectors: 0,
+		},
+		{
 			name:     "MSK service creates MSK collector",
 			services: []string{"MSK"},
 			regions: []types.Region{
@@ -199,6 +219,7 @@ func Test_NewWithDependencies(t *testing.T) {
 
 			// Call function
 			awsConfig := aws.Config{Region: "us-east-1"}
+			pricingConfig := aws.Config{Region: "us-east-1"}
 			aws, err := newWithDependencies(
 				t.Context(),
 				config,
@@ -206,6 +227,7 @@ func Test_NewWithDependencies(t *testing.T) {
 				regionClients,
 				tt.regions,
 				awsConfig,
+				pricingConfig,
 			)
 
 			// Validate results
@@ -595,7 +617,8 @@ func Test_AllCostMetricDescsIncludeAccountID(t *testing.T) {
 
 	regions := []types.Region{{RegionName: stringPtr("us-east-1")}}
 	awsConfig := aws.Config{Region: "us-east-1"}
-	a, err := newWithDependencies(t.Context(), config, mockClient, regionClients, regions, awsConfig)
+	pricingConfig := aws.Config{Region: "us-east-1"}
+	a, err := newWithDependencies(t.Context(), config, mockClient, regionClients, regions, awsConfig, pricingConfig)
 	require.NoError(t, err)
 
 	ch := make(chan *prometheus.Desc, 100)

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -175,7 +175,7 @@ func (a *Azure) Collect(ch chan<- prometheus.Metric) {
 		go func(c provider.Collector) {
 			defer wg.Done()
 
-			duration, hasError := collectormetrics.Collect(collectCtx, c, ch, a.logger)
+			duration, hasError := collectormetrics.Collect(collectCtx, c, ch, a.logger, subsystem)
 
 			//TODO: remove collectorErrors once we have the new metrics
 			collectorErrors := 0.0

--- a/pkg/collectormetrics/collectormetrics.go
+++ b/pkg/collectormetrics/collectormetrics.go
@@ -18,7 +18,7 @@ var durationHistogramVec = prometheus.NewHistogramVec(
 		NativeHistogramBucketFactor:    1.1,
 		NativeHistogramMaxBucketNumber: 100,
 	},
-	[]string{"collector", "region"},
+	[]string{"collector", "provider", "region"},
 )
 
 var errorCounterVec = prometheus.NewCounterVec(
@@ -26,7 +26,7 @@ var errorCounterVec = prometheus.NewCounterVec(
 		Name: prometheus.BuildFQName(cloudcost_exporter.ExporterName, "collector", "error"),
 		Help: "Total number of errors that occurred during the last scrape.",
 	},
-	[]string{"collector", "region"},
+	[]string{"collector", "provider", "region"},
 )
 
 var totalCounterVec = prometheus.NewCounterVec(
@@ -34,21 +34,21 @@ var totalCounterVec = prometheus.NewCounterVec(
 		Name: prometheus.BuildFQName(cloudcost_exporter.ExporterName, "collector", "total"),
 		Help: "Total number of scrapes.",
 	},
-	[]string{"collector", "region"},
+	[]string{"collector", "provider", "region"},
 )
 
-func emitOperationalMetrics(ch chan<- prometheus.Metric, collectorName string, region string, duration float64) {
-	h := durationHistogramVec.WithLabelValues(collectorName, region).(prometheus.Histogram)
+func emitOperationalMetrics(ch chan<- prometheus.Metric, collectorName string, providerName string, region string, duration float64) {
+	h := durationHistogramVec.WithLabelValues(collectorName, providerName, region).(prometheus.Histogram)
 	h.Observe(duration)
 	ch <- h
 
-	counter := totalCounterVec.WithLabelValues(collectorName, region)
+	counter := totalCounterVec.WithLabelValues(collectorName, providerName, region)
 	counter.Inc()
 	ch <- counter
 }
 
 // Collect collects metrics from a collector and emits operational metrics to the channel.
-func Collect(ctx context.Context, c provider.Collector, ch chan<- prometheus.Metric, logger *slog.Logger) (float64, bool) {
+func Collect(ctx context.Context, c provider.Collector, ch chan<- prometheus.Metric, logger *slog.Logger, providerName string) (float64, bool) {
 	start := time.Now()
 	var hasError bool
 	var duration float64
@@ -70,14 +70,14 @@ func Collect(ctx context.Context, c provider.Collector, ch chan<- prometheus.Met
 			slog.String("message", collectErr.Error()),
 		)
 		for _, region := range regions {
-			errorCounter := errorCounterVec.WithLabelValues(c.Name(), region)
+			errorCounter := errorCounterVec.WithLabelValues(c.Name(), providerName, region)
 			errorCounter.Inc()
 			ch <- errorCounter
 		}
 	}
 
 	for _, region := range regions {
-		emitOperationalMetrics(ch, c.Name(), region, duration)
+		emitOperationalMetrics(ch, c.Name(), providerName, region, duration)
 	}
 
 	return duration, hasError

--- a/pkg/collectormetrics/collectormetrics_test.go
+++ b/pkg/collectormetrics/collectormetrics_test.go
@@ -42,7 +42,7 @@ func TestCollect(t *testing.T) {
 				c.EXPECT().Collect(gomock.Any(), ch).DoAndReturn(tt.collect).AnyTimes()
 			}
 
-			duration, hasError := Collect(context.Background(), c, ch, slog.Default())
+			duration, hasError := Collect(context.Background(), c, ch, slog.Default(), "test_provider")
 
 			close(ch)
 
@@ -64,7 +64,8 @@ func TestCollect_ErrorCounterEmitted(t *testing.T) {
 	c.EXPECT().Name().Return(collectorName).AnyTimes()
 	c.EXPECT().Collect(gomock.Any(), ch).Return(assert.AnError)
 
-	_, hasError := Collect(context.Background(), c, ch, slog.Default())
+	const providerName = "test_provider"
+	_, hasError := Collect(context.Background(), c, ch, slog.Default(), providerName)
 	close(ch)
 
 	assert.True(t, hasError, "hasError should be true when Collect fails")
@@ -82,7 +83,7 @@ func TestCollect_ErrorCounterEmitted(t *testing.T) {
 		}
 		var dtoMetric dto.Metric
 		require.NoError(t, m.Write(&dtoMetric))
-		if labels := dtoMetric.GetLabel(); len(labels) == 2 && labels[0].GetValue() == collectorName && labels[1].GetValue() == utils.RegionUnknown {
+		if labels := dtoMetric.GetLabel(); len(labels) == 3 && labels[0].GetValue() == collectorName && labels[1].GetValue() == providerName && labels[2].GetValue() == utils.RegionUnknown {
 			counterValue = dtoMetric.GetCounter().GetValue()
 			found = true
 		}
@@ -143,7 +144,7 @@ func TestCollect_MultipleCollectors(t *testing.T) {
 			}
 
 			for i, c := range collectors {
-				duration, hasError := Collect(context.Background(), c, ch, slog.Default())
+				duration, hasError := Collect(context.Background(), c, ch, slog.Default(), "test_provider")
 				assert.GreaterOrEqual(t, duration, 0.0, "collector %d duration should be >= 0", i)
 				assert.Equal(t, tt.expectedErrors[i], hasError, "collector %d error status mismatch", i)
 			}

--- a/pkg/google/gcp.go
+++ b/pkg/google/gcp.go
@@ -215,7 +215,7 @@ func (g *GCP) Collect(ch chan<- prometheus.Metric) {
 	eg.SetLimit(collectConcurrencyLimit)
 	for _, c := range g.collectors {
 		eg.Go(func() error {
-			duration, hasError := collectormetrics.Collect(collectCtx, c, ch, g.logger)
+			duration, hasError := collectormetrics.Collect(collectCtx, c, ch, g.logger, subsystem)
 
 			if !hasError {
 				g.logger.LogAttrs(collectCtx, slog.LevelInfo, "Collect successful",


### PR DESCRIPTION
Surface provider in
- `cloudcost_exporter_collector_duration_seconds`
- `cloudcost_exporter_collector_error`
- `cloudcost_exporter_collector_total`


Some refactoring to invoke the pricing API on `newWithDependencies` function.

Fixes https://github.com/grafana/deployment_tools/issues/529664