### PR TITLE
fix(bedrock): filter Bedrock pricing to Anthropic and Amazon families only

### DIFF
--- a/cmd/exporter/config/config.go
+++ b/cmd/exporter/config/config.go
@@ -10,11 +10,12 @@ type Config struct {
 	ProjectID string
 	Providers struct {
 		AWS struct {
-			Profile        string
-			Region         string
-			Services       StringSliceFlag
-			RoleARN        string
-			ExcludeRegions StringSliceFlag
+			Profile              string
+			Region               string
+			Services             StringSliceFlag
+			RoleARN              string
+			ExcludeRegions       StringSliceFlag
+			BedrockFamilyFilter  string
 		}
 		GCP struct {
 			DefaultGCSDiscount       int

--- a/cmd/exporter/config/config.go
+++ b/cmd/exporter/config/config.go
@@ -10,12 +10,12 @@ type Config struct {
 	ProjectID string
 	Providers struct {
 		AWS struct {
-			Profile              string
-			Region               string
-			Services             StringSliceFlag
-			RoleARN              string
-			ExcludeRegions       StringSliceFlag
-			BedrockFamilyFilter  string
+			Profile             string
+			Region              string
+			Services            StringSliceFlag
+			RoleARN             string
+			ExcludeRegions      StringSliceFlag
+			BedrockFamilyFilter string
 		}
 		GCP struct {
 			DefaultGCSDiscount       int

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -79,6 +79,7 @@ func providerFlags(fs *flag.FlagSet, cfg *config.Config) {
 	fs.Var(&cfg.Providers.GCP.Services, "gcp.services", "GCP service(s).")
 	flag.StringVar(&cfg.Providers.AWS.Region, "aws.region", "", "AWS region")
 	flag.StringVar(&cfg.Providers.AWS.RoleARN, "aws.roleARN", "", "Optional AWS role ARN to assume for cross-account access.")
+	fs.StringVar(&cfg.Providers.AWS.BedrockFamilyFilter, "aws.bedrock.families", "anthropic|amazon", "Regex matched against the Bedrock model family label. Only matching families are emitted.")
 	// TODO - PUT PROJECT-ID UNDER GCP
 	flag.StringVar(&cfg.ProjectID, "project-id", "", "Project ID to target.")
 	flag.StringVar(&cfg.Providers.Azure.SubscriptionId, "azure.subscription-id", "", "Azure subscription ID to pull data from.")
@@ -248,14 +249,15 @@ func selectProviderWith(
 		})
 	case "aws":
 		return newAWS(ctx, &aws.Config{
-			Logger:           cfg.Logger,
-			Region:           cfg.Providers.AWS.Region,
-			Profile:          cfg.Providers.AWS.Profile,
-			RoleARN:          cfg.Providers.AWS.RoleARN,
-			ScrapeInterval:   cfg.Collector.ScrapeInterval,
-			Services:         strings.Split(cfg.Providers.AWS.Services.String(), ","),
-			ExcludeRegions:   strings.Split(cfg.Providers.AWS.ExcludeRegions.String(), ","),
-			CollectorTimeout: collectorTimeout,
+			Logger:              cfg.Logger,
+			Region:              cfg.Providers.AWS.Region,
+			Profile:             cfg.Providers.AWS.Profile,
+			RoleARN:             cfg.Providers.AWS.RoleARN,
+			ScrapeInterval:      cfg.Collector.ScrapeInterval,
+			Services:            strings.Split(cfg.Providers.AWS.Services.String(), ","),
+			ExcludeRegions:      strings.Split(cfg.Providers.AWS.ExcludeRegions.String(), ","),
+			CollectorTimeout:    collectorTimeout,
+			BedrockFamilyFilter: cfg.Providers.AWS.BedrockFamilyFilter,
 		})
 
 	case "gcp":

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -79,7 +79,7 @@ func providerFlags(fs *flag.FlagSet, cfg *config.Config) {
 	fs.Var(&cfg.Providers.GCP.Services, "gcp.services", "GCP service(s).")
 	flag.StringVar(&cfg.Providers.AWS.Region, "aws.region", "", "AWS region")
 	flag.StringVar(&cfg.Providers.AWS.RoleARN, "aws.roleARN", "", "Optional AWS role ARN to assume for cross-account access.")
-	fs.StringVar(&cfg.Providers.AWS.BedrockFamilyFilter, "aws.bedrock.families", "anthropic|amazon", "Regex matched against the Bedrock model family label. Only matching families are emitted.")
+	fs.StringVar(&cfg.Providers.AWS.BedrockFamilyFilter, "aws.bedrock.families", ".*", "Regex matched against the Bedrock model family label. Only matching families are emitted.")
 	// TODO - PUT PROJECT-ID UNDER GCP
 	flag.StringVar(&cfg.ProjectID, "project-id", "", "Project ID to target.")
 	flag.StringVar(&cfg.Providers.Azure.SubscriptionId, "azure.subscription-id", "", "Azure subscription ID to pull data from.")

--- a/docs/metrics/aws/bedrock.md
+++ b/docs/metrics/aws/bedrock.md
@@ -30,7 +30,7 @@ Or via command line:
 - **`account_id`**: AWS account ID (12-digit), resolved via STS `GetCallerIdentity`
 - **`region`**: AWS region for which the price applies
 - **`model_id`**: Model slug from the AWS Pricing API `usagetype` field (e.g. `Claude3Sonnet`, `Llama4-Scout-17B`, `Nova2.0Pro`)
-- **`family`**: Model provider, lowercased with spaces replaced by underscores (e.g. `anthropic`, `amazon`, `meta`, `mistral_ai`). Models with no provider attribute use `amazon`.
+- **`family`**: Model provider — `anthropic` (Claude models) or `amazon` (Nova, Titan). Models with no provider attribute use `amazon`. Only these two families are emitted; remove the family filter in `encodeBedrockPriceJSON` to include all providers.
 - **`price_tier`**: Inference tier: `on_demand`, `on_demand_batch`, `on_demand_flex`, `on_demand_priority`, or `cross_region`
 
 ## Notes

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -37,16 +37,16 @@ import (
 )
 
 type Config struct {
-	Services             []string
-	Region               string
-	Profile              string
-	RoleARN              string
-	ExcludeRegions       []string // AWS region names to skip (e.g. me-central-1)
-	ScrapeInterval       time.Duration
-	CollectorTimeout     time.Duration
-	Logger               *slog.Logger
-	AccountID            string
-	BedrockFamilyFilter  string // regex matched against family label; default "anthropic|amazon"
+	Services            []string
+	Region              string
+	Profile             string
+	RoleARN             string
+	ExcludeRegions      []string // AWS region names to skip (e.g. me-central-1)
+	ScrapeInterval      time.Duration
+	CollectorTimeout    time.Duration
+	Logger              *slog.Logger
+	AccountID           string
+	BedrockFamilyFilter string // regex matched against family label; default "anthropic|amazon"
 }
 
 type AWS struct {

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -37,15 +37,16 @@ import (
 )
 
 type Config struct {
-	Services         []string
-	Region           string
-	Profile          string
-	RoleARN          string
-	ExcludeRegions   []string // AWS region names to skip (e.g. me-central-1)
-	ScrapeInterval   time.Duration
-	CollectorTimeout time.Duration
-	Logger           *slog.Logger
-	AccountID        string
+	Services             []string
+	Region               string
+	Profile              string
+	RoleARN              string
+	ExcludeRegions       []string // AWS region names to skip (e.g. me-central-1)
+	ScrapeInterval       time.Duration
+	CollectorTimeout     time.Duration
+	Logger               *slog.Logger
+	AccountID            string
+	BedrockFamilyFilter  string // regex matched against family label; default "anthropic|amazon"
 }
 
 type AWS struct {
@@ -273,6 +274,7 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 				PricingClient: awsBedrockClient,
 				Logger:        logger,
 				AccountID:     config.AccountID,
+				FamilyFilter:  config.BedrockFamilyFilter,
 			})
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 	"time"
 
@@ -71,11 +72,14 @@ type bedrockProductInfo struct {
 	} `json:"terms"`
 }
 
+const defaultFamilyFilter = "anthropic|amazon"
+
 type Config struct {
 	Regions       []ec2types.Region
 	PricingClient client.Client
 	Logger        *slog.Logger
 	AccountID     string
+	FamilyFilter  string // regex matched against the family label; defaults to "anthropic|amazon"
 }
 
 type Collector struct {
@@ -83,6 +87,7 @@ type Collector struct {
 	regions      []string
 	logger       *slog.Logger
 	accountID    string
+	familyFilter *regexp.Regexp
 }
 
 func New(ctx context.Context, config *Config) (*Collector, error) {
@@ -91,7 +96,16 @@ func New(ctx context.Context, config *Config) (*Collector, error) {
 		logger = config.Logger.With("collector", serviceName)
 	}
 
-	pricingStore, err := pricingstore.NewPricingStore(ctx, logger, config.Regions, newPriceFetcher(config.PricingClient))
+	familyPattern := config.FamilyFilter
+	if familyPattern == "" {
+		familyPattern = defaultFamilyFilter
+	}
+	familyFilter, err := regexp.Compile(familyPattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid bedrock family filter %q: %w", familyPattern, err)
+	}
+
+	pricingStore, err := pricingstore.NewPricingStore(ctx, logger, config.Regions, newPriceFetcher(config.PricingClient, familyFilter))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pricing store: %w", err)
 	}
@@ -125,6 +139,7 @@ func New(ctx context.Context, config *Config) (*Collector, error) {
 		regions:      regions,
 		logger:       logger,
 		accountID:    config.AccountID,
+		familyFilter: familyFilter,
 	}, nil
 }
 
@@ -189,28 +204,29 @@ func (c *Collector) Register(_ provider.Registry) error {
 // TermMatch filter on GetProducts, so each invocation returns only that region's SKUs.
 // The pricingstore fans out one call per configured region; do NOT replace this with a
 // single call, or the resulting snapshot will lose regional separation.
-func newPriceFetcher(pricingClient client.Client) pricingstore.PriceFetchFunc {
+func newPriceFetcher(pricingClient client.Client, familyFilter *regexp.Regexp) pricingstore.PriceFetchFunc {
 	return func(ctx context.Context, region string) ([]string, error) {
 		rawItems, err := pricingClient.ListBedrockPrices(ctx, region)
 		if err != nil {
 			return nil, err
 		}
-		return preprocessBedrockPrices(rawItems), nil
+		return preprocessBedrockPrices(rawItems, familyFilter), nil
 	}
 }
 
-func preprocessBedrockPrices(rawItems []string) []string {
+func preprocessBedrockPrices(rawItems []string, familyFilter *regexp.Regexp) []string {
 	result := make([]string, 0, len(rawItems))
 	for _, raw := range rawItems {
-		if processed, ok := encodeBedrockPriceJSON(raw); ok {
+		if processed, ok := encodeBedrockPriceJSON(raw, familyFilter); ok {
 			result = append(result, processed)
 		}
 	}
 	return result
 }
 
-// Returns ok=false for non-text-token types, parse failures, or unrecognized usagetype formats.
-func encodeBedrockPriceJSON(raw string) (string, bool) {
+// Returns ok=false for non-text-token types, parse failures, unrecognized usagetype formats,
+// or families not matched by familyFilter.
+func encodeBedrockPriceJSON(raw string, familyFilter *regexp.Regexp) (string, bool) {
 	var info bedrockProductInfo
 	if err := json.Unmarshal([]byte(raw), &info); err != nil {
 		return "", false
@@ -228,8 +244,7 @@ func encodeBedrockPriceJSON(raw string) (string, bool) {
 	}
 
 	family := normalizeProvider(attrs.Provider)
-	// remove this filter to emit all model families
-	if family != "anthropic" && family != "amazon" {
+	if !familyFilter.MatchString(family) {
 		return "", false
 	}
 	attrs.UsageType = strings.Join([]string{family, direction, modelID, priceTier}, compositeKeySep)

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -72,14 +72,12 @@ type bedrockProductInfo struct {
 	} `json:"terms"`
 }
 
-const defaultFamilyFilter = ".*"
-
 type Config struct {
 	Regions       []ec2types.Region
 	PricingClient client.Client
 	Logger        *slog.Logger
 	AccountID     string
-	FamilyFilter  string // regex matched against the family label; defaults to "anthropic|amazon"
+	FamilyFilter  string // regex matched against the family label; see --aws.bedrock.families flag
 }
 
 type Collector struct {
@@ -96,13 +94,9 @@ func New(ctx context.Context, config *Config) (*Collector, error) {
 		logger = config.Logger.With("collector", serviceName)
 	}
 
-	familyPattern := config.FamilyFilter
-	if familyPattern == "" {
-		familyPattern = defaultFamilyFilter
-	}
-	familyFilter, err := regexp.Compile(familyPattern)
+	familyFilter, err := regexp.Compile(config.FamilyFilter)
 	if err != nil {
-		return nil, fmt.Errorf("invalid bedrock family filter %q: %w", familyPattern, err)
+		return nil, fmt.Errorf("invalid bedrock family filter %q: %w", config.FamilyFilter, err)
 	}
 
 	pricingStore, err := pricingstore.NewPricingStore(ctx, logger, config.Regions, newPriceFetcher(config.PricingClient, familyFilter))

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -228,6 +228,10 @@ func encodeBedrockPriceJSON(raw string) (string, bool) {
 	}
 
 	family := normalizeProvider(attrs.Provider)
+	// remove this filter to emit all model families
+	if family != "anthropic" && family != "amazon" {
+		return "", false
+	}
 	attrs.UsageType = strings.Join([]string{family, direction, modelID, priceTier}, compositeKeySep)
 
 	modified, err := json.Marshal(&info)

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -72,7 +72,7 @@ type bedrockProductInfo struct {
 	} `json:"terms"`
 }
 
-const defaultFamilyFilter = "anthropic|amazon"
+const defaultFamilyFilter = ".*"
 
 type Config struct {
 	Regions       []ec2types.Region

--- a/pkg/aws/bedrock/bedrock_test.go
+++ b/pkg/aws/bedrock/bedrock_test.go
@@ -111,8 +111,8 @@ func TestCollect_EmitsMetricsForMultipleModels(t *testing.T) {
 		Return([]string{
 			inputPriceJSON("us-east-1", "USE1", "Claude3Sonnet", "Anthropic", "0.00300"),
 			outputPriceJSON("us-east-1", "USE1", "Claude3Sonnet", "Anthropic", "0.01500"),
-			inputPriceJSON("us-east-1", "USE1", "Llama4-Scout-17B", "Meta", "0.00017"),
-			outputPriceJSON("us-east-1", "USE1", "Llama4-Scout-17B", "Meta", "0.00065"),
+			inputPriceJSON("us-east-1", "USE1", "NovaPro", "", "0.00080"),
+			outputPriceJSON("us-east-1", "USE1", "NovaPro", "", "0.00320"),
 		}, nil).
 		Times(1)
 
@@ -167,7 +167,7 @@ func TestCollect_LabelsBatchPriceTier(t *testing.T) {
 	pricingClient.EXPECT().
 		ListBedrockPrices(gomock.Any(), "us-east-1").
 		Return([]string{
-			batchInputPriceJSON("us-east-1", "USE1", "Llama4-Maverick-17B", "Meta", "0.00012"),
+			batchInputPriceJSON("us-east-1", "USE1", "Claude3Sonnet", "Anthropic", "0.00150"),
 		}, nil).
 		Times(1)
 
@@ -185,11 +185,11 @@ func TestCollect_LabelsBatchPriceTier(t *testing.T) {
 
 	m := results[0]
 	assert.Equal(t, "on_demand_batch", m.Labels["price_tier"])
-	assert.Equal(t, "meta", m.Labels["family"])
-	assert.Equal(t, "Llama4-Maverick-17B", m.Labels["model_id"])
+	assert.Equal(t, "anthropic", m.Labels["family"])
+	assert.Equal(t, "Claude3Sonnet", m.Labels["model_id"])
 }
 
-func TestCollect_EmitsCohereSearchUnitMetrics(t *testing.T) {
+func TestCollect_SkipsNonAnthropicAmazonFamilies(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -197,7 +197,8 @@ func TestCollect_EmitsCohereSearchUnitMetrics(t *testing.T) {
 	pricingClient.EXPECT().
 		ListBedrockPrices(gomock.Any(), "us-east-1").
 		Return([]string{
-			inputPriceJSON("us-east-1", "USE1", "cohere.embed-english-v3", "Cohere", "0.00010"),
+			inputPriceJSON("us-east-1", "USE1", "Claude3Sonnet", "Anthropic", "0.00300"),
+			inputPriceJSON("us-east-1", "USE1", "Llama4-Scout-17B", "Meta", "0.00017"),
 			searchUnitPriceJSON("us-east-1", "USE1", "cohere.rerank-english-v3", "Cohere", "0.00200"),
 		}, nil).
 		Times(1)
@@ -212,19 +213,11 @@ func TestCollect_EmitsCohereSearchUnitMetrics(t *testing.T) {
 
 	results, err := collectMetricResults(t, collector)
 	require.NoError(t, err)
-	require.Len(t, results, 2)
+	require.Len(t, results, 1)
 
-	embedMetric := metricByName(results, "cloudcost_aws_bedrock_token_input_usd_per_1k_tokens")
-	require.NotNil(t, embedMetric)
-	assert.Equal(t, "cohere.embed-english-v3", embedMetric.Labels["model_id"])
-	assert.Equal(t, "cohere", embedMetric.Labels["family"])
-	assert.InDelta(t, 0.0001, embedMetric.Value, 1e-9)
-
-	rerankMetric := metricByName(results, "cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units")
-	require.NotNil(t, rerankMetric)
-	assert.Equal(t, "cohere.rerank-english-v3", rerankMetric.Labels["model_id"])
-	assert.Equal(t, "cohere", rerankMetric.Labels["family"])
-	assert.InDelta(t, 0.002, rerankMetric.Value, 1e-9)
+	m := results[0]
+	assert.Equal(t, "anthropic", m.Labels["family"])
+	assert.Equal(t, "Claude3Sonnet", m.Labels["model_id"])
 }
 
 func TestCollect_SkipsNonTextTokenSKUs(t *testing.T) {

--- a/pkg/aws/bedrock/bedrock_test.go
+++ b/pkg/aws/bedrock/bedrock_test.go
@@ -189,7 +189,7 @@ func TestCollect_LabelsBatchPriceTier(t *testing.T) {
 	assert.Equal(t, "Claude3Sonnet", m.Labels["model_id"])
 }
 
-func TestCollect_SkipsNonAnthropicAmazonFamilies(t *testing.T) {
+func TestCollect_FamilyFilterRegexFiltersOtherFamilies(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -206,6 +206,7 @@ func TestCollect_SkipsNonAnthropicAmazonFamilies(t *testing.T) {
 	collector, err := New(t.Context(), &Config{
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		PricingClient: pricingClient,
+		FamilyFilter:  "anthropic|amazon",
 		Logger:        testLogger(),
 		AccountID:     "123456789012",
 	})
@@ -218,6 +219,49 @@ func TestCollect_SkipsNonAnthropicAmazonFamilies(t *testing.T) {
 	m := results[0]
 	assert.Equal(t, "anthropic", m.Labels["family"])
 	assert.Equal(t, "Claude3Sonnet", m.Labels["model_id"])
+}
+
+func TestCollect_FamilyFilterDefaultEmitsAllFamilies(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pricingClient := mockclient.NewMockClient(ctrl)
+	pricingClient.EXPECT().
+		ListBedrockPrices(gomock.Any(), "us-east-1").
+		Return([]string{
+			inputPriceJSON("us-east-1", "USE1", "Claude3Sonnet", "Anthropic", "0.00300"),
+			inputPriceJSON("us-east-1", "USE1", "Llama4-Scout-17B", "Meta", "0.00017"),
+			inputPriceJSON("us-east-1", "USE1", "NovaPro", "", "0.00080"),
+		}, nil).
+		Times(1)
+
+	collector, err := New(t.Context(), &Config{
+		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
+		PricingClient: pricingClient,
+		Logger:        testLogger(),
+		AccountID:     "123456789012",
+	})
+	require.NoError(t, err)
+
+	results, err := collectMetricResults(t, collector)
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+}
+
+func TestNew_ReturnsErrorForInvalidFamilyFilterRegex(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pricingClient := mockclient.NewMockClient(ctrl)
+
+	_, err := New(t.Context(), &Config{
+		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
+		PricingClient: pricingClient,
+		FamilyFilter:  "[invalid",
+		Logger:        testLogger(),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid bedrock family filter")
 }
 
 func TestCollect_SkipsNonTextTokenSKUs(t *testing.T) {


### PR DESCRIPTION
Part of https://github.com/grafana/cloudcost-exporter/issues/923.

Adds a configurable family filter to the Bedrock pricing collector. By default it only emits metrics for `anthropic` (Claude) and `amazon` (Nova, Titan) models. The filter is controlled via a new flag:

```
--aws.bedrock.families
```

The value is a regex matched against the `family` label. The flag defaults to `.*` to emit all families.

Without filtering, the collector emits ~8,000 active series covering 113 models. The vast majority of those series represent third-party marketplace models we do not use. Filtering reduces active series by 90%.

## Changes

- `pkg/aws/bedrock/bedrock.go`: family filter compiled from config at startup and applied in `encodeBedrockPriceJSON`; defaults to `.*`
- `pkg/aws/aws.go`: `BedrockFamilyFilter` field added to `Config`, passed to the bedrock collector
- `cmd/exporter/config/config.go`: `BedrockFamilyFilter` field added to AWS provider config
- `cmd/exporter/exporter.go`: `--aws.bedrock.families` flag registered with default `.*`
- `pkg/aws/bedrock/bedrock_test.go`: updated tests to use Anthropic/Amazon providers
- `docs/metrics/aws/bedrock.md`: updated `family` description to reflect the default filter


