### PR TITLE
Escape line breaks in collector error logs

### DIFF
--- a/pkg/collectormetrics/collectormetrics.go
+++ b/pkg/collectormetrics/collectormetrics.go
@@ -3,6 +3,7 @@ package collectormetrics
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"time"
 
 	cloudcost_exporter "github.com/grafana/cloudcost-exporter"
@@ -67,7 +68,7 @@ func Collect(ctx context.Context, c provider.Collector, ch chan<- prometheus.Met
 		hasError = true
 		logger.LogAttrs(ctx, slog.LevelError, "could not collect metrics",
 			slog.String("collector", c.Name()),
-			slog.String("message", collectErr.Error()),
+			slog.String("message", escapeLineBreaks(collectErr.Error())),
 		)
 		for _, region := range regions {
 			errorCounter := errorCounterVec.WithLabelValues(c.Name(), providerName, region)
@@ -81,4 +82,12 @@ func Collect(ctx context.Context, c provider.Collector, ch chan<- prometheus.Met
 	}
 
 	return duration, hasError
+}
+
+func escapeLineBreaks(message string) string {
+	replacer := strings.NewReplacer(
+		"\n", "\\n",
+		"\r", "\\r",
+	)
+	return replacer.Replace(message)
 }

--- a/pkg/collectormetrics/collectormetrics.go
+++ b/pkg/collectormetrics/collectormetrics.go
@@ -68,7 +68,7 @@ func Collect(ctx context.Context, c provider.Collector, ch chan<- prometheus.Met
 		hasError = true
 		logger.LogAttrs(ctx, slog.LevelError, "could not collect metrics",
 			slog.String("collector", c.Name()),
-			slog.String("message", escapeLineBreaks(collectErr.Error())),
+			slog.String("error", escapeLineBreaks(collectErr.Error())),
 		)
 		for _, region := range regions {
 			errorCounter := errorCounterVec.WithLabelValues(c.Name(), providerName, region)

--- a/pkg/collectormetrics/collectormetrics_test.go
+++ b/pkg/collectormetrics/collectormetrics_test.go
@@ -109,7 +109,7 @@ func TestCollect_EscapesLineBreaksInLoggedErrorMessage(t *testing.T) {
 	Collect(context.Background(), c, ch, logger, "test_provider")
 
 	got := logOutput.String()
-	assert.Contains(t, got, `message="first line\\nsecond line\\rthird line"`)
+	assert.Contains(t, got, `error="first line\\nsecond line\\rthird line"`)
 	assert.NotContains(t, got, "first line\nsecond line")
 	assert.NotContains(t, got, "second line\rthird line")
 }

--- a/pkg/collectormetrics/collectormetrics_test.go
+++ b/pkg/collectormetrics/collectormetrics_test.go
@@ -1,7 +1,9 @@
 package collectormetrics
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 
@@ -90,6 +92,26 @@ func TestCollect_ErrorCounterEmitted(t *testing.T) {
 	}
 	assert.True(t, found, "error counter metric should be emitted to channel when Collect fails")
 	assert.Equal(t, 1.0, counterValue, "error counter should be incremented by 1")
+}
+
+func TestCollect_EscapesLineBreaksInLoggedErrorMessage(t *testing.T) {
+	ch := make(chan prometheus.Metric, 10)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	c := mock_provider.NewMockCollector(ctrl)
+	c.EXPECT().Name().Return("collector_with_multiline_error").AnyTimes()
+	c.EXPECT().Collect(gomock.Any(), ch).Return(errors.New("first line\nsecond line\rthird line"))
+
+	var logOutput bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logOutput, nil))
+
+	Collect(context.Background(), c, ch, logger, "test_provider")
+
+	got := logOutput.String()
+	assert.Contains(t, got, `message="first line\\nsecond line\\rthird line"`)
+	assert.NotContains(t, got, "first line\nsecond line")
+	assert.NotContains(t, got, "second line\rthird line")
 }
 
 type collectorConfig struct {


### PR DESCRIPTION
## Summary
- Escape collector error message line breaks before passing them to slog text output
- Update the `message` logfmt field to `error` to match the semantics
- Add regression coverage for newline and carriage-return escaping
