### PR TITLE
Extract pinned aws pricingAPI instantiation to be done just once

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -384,6 +384,7 @@ func filterExcludedRegions(regions []types.Region, excludeList []string) []types
 
 func newRegionClientMap(ctx context.Context, globalConfig aws.Config, pricingConfig aws.Config, regions []types.Region, profile string, roleARN string) (map[string]client.Client, error) {
 	awsClientPerRegion := make(map[string]client.Client)
+	pricingAPI := awsPricing.NewFromConfig(pricingConfig)
 	for _, region := range regions {
 		ac, err := createAWSConfig(ctx, *region.RegionName, profile, roleARN)
 		if err != nil {
@@ -391,7 +392,7 @@ func newRegionClientMap(ctx context.Context, globalConfig aws.Config, pricingCon
 		}
 		awsClientPerRegion[*region.RegionName] = client.NewAWSClient(
 			client.Config{
-				PricingService: awsPricing.NewFromConfig(pricingConfig),
+				PricingService: pricingAPI,
 				EC2Service:     ec2.NewFromConfig(ac),
 				BillingService: costexplorer.NewFromConfig(globalConfig),
 				RDSService:     rds.NewFromConfig(ac),

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -134,13 +134,13 @@ func New(ctx context.Context, config *Config) (*AWS, error) {
 	}
 	config.AccountID = aws.ToString(identity.Account)
 
-	// Create per-region clients
-	awsClientPerRegion, err := newRegionClientMap(ctx, ac, regions, config.Profile, config.RoleARN)
+	pricingConfig, err := createAWSConfig(ctx, "us-east-1", config.Profile, config.RoleARN)
 	if err != nil {
 		return nil, err
 	}
 
-	pricingConfig, err := createAWSConfig(ctx, "us-east-1", config.Profile, config.RoleARN)
+	// Create per-region clients
+	awsClientPerRegion, err := newRegionClientMap(ctx, ac, pricingConfig, regions, config.Profile, config.RoleARN)
 	if err != nil {
 		return nil, err
 	}
@@ -152,6 +152,7 @@ func New(ctx context.Context, config *Config) (*AWS, error) {
 func newWithDependencies(ctx context.Context, config *Config, awsClient client.Client, regionClients map[string]client.Client, regions []types.Region, awsConfig aws.Config, pricingConfig aws.Config) (*AWS, error) {
 	var collectors []provider.Collector
 	logger := config.Logger.With("provider", subsystem)
+	pricingAPI := awsPricing.NewFromConfig(pricingConfig)
 
 	for _, service := range config.Services {
 		service = strings.ToUpper(service)
@@ -184,17 +185,8 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 			}
 			collectors = append(collectors, collector)
 		case serviceRDS:
-			// pricing API for RDS client needs to use always the same region
-			// as for RDS, the pricing data is only available in the us-east-1
-			pricingConfig, err := createAWSConfig(ctx, "us-east-1", config.Profile, config.RoleARN)
-			if err != nil {
-				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
-					slog.String("service", service),
-					slog.String("message", err.Error()))
-				continue
-			}
 			awsRDSClient := client.NewAWSClient(client.Config{
-				PricingService: awsPricing.NewFromConfig(pricingConfig),
+				PricingService: pricingAPI,
 				RDSService:     rds.NewFromConfig(awsConfig),
 			})
 			collector, err := rdsCollector.New(ctx, &rdsCollector.Config{
@@ -226,17 +218,8 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 			}
 			collectors = append(collectors, collector)
 		case serviceELB:
-			// pricing API for ELB client needs to use always the same region
-			// as the pricing data is only available in us-east-1
-			elbPricingConfig, err := createAWSConfig(ctx, "us-east-1", config.Profile, config.RoleARN)
-			if err != nil {
-				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
-					slog.String("service", service),
-					slog.String("message", err.Error()))
-				continue
-			}
 			awsELBPricingClient := client.NewAWSClient(client.Config{
-				PricingService: awsPricing.NewFromConfig(elbPricingConfig),
+				PricingService: pricingAPI,
 			})
 			collector, err := elb.New(ctx, &elb.Config{
 				Regions:        regions,
@@ -253,17 +236,8 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 			}
 			collectors = append(collectors, collector)
 		case serviceVPC:
-			// pricing API for VPC client needs to use always the same region
-			// as for VPC, the pricing data is only available in the us-east-1
-			pricingConfig, err := createAWSConfig(ctx, "us-east-1", config.Profile, config.RoleARN)
-			if err != nil {
-				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
-					slog.String("service", service),
-					slog.String("message", err.Error()))
-				continue
-			}
 			awsVPCClient := client.NewAWSClient(client.Config{
-				PricingService: awsPricing.NewFromConfig(pricingConfig),
+				PricingService: pricingAPI,
 				EC2Service:     ec2.NewFromConfig(pricingConfig),
 			})
 			collector, err := awsvpc.New(ctx, &awsvpc.Config{
@@ -281,7 +255,7 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 			collectors = append(collectors, collector)
 		case serviceMSK:
 			awsMSKClient := client.NewAWSClient(client.Config{
-				PricingService: awsPricing.NewFromConfig(pricingConfig),
+				PricingService: pricingAPI,
 			})
 			collector, err := mskCollector.New(ctx, &mskCollector.Config{
 				Regions:   regions,
@@ -301,10 +275,8 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 			// Note: this pins the *endpoint*, not the queried region — the collector still
 			// fetches prices per configured region via a regionCode filter. See
 			// pkg/aws/bedrock.go newPriceFetcher().
-			bedrockPricingConfig := awsConfig.Copy()
-			bedrockPricingConfig.Region = "us-east-1"
 			awsBedrockClient := client.NewAWSClient(client.Config{
-				PricingService: awsPricing.NewFromConfig(bedrockPricingConfig),
+				PricingService: pricingAPI,
 			})
 			collector, err := bedrock.New(ctx, &bedrock.Config{
 				Regions:       regions,
@@ -410,7 +382,7 @@ func filterExcludedRegions(regions []types.Region, excludeList []string) []types
 	return filtered
 }
 
-func newRegionClientMap(ctx context.Context, globalConfig aws.Config, regions []types.Region, profile string, roleARN string) (map[string]client.Client, error) {
+func newRegionClientMap(ctx context.Context, globalConfig aws.Config, pricingConfig aws.Config, regions []types.Region, profile string, roleARN string) (map[string]client.Client, error) {
 	awsClientPerRegion := make(map[string]client.Client)
 	for _, region := range regions {
 		ac, err := createAWSConfig(ctx, *region.RegionName, profile, roleARN)
@@ -419,7 +391,7 @@ func newRegionClientMap(ctx context.Context, globalConfig aws.Config, regions []
 		}
 		awsClientPerRegion[*region.RegionName] = client.NewAWSClient(
 			client.Config{
-				PricingService: awsPricing.NewFromConfig(globalConfig),
+				PricingService: awsPricing.NewFromConfig(pricingConfig),
 				EC2Service:     ec2.NewFromConfig(ac),
 				BillingService: costexplorer.NewFromConfig(globalConfig),
 				RDSService:     rds.NewFromConfig(ac),

--- a/pkg/aws/elb/elb_test.go
+++ b/pkg/aws/elb/elb_test.go
@@ -152,6 +152,52 @@ func TestFetchRegionPricing(t *testing.T) {
 	assert.Equal(t, 0.006, pricing.NLBHourlyRate[LCUUsage])
 }
 
+func TestCollect_EmitsMetrics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockPricingClient := mock_client.NewMockClient(ctrl)
+	mockRegionClient := mock_client.NewMockClient(ctrl)
+
+	albLBUsage := `{"Product":{"Attributes":{"usageType":"USE1-LoadBalancerUsage","operation":"LoadBalancing:Application"}},"Terms":{"OnDemand":{"t1":{"PriceDimensions":{"d1":{"pricePerUnit":{"USD":"0.0225"}}}}}}}`
+	albLCUUsage := `{"Product":{"Attributes":{"usageType":"USE1-LCUUsage","operation":"LoadBalancing:Application"}},"Terms":{"OnDemand":{"t1":{"PriceDimensions":{"d1":{"pricePerUnit":{"USD":"0.008"}}}}}}}`
+	mockPricingClient.EXPECT().ListELBPrices(gomock.Any(), "us-east-1").Return([]string{albLBUsage, albLCUUsage}, nil)
+	mockRegionClient.EXPECT().DescribeLoadBalancers(gomock.Any()).Return([]elbTypes.LoadBalancer{
+		{
+			LoadBalancerName: utils.StringPtr("test-alb"),
+			Type:             elbTypes.LoadBalancerTypeEnumApplication,
+		},
+	}, nil)
+
+	config := &Config{
+		ScrapeInterval: time.Minute,
+		Regions:        []ec2Types.Region{{RegionName: utils.StringPtr("us-east-1")}},
+		PricingClient:  mockPricingClient,
+		RegionMap:      map[string]client.Client{"us-east-1": mockRegionClient},
+		AccountID:      "123456789012",
+	}
+
+	collector, err := New(context.Background(), config, slog.Default())
+	require.NoError(t, err)
+
+	ch := make(chan prometheus.Metric, 10)
+	err = collector.Collect(t.Context(), ch)
+	close(ch)
+
+	require.NoError(t, err)
+
+	var metrics []prometheus.Metric
+	for m := range ch {
+		metrics = append(metrics, m)
+	}
+	require.Len(t, metrics, 2)
+
+	descStrings := make(map[string]struct{}, 2)
+	for _, m := range metrics {
+		descStrings[m.Desc().String()] = struct{}{}
+	}
+	assert.Contains(t, descStrings, LoadBalancerUsageHourlyCostDesc.String())
+	assert.Contains(t, descStrings, LoadBalancerCapacityUnitsUsageHourlyCostDesc.String())
+}
+
 func TestFetchRegionPricingError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockClient := mock_client.NewMockClient(ctrl)

--- a/pkg/aws/vpc/vpc_test.go
+++ b/pkg/aws/vpc/vpc_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	awsclient "github.com/grafana/cloudcost-exporter/pkg/aws/client"
 	"github.com/grafana/cloudcost-exporter/pkg/utils"
@@ -153,6 +154,41 @@ func TestDescribe(t *testing.T) {
 
 	err := collector.Describe(ch)
 	assert.NoError(t, err)
+}
+
+func TestCollect_EmitsMetrics(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	mockClient := &MockClient{}
+
+	products := []string{
+		`{"product":{"attributes":{"usageType":"USE1-VpcEndpoint-Hours","regionCode":"us-east-1"}},"terms":{"OnDemand":{"t1":{"priceDimensions":{"d1":{"pricePerUnit":{"USD":"0.01"}}}}}}}`,
+		`{"product":{"attributes":{"usageType":"USE1-VpcEndpoint-Service-Hours","regionCode":"us-east-1"}},"terms":{"OnDemand":{"t1":{"priceDimensions":{"d1":{"pricePerUnit":{"USD":"0.01"}}}}}}}`,
+		`{"product":{"attributes":{"usageType":"USE1-TransitGateway-Hours","regionCode":"us-east-1"}},"terms":{"OnDemand":{"t1":{"priceDimensions":{"d1":{"pricePerUnit":{"USD":"0.05"}}}}}}}`,
+		`{"product":{"attributes":{"usageType":"USE1-PublicIPv4:InUseAddress","regionCode":"us-east-1"}},"terms":{"OnDemand":{"t1":{"priceDimensions":{"d1":{"pricePerUnit":{"USD":"0.005"}}}}}}}`,
+		`{"product":{"attributes":{"usageType":"USE1-PublicIPv4:IdleAddress","regionCode":"us-east-1"}},"terms":{"OnDemand":{"t1":{"priceDimensions":{"d1":{"pricePerUnit":{"USD":"0.003"}}}}}}}`,
+	}
+	mockClient.On("ListVPCServicePrices", mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(products, nil)
+
+	collector, err := New(t.Context(), &Config{
+		ScrapeInterval: time.Hour,
+		Regions:        []ec2Types.Region{{RegionName: utils.StringPtr("us-east-1")}},
+		Client:         mockClient,
+		AccountID:      "123456789012",
+	}, logger)
+	require.NoError(t, err)
+
+	ch := make(chan prometheus.Metric, 10)
+	err = collector.Collect(t.Context(), ch)
+	close(ch)
+
+	require.NoError(t, err)
+
+	var metrics []prometheus.Metric
+	for m := range ch {
+		metrics = append(metrics, m)
+	}
+	// One metric per rate type: VPC endpoint, VPC service endpoint, Transit Gateway, EIP in-use, EIP idle
+	assert.Len(t, metrics, 5)
 }
 
 // Test that VPC pricing map methods return errors when no data is available


### PR DESCRIPTION
This is valid for the following services:
- RDS
- VPC
- bedrock
- ELB
- MSK
- EC2