### PR TITLE
feat(aws): add Bedrock token pricing collector

### DIFF
--- a/docs/metrics/aws/bedrock.md
+++ b/docs/metrics/aws/bedrock.md
@@ -1,0 +1,60 @@
+# AWS Bedrock Metrics
+
+| Metric name                                               | Metric type | Description                                                        | Labels                                                                                                                                                                |
+|-----------------------------------------------------------|-------------|--------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| cloudcost_aws_bedrock_token_input_usd_per_1k_tokens       | Gauge       | List price for AWS Bedrock input tokens in USD per 1000 tokens     | `account_id`=<AWS account ID> <br/> `region`=<AWS region> <br/> `model_id`=<model slug> <br/> `family`=<model provider> <br/> `price_tier`=<on_demand\|on_demand_batch\|on_demand_flex\|on_demand_priority\|cross_region> |
+| cloudcost_aws_bedrock_token_output_usd_per_1k_tokens      | Gauge       | List price for AWS Bedrock output tokens in USD per 1000 tokens    | `account_id`=<AWS account ID> <br/> `region`=<AWS region> <br/> `model_id`=<model slug> <br/> `family`=<model provider> <br/> `price_tier`=<on_demand\|on_demand_batch\|on_demand_flex\|on_demand_priority\|cross_region> |
+| cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units | Gauge       | List price for AWS Bedrock search units in USD per 1000 search units (e.g. Cohere Rerank) | `account_id`=<AWS account ID> <br/> `region`=<AWS region> <br/> `model_id`=<model slug> <br/> `family`=<model provider> <br/> `price_tier`=<on_demand\|cross_region> |
+
+## Overview
+
+The Bedrock collector exports list-price token cost metrics for AWS Bedrock foundation models across all configured regions. These are pricing rates, not measured spend. Multiply rates by token usage (e.g. from CloudWatch `AWS/Bedrock` metrics) to compute estimated cost.
+
+## Configuration
+
+Enable the Bedrock collector by adding `bedrock` to your AWS services configuration:
+
+```yaml
+aws:
+  services: ["bedrock"]
+  regions: ["us-east-1", "us-west-2"]
+```
+
+Or via command line:
+```bash
+--aws.services=bedrock
+```
+
+## Labels
+
+- **account_id**: The AWS account ID (12-digit), resolved via STS GetCallerIdentity
+- **region**: The AWS region for which the price applies
+- **model_id**: The model slug from the AWS Pricing API `usagetype` field (e.g. `Claude3Sonnet`, `Llama4-Scout-17B`, `Nova2.0Pro`)
+- **family**: The model provider, lowercased with spaces replaced by underscores (e.g. `anthropic`, `amazon`, `meta`, `mistral_ai`). Amazon-developed models with no provider attribute use `amazon`.
+- **price_tier**: The inference tier: `on_demand`, `on_demand_batch`, `on_demand_flex`, `on_demand_priority`, or `cross_region`
+
+## Notes
+
+- Pricing data is fetched from the AWS Pricing API (us-east-1 endpoint)
+- Prices are refreshed every 24 hours
+- Only text token SKUs are emitted (image, video, audio, cache, and guardrail SKUs are silently skipped)
+- The `model_id` label is the pricing SKU slug, not the canonical Bedrock model ARN
+
+## IAM Permissions
+
+Required permissions for Bedrock metrics collection:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "pricing:GetProducts"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```

--- a/docs/metrics/aws/bedrock.md
+++ b/docs/metrics/aws/bedrock.md
@@ -1,10 +1,10 @@
 # AWS Bedrock Metrics
 
-| Metric name                                               | Metric type | Description                                                        | Labels                                                                                                                                                                |
-|-----------------------------------------------------------|-------------|--------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| cloudcost_aws_bedrock_token_input_usd_per_1k_tokens       | Gauge       | List price for AWS Bedrock input tokens in USD per 1000 tokens     | `account_id`=<AWS account ID> <br/> `region`=<AWS region> <br/> `model_id`=<model slug> <br/> `family`=<model provider> <br/> `price_tier`=<on_demand\|on_demand_batch\|on_demand_flex\|on_demand_priority\|cross_region> |
-| cloudcost_aws_bedrock_token_output_usd_per_1k_tokens      | Gauge       | List price for AWS Bedrock output tokens in USD per 1000 tokens    | `account_id`=<AWS account ID> <br/> `region`=<AWS region> <br/> `model_id`=<model slug> <br/> `family`=<model provider> <br/> `price_tier`=<on_demand\|on_demand_batch\|on_demand_flex\|on_demand_priority\|cross_region> |
-| cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units | Gauge       | List price for AWS Bedrock search units in USD per 1000 search units (e.g. Cohere Rerank) | `account_id`=<AWS account ID> <br/> `region`=<AWS region> <br/> `model_id`=<model slug> <br/> `family`=<model provider> <br/> `price_tier`=<on_demand\|cross_region> |
+| Metric name                                               | Metric type | Description                                                   | Labels                                                                                                                                                                |
+|-----------------------------------------------------------|-------------|---------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `cloudcost_aws_bedrock_token_input_usd_per_1k_tokens`     | Gauge       | AWS Bedrock input token price in USD per 1000 tokens          | `account_id`=<AWS account ID> <br/> `region`=<AWS region> <br/> `model_id`=<model slug> <br/> `family`=<model provider> <br/> `price_tier`=<on_demand\|on_demand_batch\|on_demand_flex\|on_demand_priority\|cross_region> |
+| `cloudcost_aws_bedrock_token_output_usd_per_1k_tokens`    | Gauge       | AWS Bedrock output token price in USD per 1000 tokens         | `account_id`=<AWS account ID> <br/> `region`=<AWS region> <br/> `model_id`=<model slug> <br/> `family`=<model provider> <br/> `price_tier`=<on_demand\|on_demand_batch\|on_demand_flex\|on_demand_priority\|cross_region> |
+| `cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units` | Gauge     | AWS Bedrock search unit price in USD per 1000 search units (e.g. Cohere Rerank) | `account_id`=<AWS account ID> <br/> `region`=<AWS region> <br/> `model_id`=<model slug> <br/> `family`=<model provider> <br/> `price_tier`=<on_demand\|cross_region> |
 
 ## Overview
 
@@ -12,7 +12,7 @@ The Bedrock collector exports list-price token cost metrics for AWS Bedrock foun
 
 ## Configuration
 
-Enable the Bedrock collector by adding `bedrock` to your AWS services configuration:
+Add `bedrock` to your AWS services configuration:
 
 ```yaml
 aws:
@@ -27,18 +27,17 @@ Or via command line:
 
 ## Labels
 
-- **account_id**: The AWS account ID (12-digit), resolved via STS GetCallerIdentity
-- **region**: The AWS region for which the price applies
-- **model_id**: The model slug from the AWS Pricing API `usagetype` field (e.g. `Claude3Sonnet`, `Llama4-Scout-17B`, `Nova2.0Pro`)
-- **family**: The model provider, lowercased with spaces replaced by underscores (e.g. `anthropic`, `amazon`, `meta`, `mistral_ai`). Amazon-developed models with no provider attribute use `amazon`.
-- **price_tier**: The inference tier: `on_demand`, `on_demand_batch`, `on_demand_flex`, `on_demand_priority`, or `cross_region`
+- **`account_id`**: AWS account ID (12-digit), resolved via STS `GetCallerIdentity`
+- **`region`**: AWS region for which the price applies
+- **`model_id`**: Model slug from the AWS Pricing API `usagetype` field (e.g. `Claude3Sonnet`, `Llama4-Scout-17B`, `Nova2.0Pro`)
+- **`family`**: Model provider, lowercased with spaces replaced by underscores (e.g. `anthropic`, `amazon`, `meta`, `mistral_ai`). Models with no provider attribute use `amazon`.
+- **`price_tier`**: Inference tier: `on_demand`, `on_demand_batch`, `on_demand_flex`, `on_demand_priority`, or `cross_region`
 
 ## Notes
 
-- Pricing data is fetched from the AWS Pricing API (us-east-1 endpoint)
-- Prices are refreshed every 24 hours
-- Only text token SKUs are emitted (image, video, audio, cache, and guardrail SKUs are silently skipped)
-- The `model_id` label is the pricing SKU slug, not the canonical Bedrock model ARN
+- Pricing data is fetched from the AWS Pricing API (`us-east-1` endpoint) and refreshed every 24 hours
+- Image, video, audio, cache, and guardrail SKUs are skipped; only text token SKUs are emitted
+- `model_id` is the pricing SKU slug, not the canonical Bedrock model ARN
 
 ## IAM Permissions
 

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/grafana/cloudcost-exporter/pkg/aws/bedrock"
 	"github.com/grafana/cloudcost-exporter/pkg/aws/client"
 	ec2Collector "github.com/grafana/cloudcost-exporter/pkg/aws/ec2"
 	"github.com/grafana/cloudcost-exporter/pkg/aws/elb"
@@ -90,10 +91,11 @@ const (
 	serviceS3    = "S3"
 	serviceEC2   = "EC2"
 	serviceRDS   = "RDS"
-	serviceNATGW = "NATGATEWAY"
-	serviceELB   = "ELB"
-	serviceVPC   = "VPC"
-	serviceMSK   = "MSK"
+	serviceNATGW   = "NATGATEWAY"
+	serviceELB     = "ELB"
+	serviceVPC     = "VPC"
+	serviceMSK     = "MSK"
+	serviceBedrock = "BEDROCK"
 )
 
 func New(ctx context.Context, config *Config) (*AWS, error) {
@@ -266,6 +268,28 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 				Client:    awsMSKClient,
 				Logger:    logger,
 				AccountID: config.AccountID,
+			})
+			if err != nil {
+				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
+					slog.String("service", service),
+					slog.String("message", err.Error()))
+				continue
+			}
+			collectors = append(collectors, collector)
+		case serviceBedrock:
+			// The AWS Pricing API is only available in us-east-1 and ap-south-1.
+			// Copy the already-loaded config and pin the region to us-east-1 so
+			// Bedrock pricing lookups succeed regardless of the collector's configured regions.
+			bedrockPricingConfig := awsConfig.Copy()
+			bedrockPricingConfig.Region = "us-east-1"
+			awsBedrockClient := client.NewAWSClient(client.Config{
+				PricingService: awsPricing.NewFromConfig(bedrockPricingConfig),
+			})
+			collector, err := bedrock.New(ctx, &bedrock.Config{
+				Regions:       regions,
+				PricingClient: awsBedrockClient,
+				Logger:        logger,
+				AccountID:     config.AccountID,
 			})
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -88,9 +88,9 @@ const (
 	collectConcurrencyLimit = 10
 
 	// AWS service names used across the AWS provider.
-	serviceS3    = "S3"
-	serviceEC2   = "EC2"
-	serviceRDS   = "RDS"
+	serviceS3      = "S3"
+	serviceEC2     = "EC2"
+	serviceRDS     = "RDS"
 	serviceNATGW   = "NATGATEWAY"
 	serviceELB     = "ELB"
 	serviceVPC     = "VPC"

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -277,9 +277,10 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 			}
 			collectors = append(collectors, collector)
 		case serviceBedrock:
-			// The AWS Pricing API is only available in us-east-1 and ap-south-1.
-			// Copy the already-loaded config and pin the region to us-east-1 so
 			// Bedrock pricing lookups succeed regardless of the collector's configured regions.
+			// Note: this pins the *endpoint*, not the queried region — the collector still
+			// fetches prices per configured region via a regionCode filter. See
+			// pkg/aws/bedrock.go newPriceFetcher().
 			bedrockPricingConfig := awsConfig.Copy()
 			bedrockPricingConfig.Region = "us-east-1"
 			awsBedrockClient := client.NewAWSClient(client.Config{

--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -163,6 +163,18 @@ func Test_NewWithDependencies(t *testing.T) {
 			// The collector is skipped gracefully; newWithDependencies still succeeds.
 			expectedCollectors: 0,
 		},
+		{
+			name:     "Bedrock service is skipped gracefully when pricing API unavailable",
+			services: []string{"BEDROCK"},
+			regions: []types.Region{
+				{RegionName: stringPtr("us-east-1")},
+			},
+			setupRegionClients: map[string]client.Client{},
+			// Bedrock uses its own dedicated pricing client (not the injected awsClient),
+			// so collector creation fails without real AWS credentials in tests.
+			// The collector is skipped gracefully; newWithDependencies still succeeds.
+			expectedCollectors: 0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -583,8 +595,12 @@ func Test_AllCostMetricDescsIncludeAccountID(t *testing.T) {
 
 	// Create provider with all services that implement Describe.
 	// S3 and RDS return nil from Describe, so they won't contribute Descs,
-	// but EC2, ELB, NATGATEWAY, VPC, and MSK all do.
-	allServices := []string{serviceEC2, serviceELB, serviceNATGW, serviceVPC, serviceMSK}
+	// but EC2, ELB, NATGATEWAY, VPC, MSK, and Bedrock all do.
+	// Note: ELB, VPC, and NATGATEWAY call createAWSConfig which requires real credentials;
+	// Bedrock and MSK create their own pricing clients that also need credentials.
+	// Without credentials these collectors are skipped, but the test still verifies
+	// that any collector which does initialize exposes account_id on all its Descs.
+	allServices := []string{serviceEC2, serviceELB, serviceNATGW, serviceVPC, serviceMSK, serviceBedrock}
 	config := &Config{
 		Services:       allServices,
 		Region:         "us-east-1",

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -1,0 +1,319 @@
+package bedrock
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/prometheus/client_golang/prometheus"
+
+	cloudcostexporter "github.com/grafana/cloudcost-exporter"
+	"github.com/grafana/cloudcost-exporter/pkg/aws/client"
+	"github.com/grafana/cloudcost-exporter/pkg/aws/pricingstore"
+	"github.com/grafana/cloudcost-exporter/pkg/provider"
+	"github.com/grafana/cloudcost-exporter/pkg/utils"
+)
+
+const (
+	subsystem   = "aws_bedrock"
+	serviceName = "bedrock"
+
+	priceTierOnDemand    = "on_demand"
+	priceTierCrossRegion = "cross_region"
+
+	// compositeKeySep separates the four fields encoded in the pricingstore usagetype key.
+	compositeKeySep = "|"
+)
+
+var (
+	InputTokenCostDesc = utils.GenerateDesc(
+		cloudcostexporter.MetricPrefix,
+		subsystem,
+		utils.TokenInputCostSuffix,
+		"The cost of AWS Bedrock input tokens in USD per 1000 tokens",
+		[]string{"account_id", "region", "model_id", "family", "price_tier"},
+	)
+	OutputTokenCostDesc = utils.GenerateDesc(
+		cloudcostexporter.MetricPrefix,
+		subsystem,
+		utils.TokenOutputCostSuffix,
+		"The cost of AWS Bedrock output tokens in USD per 1000 tokens",
+		[]string{"account_id", "region", "model_id", "family", "price_tier"},
+	)
+	SearchUnitCostDesc = utils.GenerateDesc(
+		cloudcostexporter.MetricPrefix,
+		subsystem,
+		utils.SearchUnitCostSuffix,
+		"The cost of AWS Bedrock search units in USD per 1000 search units (e.g. Cohere Rerank)",
+		[]string{"account_id", "region", "model_id", "family", "price_tier"},
+	)
+)
+
+type bedrockProductInfo struct {
+	Product struct {
+		Attributes struct {
+			UsageType     string `json:"usagetype"`
+			RegionCode    string `json:"regionCode"`
+			InferenceType string `json:"inferenceType"`
+			Provider      string `json:"provider"`
+		} `json:"attributes"`
+	} `json:"product"`
+	Terms struct {
+		OnDemand map[string]struct {
+			PriceDimensions map[string]struct {
+				PricePerUnit map[string]string `json:"pricePerUnit"`
+			} `json:"priceDimensions"`
+		} `json:"OnDemand"`
+	} `json:"terms"`
+}
+
+type Config struct {
+	Regions       []ec2types.Region
+	PricingClient client.Client
+	Logger        *slog.Logger
+	AccountID     string
+}
+
+type Collector struct {
+	pricingStore pricingstore.PricingStoreRefresher
+	regions      []string
+	logger       *slog.Logger
+	accountID    string
+}
+
+func New(ctx context.Context, config *Config) (*Collector, error) {
+	logger := slog.Default()
+	if config.Logger != nil {
+		logger = config.Logger.With("logger", serviceName)
+	}
+
+	pricingStore, err := pricingstore.NewPricingStore(ctx, logger, config.Regions, newPriceFetcher(config.PricingClient))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pricing store: %w", err)
+	}
+
+	go func(ctx context.Context) {
+		priceTicker := time.NewTicker(pricingstore.PriceRefreshInterval)
+		defer priceTicker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-priceTicker.C:
+				logger.LogAttrs(ctx, slog.LevelInfo, "refreshing pricing map")
+				if err := pricingStore.PopulatePricingMap(ctx); err != nil {
+					logger.Error("error refreshing pricing map", "error", err)
+				}
+			}
+		}
+	}(ctx)
+
+	regions := make([]string, 0, len(config.Regions))
+	for _, r := range config.Regions {
+		if r.RegionName != nil {
+			regions = append(regions, *r.RegionName)
+		}
+	}
+
+	return &Collector{
+		pricingStore: pricingStore,
+		regions:      regions,
+		logger:       logger,
+		accountID:    config.AccountID,
+	}, nil
+}
+
+func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	snapshot := c.pricingStore.Snapshot()
+
+	for region, regionSnap := range snapshot.Regions() {
+		for compositeKey, price := range regionSnap.Entries() {
+			parts := strings.SplitN(compositeKey, compositeKeySep, 4)
+			if len(parts) != 4 {
+				c.logger.LogAttrs(ctx, slog.LevelWarn, "malformed Bedrock pricing key, skipping",
+					slog.String("region", region),
+					slog.String("key", compositeKey))
+				continue
+			}
+			family, direction, modelID, priceTier := parts[0], parts[1], parts[2], parts[3]
+			labelVals := []string{c.accountID, region, modelID, family, priceTier}
+
+			switch direction {
+			case "input":
+				ch <- prometheus.MustNewConstMetric(InputTokenCostDesc, prometheus.GaugeValue, price, labelVals...)
+			case "output":
+				ch <- prometheus.MustNewConstMetric(OutputTokenCostDesc, prometheus.GaugeValue, price, labelVals...)
+			case "search":
+				ch <- prometheus.MustNewConstMetric(SearchUnitCostDesc, prometheus.GaugeValue, price, labelVals...)
+			default:
+				c.logger.LogAttrs(ctx, slog.LevelWarn, "unknown direction in Bedrock pricing key, skipping",
+					slog.String("region", region),
+					slog.String("direction", direction))
+			}
+		}
+	}
+
+	return ctx.Err()
+}
+
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
+	ch <- InputTokenCostDesc
+	ch <- OutputTokenCostDesc
+	ch <- SearchUnitCostDesc
+	return nil
+}
+
+func (c *Collector) Name() string {
+	return subsystem
+}
+
+func (c *Collector) Regions() []string {
+	return c.regions
+}
+
+func (c *Collector) Register(_ provider.Registry) error {
+	return nil
+}
+
+// newPriceFetcher returns a PriceFetchFunc that fetches and preprocesses Bedrock pricing data.
+// The AWS Pricing API is only available in us-east-1 and ap-south-1; callers must pin the
+// client to us-east-1 before passing it here.
+func newPriceFetcher(pricingClient client.Client) pricingstore.PriceFetchFunc {
+	return func(ctx context.Context, region string) ([]string, error) {
+		rawItems, err := pricingClient.ListBedrockPrices(ctx, region)
+		if err != nil {
+			return nil, err
+		}
+		return preprocessBedrockPrices(rawItems), nil
+	}
+}
+
+// preprocessBedrockPrices filters and transforms raw Pricing API JSON strings. Each item's
+// usagetype field is replaced with a composite key encoding family, direction, model ID, and
+// price tier. Non-text-token SKUs (image, video, audio, cache, guardrail) are dropped.
+func preprocessBedrockPrices(rawItems []string) []string {
+	result := make([]string, 0, len(rawItems))
+	for _, raw := range rawItems {
+		if processed, ok := encodeBedrockPriceJSON(raw); ok {
+			result = append(result, processed)
+		}
+	}
+	return result
+}
+
+// encodeBedrockPriceJSON parses one raw Pricing API JSON string and returns a modified copy
+// with the usagetype replaced by a composite key: "<family>|<direction>|<modelID>|<priceTier>".
+// Returns ok=false if the entry should be skipped (non-text-token inferenceType, parse failure,
+// or unrecognized usagetype format).
+func encodeBedrockPriceJSON(raw string) (string, bool) {
+	var info bedrockProductInfo
+	if err := json.Unmarshal([]byte(raw), &info); err != nil {
+		return "", false
+	}
+
+	attrs := &info.Product.Attributes
+	direction, ok := classifyInferenceType(attrs.InferenceType)
+	if !ok {
+		return "", false
+	}
+
+	modelID, priceTier := parseBedrockModelID(attrs.UsageType)
+	if modelID == "" {
+		return "", false
+	}
+
+	family := normalizeProvider(attrs.Provider)
+	attrs.UsageType = strings.Join([]string{family, direction, modelID, priceTier}, compositeKeySep)
+
+	modified, err := json.Marshal(&info)
+	if err != nil {
+		return "", false
+	}
+	return string(modified), true
+}
+
+// classifyInferenceType maps the Bedrock Pricing API inferenceType attribute to a direction
+// string ("input", "output", "search"). Returns ok=false for non-text-token types (image,
+// video, audio, cache, guardrail) that should not be emitted as pricing metrics.
+func classifyInferenceType(inferenceType string) (direction string, ok bool) {
+	lower := strings.ToLower(inferenceType)
+	if strings.HasPrefix(lower, "prompt cache") {
+		return "", false
+	}
+	for _, media := range []string{"image", "video", "audio"} {
+		if strings.Contains(lower, media) {
+			return "", false
+		}
+	}
+	if strings.Contains(lower, "input tokens") || strings.Contains(lower, "text input token") {
+		return "input", true
+	}
+	if strings.Contains(lower, "output tokens") {
+		return "output", true
+	}
+	if strings.Contains(lower, "search unit") || strings.Contains(lower, "rerank") {
+		return "search", true
+	}
+	return "", false
+}
+
+// tokenTypeMarkers are usagetype substrings that mark the boundary between model ID and
+// token type. Checked in order so longer matches take priority over shorter ones.
+var tokenTypeMarkers = []string{
+	"-text-input-tokens",
+	"-input-tokens",
+	"-output-tokens",
+	"-search-units",
+}
+
+// parseBedrockModelID extracts the model ID slug and price tier from a Bedrock usagetype string.
+// It strips the leading region prefix (e.g. "USE1-") and the trailing token-type suffix, then
+// maps the remaining suffix to a price tier label.
+func parseBedrockModelID(usagetype string) (modelID, priceTier string) {
+	slug := usagetype
+	if i := strings.Index(usagetype, "-"); i >= 0 {
+		slug = usagetype[i+1:]
+	}
+
+	for _, marker := range tokenTypeMarkers {
+		if idx := strings.Index(slug, marker); idx >= 0 {
+			tierSuffix := slug[idx+len(marker):]
+			return slug[:idx], extractPriceTier(tierSuffix)
+		}
+	}
+	return "", priceTierOnDemand
+}
+
+// extractPriceTier maps the token-type suffix remainder (everything after the marker such as
+// "-input-tokens") to a price_tier label value.
+func extractPriceTier(suffix string) string {
+	lower := strings.ToLower(suffix)
+	if strings.Contains(lower, "cross-region") {
+		return priceTierCrossRegion
+	}
+	switch {
+	case strings.HasSuffix(lower, "-batch"):
+		return "on_demand_batch"
+	case strings.HasSuffix(lower, "-flex"):
+		return "on_demand_flex"
+	case strings.HasSuffix(lower, "-priority"):
+		return "on_demand_priority"
+	default:
+		return priceTierOnDemand
+	}
+}
+
+// normalizeProvider lowercases the provider attribute and replaces spaces with underscores
+// for use as the family label. Amazon-developed models (Nova, Titan, etc.) have an empty
+// provider attribute and are mapped to "amazon".
+func normalizeProvider(provider string) string {
+	if provider == "" {
+		return "amazon"
+	}
+	return strings.ReplaceAll(strings.ToLower(provider), " ", "_")
+}

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -88,7 +88,7 @@ type Collector struct {
 func New(ctx context.Context, config *Config) (*Collector, error) {
 	logger := slog.Default()
 	if config.Logger != nil {
-		logger = config.Logger.With("logger", serviceName)
+		logger = config.Logger.With("collector", serviceName)
 	}
 
 	pricingStore, err := pricingstore.NewPricingStore(ctx, logger, config.Regions, newPriceFetcher(config.PricingClient))
@@ -180,7 +180,15 @@ func (c *Collector) Register(_ provider.Registry) error {
 	return nil
 }
 
-// The AWS Pricing API is only available in us-east-1; callers must pin the client there.
+// Endpoint vs. filter region. The AWS Pricing API is only served from us-east-1 and
+// ap-south-1, so the *client* passed in must be pinned to one of those regions (see
+// pkg/aws/aws.go where the Bedrock pricing client is created against us-east-1).
+//
+// The `region` argument passed into the returned PriceFetchFunc is a different thing:
+// pkg/aws/client.listBedrockPrices -> listServicePrices applies it as a `regionCode`
+// TermMatch filter on GetProducts, so each invocation returns only that region's SKUs.
+// The pricingstore fans out one call per configured region; do NOT replace this with a
+// single call, or the resulting snapshot will lose regional separation.
 func newPriceFetcher(pricingClient client.Client) pricingstore.PriceFetchFunc {
 	return func(ctx context.Context, region string) ([]string, error) {
 		rawItems, err := pricingClient.ListBedrockPrices(ctx, region)

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -180,9 +180,7 @@ func (c *Collector) Register(_ provider.Registry) error {
 	return nil
 }
 
-// newPriceFetcher returns a PriceFetchFunc that fetches and preprocesses Bedrock pricing data.
-// The AWS Pricing API is only available in us-east-1 and ap-south-1; callers must pin the
-// client to us-east-1 before passing it here.
+// The AWS Pricing API is only available in us-east-1; callers must pin the client there.
 func newPriceFetcher(pricingClient client.Client) pricingstore.PriceFetchFunc {
 	return func(ctx context.Context, region string) ([]string, error) {
 		rawItems, err := pricingClient.ListBedrockPrices(ctx, region)
@@ -193,9 +191,6 @@ func newPriceFetcher(pricingClient client.Client) pricingstore.PriceFetchFunc {
 	}
 }
 
-// preprocessBedrockPrices filters and transforms raw Pricing API JSON strings. Each item's
-// usagetype field is replaced with a composite key encoding family, direction, model ID, and
-// price tier. Non-text-token SKUs (image, video, audio, cache, guardrail) are dropped.
 func preprocessBedrockPrices(rawItems []string) []string {
 	result := make([]string, 0, len(rawItems))
 	for _, raw := range rawItems {
@@ -206,10 +201,7 @@ func preprocessBedrockPrices(rawItems []string) []string {
 	return result
 }
 
-// encodeBedrockPriceJSON parses one raw Pricing API JSON string and returns a modified copy
-// with the usagetype replaced by a composite key: "<family>|<direction>|<modelID>|<priceTier>".
-// Returns ok=false if the entry should be skipped (non-text-token inferenceType, parse failure,
-// or unrecognized usagetype format).
+// Returns ok=false for non-text-token types, parse failures, or unrecognized usagetype formats.
 func encodeBedrockPriceJSON(raw string) (string, bool) {
 	var info bedrockProductInfo
 	if err := json.Unmarshal([]byte(raw), &info); err != nil {
@@ -237,9 +229,6 @@ func encodeBedrockPriceJSON(raw string) (string, bool) {
 	return string(modified), true
 }
 
-// classifyInferenceType maps the Bedrock Pricing API inferenceType attribute to a direction
-// string ("input", "output", "search"). Returns ok=false for non-text-token types (image,
-// video, audio, cache, guardrail) that should not be emitted as pricing metrics.
 func classifyInferenceType(inferenceType string) (direction string, ok bool) {
 	lower := strings.ToLower(inferenceType)
 	if strings.HasPrefix(lower, "prompt cache") {
@@ -271,9 +260,6 @@ var tokenTypeMarkers = []string{
 	"-search-units",
 }
 
-// parseBedrockModelID extracts the model ID slug and price tier from a Bedrock usagetype string.
-// It strips the leading region prefix (e.g. "USE1-") and the trailing token-type suffix, then
-// maps the remaining suffix to a price tier label.
 func parseBedrockModelID(usagetype string) (modelID, priceTier string) {
 	slug := usagetype
 	if i := strings.Index(usagetype, "-"); i >= 0 {
@@ -289,8 +275,6 @@ func parseBedrockModelID(usagetype string) (modelID, priceTier string) {
 	return "", priceTierOnDemand
 }
 
-// extractPriceTier maps the token-type suffix remainder (everything after the marker such as
-// "-input-tokens") to a price_tier label value.
 func extractPriceTier(suffix string) string {
 	lower := strings.ToLower(suffix)
 	if strings.Contains(lower, "cross-region") {
@@ -308,9 +292,7 @@ func extractPriceTier(suffix string) string {
 	}
 }
 
-// normalizeProvider lowercases the provider attribute and replaces spaces with underscores
-// for use as the family label. Amazon-developed models (Nova, Titan, etc.) have an empty
-// provider attribute and are mapped to "amazon".
+// Empty provider maps to "amazon" (Nova, Titan, and other Amazon-developed models).
 func normalizeProvider(provider string) string {
 	if provider == "" {
 		return "amazon"

--- a/pkg/aws/bedrock/bedrock_test.go
+++ b/pkg/aws/bedrock/bedrock_test.go
@@ -1,0 +1,477 @@
+package bedrock
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	mockclient "github.com/grafana/cloudcost-exporter/pkg/aws/client/mocks"
+	"github.com/grafana/cloudcost-exporter/pkg/utils"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestNew_Succeeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pricingClient := mockclient.NewMockClient(ctrl)
+	pricingClient.EXPECT().
+		ListBedrockPrices(gomock.Any(), "us-east-1").
+		Return([]string{inputPriceJSON("us-east-1", "USE1", "Claude3Sonnet", "Anthropic", "0.00300")}, nil).
+		Times(1)
+
+	collector, err := New(t.Context(), &Config{
+		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
+		PricingClient: pricingClient,
+		Logger:        testLogger(),
+		AccountID:     "123456789012",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, collector)
+}
+
+func TestNew_ReturnsErrorWhenPricingAPIUnavailable(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pricingClient := mockclient.NewMockClient(ctrl)
+	pricingClient.EXPECT().
+		ListBedrockPrices(gomock.Any(), "us-east-1").
+		Return(nil, fmt.Errorf("pricing API unavailable")).
+		Times(1)
+
+	collector, err := New(t.Context(), &Config{
+		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
+		PricingClient: pricingClient,
+		Logger:        testLogger(),
+	})
+
+	assert.Nil(t, collector)
+	require.Error(t, err)
+}
+
+func TestCollect_EmitsInputAndOutputTokenMetrics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pricingClient := mockclient.NewMockClient(ctrl)
+	pricingClient.EXPECT().
+		ListBedrockPrices(gomock.Any(), "us-east-1").
+		Return([]string{
+			inputPriceJSON("us-east-1", "USE1", "Claude3Sonnet", "Anthropic", "0.00300"),
+			outputPriceJSON("us-east-1", "USE1", "Claude3Sonnet", "Anthropic", "0.01500"),
+		}, nil).
+		Times(1)
+
+	collector, err := New(t.Context(), &Config{
+		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
+		PricingClient: pricingClient,
+		Logger:        testLogger(),
+		AccountID:     "123456789012",
+	})
+	require.NoError(t, err)
+
+	results, err := collectMetricResults(t, collector)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	inputMetric := metricByName(results, "cloudcost_aws_bedrock_token_input_usd_per_1k_tokens")
+	require.NotNil(t, inputMetric)
+	assert.Equal(t, "us-east-1", inputMetric.Labels["region"])
+	assert.Equal(t, "Claude3Sonnet", inputMetric.Labels["model_id"])
+	assert.Equal(t, "anthropic", inputMetric.Labels["family"])
+	assert.Equal(t, "on_demand", inputMetric.Labels["price_tier"])
+	assert.Equal(t, "123456789012", inputMetric.Labels["account_id"])
+	assert.InDelta(t, 0.003, inputMetric.Value, 1e-9)
+
+	outputMetric := metricByName(results, "cloudcost_aws_bedrock_token_output_usd_per_1k_tokens")
+	require.NotNil(t, outputMetric)
+	assert.Equal(t, "us-east-1", outputMetric.Labels["region"])
+	assert.Equal(t, "Claude3Sonnet", outputMetric.Labels["model_id"])
+	assert.Equal(t, "anthropic", outputMetric.Labels["family"])
+	assert.Equal(t, "on_demand", outputMetric.Labels["price_tier"])
+	assert.InDelta(t, 0.015, outputMetric.Value, 1e-9)
+}
+
+func TestCollect_EmitsMetricsForMultipleModels(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pricingClient := mockclient.NewMockClient(ctrl)
+	pricingClient.EXPECT().
+		ListBedrockPrices(gomock.Any(), "us-east-1").
+		Return([]string{
+			inputPriceJSON("us-east-1", "USE1", "Claude3Sonnet", "Anthropic", "0.00300"),
+			outputPriceJSON("us-east-1", "USE1", "Claude3Sonnet", "Anthropic", "0.01500"),
+			inputPriceJSON("us-east-1", "USE1", "Llama4-Scout-17B", "Meta", "0.00017"),
+			outputPriceJSON("us-east-1", "USE1", "Llama4-Scout-17B", "Meta", "0.00065"),
+		}, nil).
+		Times(1)
+
+	collector, err := New(t.Context(), &Config{
+		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
+		PricingClient: pricingClient,
+		Logger:        testLogger(),
+		AccountID:     "123456789012",
+	})
+	require.NoError(t, err)
+
+	results, err := collectMetricResults(t, collector)
+	require.NoError(t, err)
+	assert.Len(t, results, 4)
+}
+
+func TestCollect_LabelsCrossRegionPriceTier(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pricingClient := mockclient.NewMockClient(ctrl)
+	pricingClient.EXPECT().
+		ListBedrockPrices(gomock.Any(), "us-east-1").
+		Return([]string{
+			crossRegionInputPriceJSON("us-east-1", "USE1", "NovaPremier", "", "0.00600"),
+		}, nil).
+		Times(1)
+
+	collector, err := New(t.Context(), &Config{
+		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
+		PricingClient: pricingClient,
+		Logger:        testLogger(),
+		AccountID:     "123456789012",
+	})
+	require.NoError(t, err)
+
+	results, err := collectMetricResults(t, collector)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	m := results[0]
+	assert.Equal(t, "cross_region", m.Labels["price_tier"])
+	assert.Equal(t, "amazon", m.Labels["family"])
+	assert.Equal(t, "NovaPremier", m.Labels["model_id"])
+}
+
+func TestCollect_LabelsBatchPriceTier(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pricingClient := mockclient.NewMockClient(ctrl)
+	pricingClient.EXPECT().
+		ListBedrockPrices(gomock.Any(), "us-east-1").
+		Return([]string{
+			batchInputPriceJSON("us-east-1", "USE1", "Llama4-Maverick-17B", "Meta", "0.00012"),
+		}, nil).
+		Times(1)
+
+	collector, err := New(t.Context(), &Config{
+		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
+		PricingClient: pricingClient,
+		Logger:        testLogger(),
+		AccountID:     "123456789012",
+	})
+	require.NoError(t, err)
+
+	results, err := collectMetricResults(t, collector)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	m := results[0]
+	assert.Equal(t, "on_demand_batch", m.Labels["price_tier"])
+	assert.Equal(t, "meta", m.Labels["family"])
+	assert.Equal(t, "Llama4-Maverick-17B", m.Labels["model_id"])
+}
+
+func TestCollect_EmitsCohereSearchUnitMetrics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pricingClient := mockclient.NewMockClient(ctrl)
+	pricingClient.EXPECT().
+		ListBedrockPrices(gomock.Any(), "us-east-1").
+		Return([]string{
+			inputPriceJSON("us-east-1", "USE1", "cohere.embed-english-v3", "Cohere", "0.00010"),
+			searchUnitPriceJSON("us-east-1", "USE1", "cohere.rerank-english-v3", "Cohere", "0.00200"),
+		}, nil).
+		Times(1)
+
+	collector, err := New(t.Context(), &Config{
+		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
+		PricingClient: pricingClient,
+		Logger:        testLogger(),
+		AccountID:     "123456789012",
+	})
+	require.NoError(t, err)
+
+	results, err := collectMetricResults(t, collector)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	embedMetric := metricByName(results, "cloudcost_aws_bedrock_token_input_usd_per_1k_tokens")
+	require.NotNil(t, embedMetric)
+	assert.Equal(t, "cohere.embed-english-v3", embedMetric.Labels["model_id"])
+	assert.Equal(t, "cohere", embedMetric.Labels["family"])
+	assert.InDelta(t, 0.0001, embedMetric.Value, 1e-9)
+
+	rerankMetric := metricByName(results, "cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units")
+	require.NotNil(t, rerankMetric)
+	assert.Equal(t, "cohere.rerank-english-v3", rerankMetric.Labels["model_id"])
+	assert.Equal(t, "cohere", rerankMetric.Labels["family"])
+	assert.InDelta(t, 0.002, rerankMetric.Value, 1e-9)
+}
+
+func TestCollect_SkipsNonTextTokenSKUs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pricingClient := mockclient.NewMockClient(ctrl)
+	pricingClient.EXPECT().
+		ListBedrockPrices(gomock.Any(), "us-east-1").
+		Return([]string{
+			inputPriceJSON("us-east-1", "USE1", "Claude3Sonnet", "Anthropic", "0.00300"),
+			// Image token entry — should be skipped.
+			rawPriceJSON("us-east-1", "USE1-Nova2.0Pro-input-image-token-count-cross-region-global", "Input Image Token Count", "", "0.00125"),
+			// Cache entry — should be skipped.
+			rawPriceJSON("us-east-1", "USE1-NovaPro-cache-write-input-token-count-custom-model", "Prompt cache write input tokens", "", "0.00000"),
+			// Guardrail entry — should be skipped.
+			rawPriceJSON("us-east-1", "USE1-Guardrail-AutomatedReasoningPolicyUnitsConsumed", "", "", "0.00017"),
+		}, nil).
+		Times(1)
+
+	collector, err := New(t.Context(), &Config{
+		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
+		PricingClient: pricingClient,
+		Logger:        testLogger(),
+		AccountID:     "123456789012",
+	})
+	require.NoError(t, err)
+
+	results, err := collectMetricResults(t, collector)
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+}
+
+func TestCollect_ReturnsContextErrWhenContextCancelled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pricingClient := mockclient.NewMockClient(ctrl)
+	pricingClient.EXPECT().
+		ListBedrockPrices(gomock.Any(), "us-east-1").
+		Return([]string{}, nil).
+		Times(1)
+
+	collector, err := New(t.Context(), &Config{
+		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
+		PricingClient: pricingClient,
+		Logger:        testLogger(),
+		AccountID:     "123456789012",
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ch := make(chan prometheus.Metric, 10)
+	err = collector.Collect(ctx, ch)
+	close(ch)
+
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestClassifyInferenceType(t *testing.T) {
+	tests := []struct {
+		name          string
+		inferenceType string
+		wantDirection string
+		wantOK        bool
+	}{
+		{"standard input", "Input tokens", "input", true},
+		{"input priority", "Input tokens priority", "input", true},
+		{"input flex", "Input tokens flex", "input", true},
+		{"input batch lowercase", "input tokens batch", "input", true},
+		{"text input token", "Text Input Token", "input", true},
+		{"standard output", "Output tokens", "output", true},
+		{"output batch", "output tokens batch", "output", true},
+		{"output flex", "Output tokens flex", "output", true},
+		{"output priority", "Output tokens priority", "output", true},
+		{"search units", "Search units", "search", true},
+		{"rerank", "Rerank units", "search", true},
+		{"image input — skip", "Input Image Token Count", "", false},
+		{"video input — skip", "Input Video Token Count Flex", "", false},
+		{"audio input — skip", "Input Audio Token Count Flex", "", false},
+		{"image output — skip", "Output Image Token Count", "", false},
+		{"cache write — skip", "Prompt cache write input tokens", "", false},
+		{"cache read — skip", "Prompt cache read input tokens", "", false},
+		{"guardrail — skip", "", "", false},
+		{"custom image — skip", "Custom T2I 1024 Standard", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			direction, ok := classifyInferenceType(tt.inferenceType)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantDirection, direction)
+			}
+		})
+	}
+}
+
+func TestParseBedrockModelID(t *testing.T) {
+	tests := []struct {
+		usagetype     string
+		wantModelID   string
+		wantPriceTier string
+	}{
+		{
+			"USE1-Claude3Sonnet-input-tokens",
+			"Claude3Sonnet", "on_demand",
+		},
+		{
+			"USE1-Claude2.0-input-tokens",
+			"Claude2.0", "on_demand",
+		},
+		{
+			"USE1-Llama4-Maverick-17B-input-tokens-batch",
+			"Llama4-Maverick-17B", "on_demand_batch",
+		},
+		{
+			"USE1-GPT-OSS-Safeguard-20B-input-tokens-priority",
+			"GPT-OSS-Safeguard-20B", "on_demand_priority",
+		},
+		{
+			"USE1-Gemma-3-4B-IT-input-tokens-flex",
+			"Gemma-3-4B-IT", "on_demand_flex",
+		},
+		{
+			"USE1-MistralSmall-input-tokens-batch",
+			"MistralSmall", "on_demand_batch",
+		},
+		{
+			"USE1-Nova2.0Lite-input-tokens-cross-region-global-batch",
+			"Nova2.0Lite", "cross_region",
+		},
+		{
+			"USE1-Nova2.0Pro-text-input-tokens-priority-cross-region-global",
+			"Nova2.0Pro", "cross_region",
+		},
+		{
+			"USE1-GPT-OSS-Safeguard-120B-output-tokens-batch",
+			"GPT-OSS-Safeguard-120B", "on_demand_batch",
+		},
+		{
+			"USE1-Llama3-2-1B-output-tokens",
+			"Llama3-2-1B", "on_demand",
+		},
+		{
+			"USE1-cohere.rerank-english-v3-search-units",
+			"cohere.rerank-english-v3", "on_demand",
+		},
+		// Unrecognized format returns empty model ID.
+		{
+			"USE1-Guardrail-AutomatedReasoningPolicyUnitsConsumed",
+			"", "on_demand",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.usagetype, func(t *testing.T) {
+			modelID, priceTier := parseBedrockModelID(tt.usagetype)
+			assert.Equal(t, tt.wantModelID, modelID)
+			assert.Equal(t, tt.wantPriceTier, priceTier)
+		})
+	}
+}
+
+func TestNormalizeProvider(t *testing.T) {
+	tests := []struct {
+		provider string
+		want     string
+	}{
+		{"Anthropic", "anthropic"},
+		{"Meta", "meta"},
+		{"OpenAI", "openai"},
+		{"Google", "google"},
+		{"Mistral", "mistral"},
+		{"Nvidia", "nvidia"},
+		{"Cohere", "cohere"},
+		{"Mistral AI", "mistral_ai"},
+		{"Moonshot AI", "moonshot_ai"},
+		{"", "amazon"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeProvider(tt.provider))
+		})
+	}
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// rawPriceJSON builds a minimal Pricing API JSON item with explicit inferenceType and provider.
+func rawPriceJSON(regionCode, usagetype, inferenceType, provider, price string) string {
+	return fmt.Sprintf(
+		`{"product":{"attributes":{"usagetype":%q,"regionCode":%q,"inferenceType":%q,"provider":%q}},"terms":{"OnDemand":{"term1":{"priceDimensions":{"dim1":{"pricePerUnit":{"USD":%q}}}}}}}`,
+		usagetype, regionCode, inferenceType, provider, price,
+	)
+}
+
+func inputPriceJSON(region, regionPrefix, modelSlug, provider, price string) string {
+	usagetype := fmt.Sprintf("%s-%s-input-tokens", regionPrefix, modelSlug)
+	return rawPriceJSON(region, usagetype, "Input tokens", provider, price)
+}
+
+func outputPriceJSON(region, regionPrefix, modelSlug, provider, price string) string {
+	usagetype := fmt.Sprintf("%s-%s-output-tokens", regionPrefix, modelSlug)
+	return rawPriceJSON(region, usagetype, "Output tokens", provider, price)
+}
+
+func batchInputPriceJSON(region, regionPrefix, modelSlug, provider, price string) string {
+	usagetype := fmt.Sprintf("%s-%s-input-tokens-batch", regionPrefix, modelSlug)
+	return rawPriceJSON(region, usagetype, "input tokens batch", provider, price)
+}
+
+func crossRegionInputPriceJSON(region, regionPrefix, modelSlug, provider, price string) string {
+	usagetype := fmt.Sprintf("%s-%s-input-tokens-cross-region-global", regionPrefix, modelSlug)
+	return rawPriceJSON(region, usagetype, "Input tokens", provider, price)
+}
+
+func searchUnitPriceJSON(region, regionPrefix, modelSlug, provider, price string) string {
+	usagetype := fmt.Sprintf("%s-%s-search-units", regionPrefix, modelSlug)
+	return rawPriceJSON(region, usagetype, "Search units", provider, price)
+}
+
+func collectMetricResults(t *testing.T, collector *Collector) ([]*utils.MetricResult, error) {
+	t.Helper()
+
+	ch := make(chan prometheus.Metric, 20)
+	err := collector.Collect(t.Context(), ch)
+	close(ch)
+
+	var results []*utils.MetricResult
+	for metric := range ch {
+		results = append(results, utils.ReadMetrics(metric))
+	}
+
+	return results, err
+}
+
+func metricByName(results []*utils.MetricResult, fqName string) *utils.MetricResult {
+	for _, result := range results {
+		if result.FqName == fqName {
+			return result
+		}
+	}
+	return nil
+}

--- a/pkg/aws/client/aws_client.go
+++ b/pkg/aws/client/aws_client.go
@@ -113,3 +113,7 @@ func (c *AWSClient) ListMSKClusters(ctx context.Context) ([]msktypes.Cluster, er
 func (c *AWSClient) ListMSKServicePrices(ctx context.Context, region string, filters []pricingTypes.Filter) ([]string, error) {
 	return c.priceService.listMSKServicePrices(ctx, region, filters)
 }
+
+func (c *AWSClient) ListBedrockPrices(ctx context.Context, region string) ([]string, error) {
+	return c.priceService.listBedrockPrices(ctx, region)
+}

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -30,6 +30,7 @@ type Client interface {
 	GetRDSUnitData(ctx context.Context, instType, region, deploymentOption, engineCode, isOutpost string) (string, error)
 	ListMSKClusters(ctx context.Context) ([]msktypes.Cluster, error)
 	ListMSKServicePrices(ctx context.Context, region string, filters []pricingTypes.Filter) ([]string, error)
+	ListBedrockPrices(ctx context.Context, region string) ([]string, error)
 
 	// TODO: Break out Metrics into an independent interface
 	Metrics() []prometheus.Collector

--- a/pkg/aws/client/mocks/client.go
+++ b/pkg/aws/client/mocks/client.go
@@ -16,9 +16,9 @@ import (
 
 	types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	types0 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
-	types3 "github.com/aws/aws-sdk-go-v2/service/kafka/types"
-	types1 "github.com/aws/aws-sdk-go-v2/service/pricing/types"
-	types2 "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	types1 "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+	types2 "github.com/aws/aws-sdk-go-v2/service/pricing/types"
+	types3 "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	client "github.com/grafana/cloudcost-exporter/pkg/aws/client"
 	prometheus "github.com/prometheus/client_golang/prometheus"
 	gomock "go.uber.org/mock/gomock"
@@ -108,6 +108,21 @@ func (mr *MockClientMockRecorder) GetRDSUnitData(ctx, instType, region, deployme
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRDSUnitData", reflect.TypeOf((*MockClient)(nil).GetRDSUnitData), ctx, instType, region, deploymentOption, engineCode, isOutpost)
 }
 
+// ListBedrockPrices mocks base method.
+func (m *MockClient) ListBedrockPrices(ctx context.Context, region string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBedrockPrices", ctx, region)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBedrockPrices indicates an expected call of ListBedrockPrices.
+func (mr *MockClientMockRecorder) ListBedrockPrices(ctx, region any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBedrockPrices", reflect.TypeOf((*MockClient)(nil).ListBedrockPrices), ctx, region)
+}
+
 // ListComputeInstances mocks base method.
 func (m *MockClient) ListComputeInstances(ctx context.Context) ([]types.Reservation, error) {
 	m.ctrl.T.Helper()
@@ -139,7 +154,7 @@ func (mr *MockClientMockRecorder) ListEBSVolumes(ctx any) *gomock.Call {
 }
 
 // ListEC2ServicePrices mocks base method.
-func (m *MockClient) ListEC2ServicePrices(ctx context.Context, region string, filters []types1.Filter) ([]string, error) {
+func (m *MockClient) ListEC2ServicePrices(ctx context.Context, region string, filters []types2.Filter) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListEC2ServicePrices", ctx, region, filters)
 	ret0, _ := ret[0].([]string)
@@ -169,10 +184,10 @@ func (mr *MockClientMockRecorder) ListELBPrices(ctx, region any) *gomock.Call {
 }
 
 // ListMSKClusters mocks base method.
-func (m *MockClient) ListMSKClusters(ctx context.Context) ([]types3.Cluster, error) {
+func (m *MockClient) ListMSKClusters(ctx context.Context) ([]types1.Cluster, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListMSKClusters", ctx)
-	ret0, _ := ret[0].([]types3.Cluster)
+	ret0, _ := ret[0].([]types1.Cluster)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -184,7 +199,7 @@ func (mr *MockClientMockRecorder) ListMSKClusters(ctx any) *gomock.Call {
 }
 
 // ListMSKServicePrices mocks base method.
-func (m *MockClient) ListMSKServicePrices(ctx context.Context, region string, filters []types1.Filter) ([]string, error) {
+func (m *MockClient) ListMSKServicePrices(ctx context.Context, region string, filters []types2.Filter) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListMSKServicePrices", ctx, region, filters)
 	ret0, _ := ret[0].([]string)
@@ -214,10 +229,10 @@ func (mr *MockClientMockRecorder) ListOnDemandPrices(ctx, region any) *gomock.Ca
 }
 
 // ListRDSInstances mocks base method.
-func (m *MockClient) ListRDSInstances(ctx context.Context) ([]types2.DBInstance, error) {
+func (m *MockClient) ListRDSInstances(ctx context.Context) ([]types3.DBInstance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListRDSInstances", ctx)
-	ret0, _ := ret[0].([]types2.DBInstance)
+	ret0, _ := ret[0].([]types3.DBInstance)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -259,7 +274,7 @@ func (mr *MockClientMockRecorder) ListStoragePrices(ctx, region any) *gomock.Cal
 }
 
 // ListVPCServicePrices mocks base method.
-func (m *MockClient) ListVPCServicePrices(ctx context.Context, region string, filters []types1.Filter) ([]string, error) {
+func (m *MockClient) ListVPCServicePrices(ctx context.Context, region string, filters []types2.Filter) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListVPCServicePrices", ctx, region, filters)
 	ret0, _ := ret[0].([]string)

--- a/pkg/aws/client/pricing.go
+++ b/pkg/aws/client/pricing.go
@@ -159,6 +159,10 @@ func (p *pricing) listMSKServicePrices(ctx context.Context, region string, filte
 	return p.listServicePrices(ctx, "AmazonMSK", region, filters)
 }
 
+func (p *pricing) listBedrockPrices(ctx context.Context, region string) ([]string, error) {
+	return p.listServicePrices(ctx, "AmazonBedrock", region, nil)
+}
+
 func (p *pricing) listELBPrices(ctx context.Context, region string) ([]string, error) {
 	// Fetch ELB pricing from AWS Pricing API
 	input := &awsPricing.GetProductsInput{

--- a/pkg/aws/ec2/mock_client_test.go
+++ b/pkg/aws/ec2/mock_client_test.go
@@ -85,6 +85,10 @@ func (m *mockClient) ListMSKServicePrices(ctx context.Context, region string, fi
 	panic("not implemented")
 }
 
+func (m *mockClient) ListBedrockPrices(ctx context.Context, region string) ([]string, error) {
+	panic("not implemented")
+}
+
 func (m *mockClient) Metrics() []prometheus.Collector {
 	panic("not implemented")
 }

--- a/pkg/aws/vpc/vpc_test.go
+++ b/pkg/aws/vpc/vpc_test.go
@@ -101,6 +101,11 @@ func (m *MockClient) ListMSKServicePrices(ctx context.Context, region string, fi
 	return args.Get(0).([]string), args.Error(1)
 }
 
+func (m *MockClient) ListBedrockPrices(ctx context.Context, region string) ([]string, error) {
+	args := m.Called(ctx, region)
+	return args.Get(0).([]string), args.Error(1)
+}
+
 func (m *MockClient) Metrics() []prometheus.Collector {
 	args := m.Called()
 	return args.Get(0).([]prometheus.Collector)

--- a/pkg/provider/mocks/provider.go
+++ b/pkg/provider/mocks/provider.go
@@ -206,6 +206,44 @@ func (mr *MockCollectorMockRecorder) Register(r any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockCollector)(nil).Register), r)
 }
 
+// MockRegionsProvider is a mock of RegionsProvider interface.
+type MockRegionsProvider struct {
+	ctrl     *gomock.Controller
+	recorder *MockRegionsProviderMockRecorder
+	isgomock struct{}
+}
+
+// MockRegionsProviderMockRecorder is the mock recorder for MockRegionsProvider.
+type MockRegionsProviderMockRecorder struct {
+	mock *MockRegionsProvider
+}
+
+// NewMockRegionsProvider creates a new mock instance.
+func NewMockRegionsProvider(ctrl *gomock.Controller) *MockRegionsProvider {
+	mock := &MockRegionsProvider{ctrl: ctrl}
+	mock.recorder = &MockRegionsProviderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRegionsProvider) EXPECT() *MockRegionsProviderMockRecorder {
+	return m.recorder
+}
+
+// Regions mocks base method.
+func (m *MockRegionsProvider) Regions() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Regions")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// Regions indicates an expected call of Regions.
+func (mr *MockRegionsProviderMockRecorder) Regions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Regions", reflect.TypeOf((*MockRegionsProvider)(nil).Regions))
+}
+
 // MockProvider is a mock of Provider interface.
 type MockProvider struct {
 	ctrl     *gomock.Controller

--- a/pkg/utils/consts.go
+++ b/pkg/utils/consts.go
@@ -27,6 +27,12 @@ const (
 	PersistentVolumeCostPerGiBSuffix = "persistent_volume_usd_per_gib_hour"
 	// RegionUnknown is used as a label value when a region or other attribute cannot be determined.
 	RegionUnknown = "unknown"
+	// TokenInputCostSuffix is the suffix for per-1k-input-token cost metrics.
+	TokenInputCostSuffix = "token_input_usd_per_1k_tokens"
+	// TokenOutputCostSuffix is the suffix for per-1k-output-token cost metrics.
+	TokenOutputCostSuffix = "token_output_usd_per_1k_tokens"
+	// SearchUnitCostSuffix is the suffix for per-1k-search-unit cost metrics (e.g. Cohere Rerank).
+	SearchUnitCostSuffix = "search_unit_usd_per_1k_search_units"
 )
 
 // RegionsFromMap returns the keys of a map as a slice of strings.


### PR DESCRIPTION
Part of https://github.com/grafana/cloudcost-exporter/issues/923. Adds a new AWS Bedrock collector that emits list-price token cost metrics.

- New `pkg/aws/bedrock` package: `Collector` implements the standard `provider.Collector` interface with `Collect`, `Describe`, `Name`, `Register`, and `Regions`
- Pricing data fetched from the AWS Pricing API (us-east-1 endpoint) and refreshed every 24 hours via the shared `pricingstore` machinery
- Three new metrics: input token cost, output token cost, and search unit cost
- Five `price_tier` values supported: `on_demand`, `on_demand_batch`, `on_demand_flex`, `on_demand_priority`, `cross_region`

## New metrics

```
cloudcost_aws_bedrock_token_input_usd_per_1k_tokens{account_id, region, model_id, family, price_tier}
cloudcost_aws_bedrock_token_output_usd_per_1k_tokens{account_id, region, model_id, family, price_tier}
cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units{account_id, region, model_id, family, price_tier}
```

Cardinality: roughly 20 models x 6 regions x 5 tiers = ~600 series.

## How it works

The AWS Pricing API returns flat JSON with a `usagetype` field that encodes model and token type. The `inferenceType` attribute signals direction (input/output/search). Before the data enters the generic `pricingstore`, a preprocessing step rewrites the `usagetype` field into a composite key `family|direction|modelID|priceTier`. `Collect` splits this key back out to populate metric labels.

## IAM permissions required

```json
{
  "Effect": "Allow",
  "Action": ["pricing:GetProducts"],
  "Resource": "*"
}
```

