### PR TITLE
feat(gcp/cloudsql): Retry Pricing Init on Transient API Failures

### DIFF
--- a/pkg/google/client/retry.go
+++ b/pkg/google/client/retry.go
@@ -1,0 +1,25 @@
+package client
+
+import (
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// IsRetryableError reports whether err represents a transient gRPC failure that
+// is worth retrying. Auth and configuration errors are not retryable.
+func IsRetryableError(err error) bool {
+	var grpcErr interface {
+		GRPCStatus() *status.Status
+	}
+	if !errors.As(err, &grpcErr) {
+		return false
+	}
+	switch grpcErr.GRPCStatus().Code() {
+	case codes.Unavailable, codes.DeadlineExceeded, codes.Internal, codes.ResourceExhausted:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/google/client/retry_test.go
+++ b/pkg/google/client/retry_test.go
@@ -1,0 +1,49 @@
+package client
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestIsRetryableError(t *testing.T) {
+	retryableCodes := []codes.Code{
+		codes.Unavailable,
+		codes.DeadlineExceeded,
+		codes.Internal,
+		codes.ResourceExhausted,
+	}
+	nonRetryableCodes := []codes.Code{
+		codes.PermissionDenied,
+		codes.Unauthenticated,
+		codes.NotFound,
+		codes.InvalidArgument,
+		codes.AlreadyExists,
+		codes.OK,
+	}
+
+	for _, code := range retryableCodes {
+		t.Run(code.String(), func(t *testing.T) {
+			err := status.Errorf(code, "transient error")
+			assert.True(t, IsRetryableError(err))
+		})
+	}
+
+	for _, code := range nonRetryableCodes {
+		t.Run(code.String(), func(t *testing.T) {
+			err := status.Errorf(code, "non-retryable error")
+			assert.False(t, IsRetryableError(err))
+		})
+	}
+
+	t.Run("non-gRPC error", func(t *testing.T) {
+		assert.False(t, IsRetryableError(errors.New("plain error")))
+	})
+
+	t.Run("nil error", func(t *testing.T) {
+		assert.False(t, IsRetryableError(nil))
+	})
+}

--- a/pkg/google/cloudsql/cloudsql.go
+++ b/pkg/google/cloudsql/cloudsql.go
@@ -38,9 +38,7 @@ var (
 	initRetryAttempts     = 3
 	initRetryInitialDelay = 1 * time.Second
 	initRetryMaxDelay     = 30 * time.Second
-)
 
-var (
 	HourlyGaugeDesc = utils.GenerateDesc(
 		cloudcost_exporter.MetricPrefix,
 		subsystem,

--- a/pkg/google/cloudsql/cloudsql.go
+++ b/pkg/google/cloudsql/cloudsql.go
@@ -35,6 +35,12 @@ const (
 )
 
 var (
+	initRetryAttempts     = 3
+	initRetryInitialDelay = 1 * time.Second
+	initRetryMaxDelay     = 30 * time.Second
+)
+
+var (
 	HourlyGaugeDesc = utils.GenerateDesc(
 		cloudcost_exporter.MetricPrefix,
 		subsystem,
@@ -50,7 +56,9 @@ func New(ctx context.Context, config *Config, logger *slog.Logger, gcpClient cli
 	projects := strings.Split(config.Projects, ",")
 	regions := client.RegionsForProjects(gcpClient, projects, logger)
 
-	if err := pm.getSKus(ctx); err != nil {
+	if err := utils.Retry(initRetryAttempts, initRetryInitialDelay, initRetryMaxDelay, client.IsRetryableError, func() error {
+		return pm.getSKus(ctx)
+	}); err != nil {
 		return nil, fmt.Errorf("failed to initialise Cloud SQL pricing: %w", err)
 	}
 

--- a/pkg/google/cloudsql/cloudsql.go
+++ b/pkg/google/cloudsql/cloudsql.go
@@ -68,7 +68,9 @@ func New(ctx context.Context, config *Config, logger *slog.Logger, gcpClient cli
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if err := pm.getSKus(ctx); err != nil {
+				if err := utils.Retry(initRetryAttempts, initRetryInitialDelay, initRetryMaxDelay, client.IsRetryableError, func() error {
+					return pm.getSKus(ctx)
+				}); err != nil {
 					logger.Error("failed to refresh Cloud SQL pricing SKUs", "error", err)
 				}
 			}

--- a/pkg/google/cloudsql/cloudsql_test.go
+++ b/pkg/google/cloudsql/cloudsql_test.go
@@ -242,6 +242,39 @@ func TestNew_DoesNotRetryOnAuthError(t *testing.T) {
 	assert.Equal(t, 1, srv.callCount, "expected exactly 1 ListServices call — PermissionDenied must not be retried")
 }
 
+func TestNew_DoesNotRetryOnEmptySKUResponse(t *testing.T) {
+	zeroRetryDelays(t)
+
+	// ListServices succeeds but ListSkus returns no SKUs — ErrNoSKUsFound must not be retried.
+	srv := &failAfterNCatalogServer{
+		failCount: 0, // always succeeds on ListServices
+		skus:      nil,
+	}
+	catalogClient := client.NewTestBillingClient(t, srv)
+
+	computeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(struct{}{})
+	}))
+	t.Cleanup(computeSrv.Close)
+
+	sqlAdminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(struct{}{})
+	}))
+	t.Cleanup(sqlAdminSrv.Close)
+
+	computeService, err := computev1.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(computeSrv.URL))
+	require.NoError(t, err)
+
+	sqlAdminService, err := sqladmin.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(sqlAdminSrv.URL))
+	require.NoError(t, err)
+
+	gcpClient := client.NewMock("test-project", 0, nil, nil, catalogClient, computeService, sqlAdminService, nil)
+	_, err = New(context.Background(), &Config{Projects: "test-project"}, slog.New(slog.NewTextHandler(os.Stdout, nil)), gcpClient)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoSKUsFound)
+	assert.Equal(t, 1, srv.callCount, "expected exactly 1 ListServices call — empty SKU response must not be retried")
+}
+
 // minimalSKUs returns a single valid Cloud SQL SKU sufficient for New() to succeed.
 func minimalSKUs() []*billingpb.Sku {
 	return []*billingpb.Sku{

--- a/pkg/google/cloudsql/cloudsql_test.go
+++ b/pkg/google/cloudsql/cloudsql_test.go
@@ -105,7 +105,52 @@ func (s *switchableCatalogServer) ListSkus(_ context.Context, _ *billingpb.ListS
 	return &billingpb.ListSkusResponse{Skus: s.skus}, nil
 }
 
+// failAfterNCatalogServer fails the first failCount ListServices calls then succeeds.
+type failAfterNCatalogServer struct {
+	billingpb.UnimplementedCloudCatalogServer
+	mu        sync.Mutex
+	callCount int
+	failCount int
+	code      codes.Code
+	skus      []*billingpb.Sku
+}
+
+func (s *failAfterNCatalogServer) ListServices(_ context.Context, _ *billingpb.ListServicesRequest) (*billingpb.ListServicesResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.callCount++
+	if s.callCount <= s.failCount {
+		return nil, status.Errorf(s.code, "transient error (call %d)", s.callCount)
+	}
+	return &billingpb.ListServicesResponse{
+		Services: []*billingpb.Service{
+			{Name: "services/cloud-sql", DisplayName: "Cloud SQL"},
+		},
+	}, nil
+}
+
+func (s *failAfterNCatalogServer) ListSkus(_ context.Context, _ *billingpb.ListSkusRequest) (*billingpb.ListSkusResponse, error) {
+	return &billingpb.ListSkusResponse{Skus: s.skus}, nil
+}
+
+func zeroRetryDelays(t *testing.T) {
+	t.Helper()
+	origAttempts := initRetryAttempts
+	origInitial := initRetryInitialDelay
+	origMax := initRetryMaxDelay
+	initRetryAttempts = 3
+	initRetryInitialDelay = 0
+	initRetryMaxDelay = 0
+	t.Cleanup(func() {
+		initRetryAttempts = origAttempts
+		initRetryInitialDelay = origInitial
+		initRetryMaxDelay = origMax
+	})
+}
+
 func TestNew_FailsIfInitialSKUFetchFails(t *testing.T) {
+	zeroRetryDelays(t)
+
 	catalogClient := client.NewTestBillingClient(t, &failingCatalogServer{})
 
 	computeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -130,6 +175,96 @@ func TestNew_FailsIfInitialSKUFetchFails(t *testing.T) {
 	_, err = New(context.Background(), config, slog.New(slog.NewTextHandler(os.Stdout, nil)), gcpClient)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "failed to initialise Cloud SQL pricing")
+}
+
+func TestNew_RetriesOnTransientError(t *testing.T) {
+	zeroRetryDelays(t)
+
+	// Fail the first 2 attempts with a retryable error, succeed on the 3rd.
+	srv := &failAfterNCatalogServer{
+		failCount: 2,
+		code:      codes.Unavailable,
+		skus:      minimalSKUs(),
+	}
+	catalogClient := client.NewTestBillingClient(t, srv)
+
+	computeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(struct{}{})
+	}))
+	t.Cleanup(computeSrv.Close)
+
+	sqlAdminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(struct{}{})
+	}))
+	t.Cleanup(sqlAdminSrv.Close)
+
+	computeService, err := computev1.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(computeSrv.URL))
+	require.NoError(t, err)
+
+	sqlAdminService, err := sqladmin.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(sqlAdminSrv.URL))
+	require.NoError(t, err)
+
+	gcpClient := client.NewMock("test-project", 0, nil, nil, catalogClient, computeService, sqlAdminService, nil)
+	_, err = New(context.Background(), &Config{Projects: "test-project"}, slog.New(slog.NewTextHandler(os.Stdout, nil)), gcpClient)
+	require.NoError(t, err)
+	assert.Equal(t, 3, srv.callCount, "expected 3 ListServices calls (2 failures + 1 success)")
+}
+
+func TestNew_DoesNotRetryOnAuthError(t *testing.T) {
+	zeroRetryDelays(t)
+
+	// PermissionDenied is a non-retryable error — New() should fail after a single attempt.
+	srv := &failAfterNCatalogServer{
+		failCount: initRetryAttempts + 1, // would succeed eventually if retried
+		code:      codes.PermissionDenied,
+	}
+	catalogClient := client.NewTestBillingClient(t, srv)
+
+	computeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(struct{}{})
+	}))
+	t.Cleanup(computeSrv.Close)
+
+	sqlAdminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(struct{}{})
+	}))
+	t.Cleanup(sqlAdminSrv.Close)
+
+	computeService, err := computev1.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(computeSrv.URL))
+	require.NoError(t, err)
+
+	sqlAdminService, err := sqladmin.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(sqlAdminSrv.URL))
+	require.NoError(t, err)
+
+	gcpClient := client.NewMock("test-project", 0, nil, nil, catalogClient, computeService, sqlAdminService, nil)
+	_, err = New(context.Background(), &Config{Projects: "test-project"}, slog.New(slog.NewTextHandler(os.Stdout, nil)), gcpClient)
+	require.Error(t, err)
+	assert.Equal(t, 1, srv.callCount, "expected exactly 1 ListServices call — PermissionDenied must not be retried")
+}
+
+// minimalSKUs returns a single valid Cloud SQL SKU sufficient for New() to succeed.
+func minimalSKUs() []*billingpb.Sku {
+	return []*billingpb.Sku{
+		{
+			SkuId: "minimal-sku",
+			Category: &billingpb.Category{
+				ServiceDisplayName: "Cloud SQL",
+			},
+			Description: "Cloud SQL: MYSQL db-f1-micro ZONAL instance running in us-central1",
+			GeoTaxonomy: &billingpb.GeoTaxonomy{
+				Regions: []string{"us-central1"},
+			},
+			PricingInfo: []*billingpb.PricingInfo{
+				{
+					PricingExpression: &billingpb.PricingExpression{
+						TieredRates: []*billingpb.PricingExpression_TierRate{
+							{UnitPrice: &money.Money{Nanos: 10000000}},
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 func TestCollect_UsesCachedSKUs(t *testing.T) {
@@ -441,7 +576,11 @@ func TestGetAllCloudSQL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gcpClient := newTestGCPClient(t, tt.regionsHandlers, tt.sqlAdminHandlers, nil)
+			skus := tt.skus
+			if len(skus) == 0 {
+				skus = minimalSKUs()
+			}
+			gcpClient := newTestGCPClient(t, tt.regionsHandlers, tt.sqlAdminHandlers, skus)
 			config := &Config{Projects: "test-project"}
 			collector, err := New(context.Background(), config, slog.New(slog.NewTextHandler(os.Stdout, nil)), gcpClient)
 			require.NoError(t, err)

--- a/pkg/google/cloudsql/cloudsql_test.go
+++ b/pkg/google/cloudsql/cloudsql_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"testing"
 
+	billingv1 "cloud.google.com/go/billing/apiv1"
 	"cloud.google.com/go/billing/apiv1/billingpb"
 	"github.com/grafana/cloudcost-exporter/pkg/google/client"
 	"github.com/grafana/cloudcost-exporter/pkg/utils"
@@ -133,6 +134,31 @@ func (s *failAfterNCatalogServer) ListSkus(_ context.Context, _ *billingpb.ListS
 	return &billingpb.ListSkusResponse{Skus: s.skus}, nil
 }
 
+// newTestGCPClientWithCatalog wires up stub compute and sqladmin HTTP servers and returns a
+// Mock GCP client that uses the provided billing catalog client. Use this in tests that need
+// a custom catalog server (e.g. one that fails or retries).
+func newTestGCPClientWithCatalog(t *testing.T, catalogClient *billingv1.CloudCatalogClient) *client.Mock {
+	t.Helper()
+
+	computeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(struct{}{})
+	}))
+	t.Cleanup(computeSrv.Close)
+
+	sqlAdminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(struct{}{})
+	}))
+	t.Cleanup(sqlAdminSrv.Close)
+
+	computeService, err := computev1.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(computeSrv.URL))
+	require.NoError(t, err)
+
+	sqlAdminService, err := sqladmin.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(sqlAdminSrv.URL))
+	require.NoError(t, err)
+
+	return client.NewMock("test-project", 0, nil, nil, catalogClient, computeService, sqlAdminService, nil)
+}
+
 func zeroRetryDelays(t *testing.T) {
 	t.Helper()
 	origAttempts := initRetryAttempts
@@ -151,28 +177,8 @@ func zeroRetryDelays(t *testing.T) {
 func TestNew_FailsIfInitialSKUFetchFails(t *testing.T) {
 	zeroRetryDelays(t)
 
-	catalogClient := client.NewTestBillingClient(t, &failingCatalogServer{})
-
-	computeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(struct{}{})
-	}))
-	t.Cleanup(computeSrv.Close)
-
-	sqlAdminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(struct{}{})
-	}))
-	t.Cleanup(sqlAdminSrv.Close)
-
-	computeService, err := computev1.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(computeSrv.URL))
-	require.NoError(t, err)
-
-	sqlAdminService, err := sqladmin.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(sqlAdminSrv.URL))
-	require.NoError(t, err)
-
-	gcpClient := client.NewMock("test-project", 0, nil, nil, catalogClient, computeService, sqlAdminService, nil)
-	config := &Config{Projects: "test-project"}
-
-	_, err = New(context.Background(), config, slog.New(slog.NewTextHandler(os.Stdout, nil)), gcpClient)
+	gcpClient := newTestGCPClientWithCatalog(t, client.NewTestBillingClient(t, &failingCatalogServer{}))
+	_, err := New(context.Background(), &Config{Projects: "test-project"}, slog.New(slog.NewTextHandler(os.Stdout, nil)), gcpClient)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "failed to initialise Cloud SQL pricing")
 }
@@ -186,26 +192,8 @@ func TestNew_RetriesOnTransientError(t *testing.T) {
 		code:      codes.Unavailable,
 		skus:      minimalSKUs(),
 	}
-	catalogClient := client.NewTestBillingClient(t, srv)
-
-	computeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(struct{}{})
-	}))
-	t.Cleanup(computeSrv.Close)
-
-	sqlAdminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(struct{}{})
-	}))
-	t.Cleanup(sqlAdminSrv.Close)
-
-	computeService, err := computev1.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(computeSrv.URL))
-	require.NoError(t, err)
-
-	sqlAdminService, err := sqladmin.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(sqlAdminSrv.URL))
-	require.NoError(t, err)
-
-	gcpClient := client.NewMock("test-project", 0, nil, nil, catalogClient, computeService, sqlAdminService, nil)
-	_, err = New(context.Background(), &Config{Projects: "test-project"}, slog.New(slog.NewTextHandler(os.Stdout, nil)), gcpClient)
+	gcpClient := newTestGCPClientWithCatalog(t, client.NewTestBillingClient(t, srv))
+	_, err := New(context.Background(), &Config{Projects: "test-project"}, slog.New(slog.NewTextHandler(os.Stdout, nil)), gcpClient)
 	require.NoError(t, err)
 	assert.Equal(t, 3, srv.callCount, "expected 3 ListServices calls (2 failures + 1 success)")
 }
@@ -218,26 +206,8 @@ func TestNew_DoesNotRetryOnAuthError(t *testing.T) {
 		failCount: initRetryAttempts + 1, // would succeed eventually if retried
 		code:      codes.PermissionDenied,
 	}
-	catalogClient := client.NewTestBillingClient(t, srv)
-
-	computeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(struct{}{})
-	}))
-	t.Cleanup(computeSrv.Close)
-
-	sqlAdminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(struct{}{})
-	}))
-	t.Cleanup(sqlAdminSrv.Close)
-
-	computeService, err := computev1.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(computeSrv.URL))
-	require.NoError(t, err)
-
-	sqlAdminService, err := sqladmin.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(sqlAdminSrv.URL))
-	require.NoError(t, err)
-
-	gcpClient := client.NewMock("test-project", 0, nil, nil, catalogClient, computeService, sqlAdminService, nil)
-	_, err = New(context.Background(), &Config{Projects: "test-project"}, slog.New(slog.NewTextHandler(os.Stdout, nil)), gcpClient)
+	gcpClient := newTestGCPClientWithCatalog(t, client.NewTestBillingClient(t, srv))
+	_, err := New(context.Background(), &Config{Projects: "test-project"}, slog.New(slog.NewTextHandler(os.Stdout, nil)), gcpClient)
 	require.Error(t, err)
 	assert.Equal(t, 1, srv.callCount, "expected exactly 1 ListServices call — PermissionDenied must not be retried")
 }
@@ -250,26 +220,8 @@ func TestNew_DoesNotRetryOnEmptySKUResponse(t *testing.T) {
 		failCount: 0, // always succeeds on ListServices
 		skus:      nil,
 	}
-	catalogClient := client.NewTestBillingClient(t, srv)
-
-	computeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(struct{}{})
-	}))
-	t.Cleanup(computeSrv.Close)
-
-	sqlAdminSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(struct{}{})
-	}))
-	t.Cleanup(sqlAdminSrv.Close)
-
-	computeService, err := computev1.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(computeSrv.URL))
-	require.NoError(t, err)
-
-	sqlAdminService, err := sqladmin.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(sqlAdminSrv.URL))
-	require.NoError(t, err)
-
-	gcpClient := client.NewMock("test-project", 0, nil, nil, catalogClient, computeService, sqlAdminService, nil)
-	_, err = New(context.Background(), &Config{Projects: "test-project"}, slog.New(slog.NewTextHandler(os.Stdout, nil)), gcpClient)
+	gcpClient := newTestGCPClientWithCatalog(t, client.NewTestBillingClient(t, srv))
+	_, err := New(context.Background(), &Config{Projects: "test-project"}, slog.New(slog.NewTextHandler(os.Stdout, nil)), gcpClient)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrNoSKUsFound)
 	assert.Equal(t, 1, srv.callCount, "expected exactly 1 ListServices call — empty SKU response must not be retried")

--- a/pkg/google/cloudsql/pricingmap.go
+++ b/pkg/google/cloudsql/pricingmap.go
@@ -48,6 +48,7 @@ type instanceTraits struct {
 }
 
 var (
+	ErrNoSKUsFound        = errors.New("no SKUs found for Cloud SQL service")
 	ErrInstanceNotFound   = errors.New("instance not found")
 	ErrPriceNotFound      = errors.New("price not found for instance")
 	ErrInvalidTier        = errors.New("invalid tier format")
@@ -95,8 +96,7 @@ func (pm *pricingMap) getSKus(ctx context.Context) error {
 
 	skus := pm.gcpClient.GetPricing(ctx, serviceFullName)
 	if len(skus) == 0 {
-		pm.logger.Warn("no SKUs found for Cloud SQL service", "serviceName", serviceFullName)
-		return nil
+		return ErrNoSKUsFound
 	}
 
 	pm.skus = skus

--- a/pkg/google/cloudsql/pricingmap.go
+++ b/pkg/google/cloudsql/pricingmap.go
@@ -96,6 +96,7 @@ func (pm *pricingMap) getSKus(ctx context.Context) error {
 
 	skus := pm.gcpClient.GetPricing(ctx, serviceFullName)
 	if len(skus) == 0 {
+		pm.logger.Warn("no SKUs found for Cloud SQL service", "serviceName", serviceFullName)
 		return ErrNoSKUsFound
 	}
 


### PR DESCRIPTION
Add exponential backoff retry to the Cloud SQL collector's \`New()\` using \`utils.Retry\`. Transient gRPC errors (\`Unavailable\`, \`DeadlineExceeded\`, \`Internal\`, \`ResourceExhausted\`) are retried up to 3 times; auth and config errors fail immediately.

Move the retryable error classifier to \`pkg/google/client\` so all GCP collectors can share it without duplication.

Fix a silent failure path where an empty SKU response from the billing API was treated as success, allowing the collector to register while producing no metrics. The empty SKU path now returns an exported \`ErrNoSKUsFound\` sentinel and is not retried. The API call succeeded but the data is absent, which retrying is unlikely to resolve.

## Tests

- \`TestNew_RetriesOnTransientError\`: verifies the collector succeeds after 2 transient failures followed by a successful call
- \`TestNew_DoesNotRetryOnAuthError\`: verifies \`PermissionDenied\` fails fast after a single attempt
- \`TestNew_DoesNotRetryOnEmptySKUResponse\`: verifies an empty SKU response fails fast with \`ErrNoSKUsFound\`