### PR TITLE
feat(gcp): add vertex collector

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@
 - [Metrics](metrics/README.md) - See what each service exposes
   - [Providers](metrics/providers.md)
   - **AWS:** [EC2](metrics/aws/ec2.md), [S3](metrics/aws/s3.md), [RDS](metrics/aws/rds.md), [MSK](metrics/aws/msk.md), [ELB](metrics/aws/elb.md), [NAT Gateway](metrics/aws/natgateway.md), [VPC](metrics/aws/vpc.md), [Bedrock](metrics/aws/bedrock.md)
-  - **GCP:** [GKE](metrics/gcp/gke.md), [GCS](metrics/gcp/gcs.md), [Cloud SQL](metrics/gcp/cloudsql.md), [Managed Kafka](metrics/gcp/managedkafka.md), [CLB](metrics/gcp/clb.md), [VPC](metrics/gcp/vpc.md)
+  - **GCP:** [GKE](metrics/gcp/gke.md), [GCS](metrics/gcp/gcs.md), [Cloud SQL](metrics/gcp/cloudsql.md), [Managed Kafka](metrics/gcp/managedkafka.md), [CLB](metrics/gcp/clb.md), [VPC](metrics/gcp/vpc.md), [Vertex AI](metrics/gcp/vertex.md)
   - **Azure:** [AKS](metrics/azure/aks.md), [blob](metrics/azure/blob.md), [Event Hubs](metrics/azure/eventhubs.md)
 - [Deploying](deploying/aws/README.md) - Run the exporter
   - [AWS](deploying/aws/README.md) — IRSA, Helm, cross-account access

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -21,6 +21,7 @@ Each bullet shows the human-readable name, the flag value to pass via `-{provide
 - **[Managed Kafka](./gcp/managedkafka.md)** (`MANAGEDKAFKA`, alias: `KAFKA`): Managed Service for Apache Kafka clusters
 - **[CLB](./gcp/clb.md)** (`CLB`): Cloud Load Balancers via forwarding rules
 - **[VPC](./gcp/vpc.md)** (`VPC`): Cloud NAT Gateway, VPN Gateway, Private Service Connect
+- **[Vertex AI](./gcp/vertex.md)** (`VERTEX`): Vertex AI model token, character, compute, and reranking pricing
 
 ## Azure Services
 

--- a/docs/metrics/gcp/vertex.md
+++ b/docs/metrics/gcp/vertex.md
@@ -1,0 +1,110 @@
+# Vertex AI Metrics
+
+Metrics exported for the GCP Vertex AI service.
+
+## Token Pricing
+
+| Metric | Labels | Description |
+|--------|--------|-------------|
+| `cloudcost_gcp_vertex_input_usd_per_1k_tokens` | `model_id`, `family`, `region`, `price_tier` | Input cost in USD per 1k tokens, for models billed by token. Character-billed models use the character metric. |
+| `cloudcost_gcp_vertex_output_usd_per_1k_tokens` | `model_id`, `family`, `region`, `price_tier` | Output cost in USD per 1k tokens, for models billed by token. Character-billed models use the character metric. |
+
+### Labels
+
+| Label | Values | Description |
+|-------|--------|-------------|
+| `model_id` | e.g. `gemini-1.5-flash`, `gemma-4`, `llama-4-maverick` | Model name, normalised to lowercase with spaces replaced by hyphens |
+| `family` | `google`, `meta`, `alibaba`, `deepseek`, `minimax`, `moonshot`, `unknown` | Model provider family; `unknown` for unrecognised model prefixes |
+| `region` | e.g. `us-central1` | GCP region |
+| `price_tier` | see below | Running mode or pricing tier derived from the GCP SKU description |
+
+#### `price_tier` Values for Token Metrics
+
+Tiers are composed from up to three modifiers: a `thinking_` prefix, a `cached_` prefix, and a `_long_context` suffix. Not all combinations exist in GCP's SKU catalogue; only tiers with a matching SKU are emitted.
+
+**Simple tiers**
+
+| Value | Description |
+|-------|-------------|
+| `on_demand` | Standard real-time inference |
+| `batch` | Batch prediction |
+| `long_context` | Long-context window at standard priority |
+| `cached` | Context-cached input |
+| `cache_storage` | Context cache storage cost |
+| `thinking` | Extended thinking, standard priority |
+| `priority` | Priority tier |
+| `flex` | Flex tier |
+| `live` | Live (streaming) mode |
+
+**Compound tiers**
+
+| Value | Description |
+|-------|-------------|
+| `batch_long_context` | Batch + long context |
+| `priority_long_context` | Priority + long context |
+| `flex_long_context` | Flex + long context |
+| `cached_long_context` | Cached input + long context |
+| `cached_batch` | Cached input + batch |
+| `cached_flex` | Cached input + flex tier |
+| `cached_priority` | Cached input + priority tier |
+| `cached_batch_long_context` | Cached input + batch + long context |
+| `cached_flex_long_context` | Cached input + flex + long context |
+| `cached_priority_long_context` | Cached input + priority + long context |
+| `thinking_batch` | Thinking + batch |
+| `thinking_flex` | Thinking + flex tier |
+| `thinking_priority` | Thinking + priority tier |
+| `thinking_long_context` | Thinking + long context |
+| `thinking_batch_long_context` | Thinking + batch + long context |
+| `thinking_flex_long_context` | Thinking + flex + long context |
+| `thinking_priority_long_context` | Thinking + priority + long context |
+
+## Character Pricing
+
+| Metric | Labels | Description |
+|--------|--------|-------------|
+| `cloudcost_gcp_vertex_input_usd_per_1k_characters` | `model_id`, `family`, `region`, `price_tier` | Input cost in USD per 1k characters, for models billed by character (e.g. translation models). |
+| `cloudcost_gcp_vertex_output_usd_per_1k_characters` | `model_id`, `family`, `region`, `price_tier` | Output cost in USD per 1k characters, for models billed by character (e.g. translation models). |
+
+### Labels
+
+| Label | Values | Description |
+|-------|--------|-------------|
+| `model_id` | e.g. `translation-llm` | Model name, normalised to lowercase with spaces replaced by hyphens |
+| `family` | `google`, `unknown` | Model provider family; `unknown` for unrecognised model prefixes |
+| `region` | e.g. `global` | GCP region |
+| `price_tier` | `on_demand` | GCP Translation is flat-rate; no batch tier exists in the billing API |
+
+## Compute Pricing
+
+| Metric | Labels | Description |
+|--------|--------|-------------|
+| `cloudcost_gcp_vertex_instance_total_usd_per_hour` | `machine_type`, `use_case`, `region`, `price_tier` | Vertex AI custom training and prediction node cost in USD per hour |
+
+### Labels
+
+| Label | Values | Description |
+|-------|--------|-------------|
+| `machine_type` | e.g. `n1-standard-4` | Machine type used for the compute node |
+| `use_case` | `training`, `prediction` | Whether the node is used for custom training or online prediction |
+| `region` | e.g. `us-central1` | GCP region |
+| `price_tier` | `on_demand`, `spot` | Pricing tier; spot metrics are only emitted when a spot price exists |
+
+## Reranking
+
+| Metric | Labels | Description |
+|--------|--------|-------------|
+| `cloudcost_gcp_vertex_search_unit_usd_per_1k_search_units` | `model_id`, `family`, `region` | Vertex AI reranking cost in USD per 1k ranking requests |
+
+Reranking SKUs are fetched from the Cloud Discovery Engine billing service. If that service is unavailable at startup, reranking metrics are omitted and a warning is logged.
+
+### Labels
+
+| Label | Values | Description |
+|-------|--------|-------------|
+| `model_id` | e.g. `semantic-ranker-api` | Ranker model name, normalised to lowercase with spaces replaced by hyphens |
+| `family` | `google` | Model provider family; Discovery Engine reranking models are Google's |
+| `region` | e.g. `global` | GCP region |
+
+## Notes
+
+Pricing data is fetched from the GCP Billing API at startup and refreshed every 24 hours. SKU descriptions are matched using regular expressions; unknown SKUs are skipped. Verify SKU description patterns against the live Billing API when adding new models or machine types.

--- a/pkg/google/gcp.go
+++ b/pkg/google/gcp.go
@@ -18,6 +18,7 @@ import (
 	cloudcost_exporter "github.com/grafana/cloudcost-exporter"
 	"github.com/grafana/cloudcost-exporter/pkg/google/gcs"
 	"github.com/grafana/cloudcost-exporter/pkg/google/gke"
+	"github.com/grafana/cloudcost-exporter/pkg/google/vertex"
 	"github.com/grafana/cloudcost-exporter/pkg/google/vpc"
 	"github.com/grafana/cloudcost-exporter/pkg/provider"
 )
@@ -39,6 +40,7 @@ const (
 	serviceSQL          = "SQL"
 	serviceManagedKafka = "MANAGEDKAFKA"
 	serviceKafkaAlias   = "KAFKA"
+	serviceVertex       = "VERTEX"
 )
 
 // Services returns the collectors that can be enabled via -gcp.services.
@@ -52,6 +54,7 @@ func Services() []provider.ServiceInfo {
 		{Name: serviceManagedKafka, DisplayName: "Managed Kafka", Description: "Managed Service for Apache Kafka clusters", Aliases: []string{serviceKafkaAlias}},
 		{Name: serviceCLB, DisplayName: "CLB", Description: "Cloud Load Balancers via forwarding rules"},
 		{Name: serviceVPC, DisplayName: "VPC", Description: "Cloud NAT Gateway, VPN Gateway, Private Service Connect"},
+		{Name: serviceVertex, DisplayName: "Vertex AI", Description: "Vertex AI model token, character, compute, and reranking pricing"},
 	}
 }
 
@@ -203,6 +206,14 @@ func New(ctx context.Context, config *Config) (*GCP, error) {
 				Projects:       config.Projects,
 				ScrapeInterval: config.ScrapeInterval,
 			}, logger, gcpClient)
+			if err != nil {
+				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
+					slog.String("service", service),
+					slog.String("message", err.Error()))
+				continue
+			}
+		case serviceVertex:
+			collector, err = vertex.New(ctx, logger, gcpClient)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
 					slog.String("service", service),

--- a/pkg/google/gcp_test.go
+++ b/pkg/google/gcp_test.go
@@ -247,7 +247,7 @@ func TestServices(t *testing.T) {
 	got := Services()
 	wantNames := []string{
 		serviceGCS, serviceGKE, serviceCLB, serviceVPC,
-		serviceSQL, serviceManagedKafka,
+		serviceSQL, serviceManagedKafka, serviceVertex,
 	}
 	gotNames := make([]string, 0, len(got))
 	for _, s := range got {

--- a/pkg/google/vertex/pricing_map.go
+++ b/pkg/google/vertex/pricing_map.go
@@ -1,0 +1,385 @@
+package vertex
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+	"sync/atomic"
+
+	"cloud.google.com/go/billing/apiv1/billingpb"
+	"github.com/grafana/cloudcost-exporter/pkg/google/client"
+)
+
+const (
+	vertexAIServiceName = "Vertex AI"
+	// discoveryEngineServiceName is the GCP Billing API service name for Vertex AI Search,
+	// which hosts the Ranking API used for reranking.
+	discoveryEngineServiceName = "Vertex AI Search"
+
+	// modalityGroup matches only the text modality in Vertex AI SKU descriptions. Audio,
+	// image, and video inputs are multimodal inputs priced separately from text tokens and
+	// are not represented by these metrics. Matching all modalities would cause each
+	// modality's price to overwrite the previous one, leaving the emitted value
+	// non-deterministic.
+	modalityGroup = `(?:text)`
+)
+
+var (
+	// computeRegex matches custom training/prediction compute SKU descriptions.
+	// Example: "Custom Training n1-standard-4 running in us-central1"
+	// Example: "Spot Custom Prediction n1-highmem-8 running in europe-west1"
+	// NOTE: Exact SKU description strings must be verified against the live GCP Billing API.
+	computeRegex = regexp.MustCompile(`(?i)^(Spot\s+)?Custom\s+(Training|Prediction)\s+(\S+)\s+running\s+in`)
+	// rerankRegex matches Discovery Engine Ranking API SKU descriptions.
+	// Example: "Semantic Ranker API Ranking Requests"
+	// NOTE: Exact SKU description strings must be verified against the live GCP Billing API.
+	rerankRegex = regexp.MustCompile(`(?i)^(.+?)\s+[Rr]anking\s+[Rr]equests?$`)
+)
+
+// skuPattern maps a compiled regex to the billing direction, billing type, and price tier.
+type skuPattern struct {
+	re          *regexp.Regexp
+	direction   string // "input" or "output"
+	billingType string // "token" or "char"
+	tier        string
+}
+
+func mustCompile(pattern string) *regexp.Regexp {
+	return regexp.MustCompile(strings.ReplaceAll(pattern, "{mod}", modalityGroup))
+}
+
+// skuPatterns is the ordered lookup table for Vertex AI token/character SKU descriptions.
+// More specific patterns must appear before generic ones to prevent the lazy (.+?) from
+// capturing too much.
+var skuPatterns = []skuPattern{
+	// Gemini output — "Thinking" prefix style (most specific first)
+	{mustCompile(`(?i)^(.+?)\s+Thinking\s+` + modalityGroup + `\s+Output\s+Priority\s+\(Long\)\s+-\s+Predictions$`), "output", "token", "thinking_priority_long_context"},
+	{mustCompile(`(?i)^(.+?)\s+Thinking\s+` + modalityGroup + `\s+Output\s+Priority\s+-\s+Predictions$`), "output", "token", "thinking_priority"},
+	{mustCompile(`(?i)^(.+?)\s+Thinking\s+` + modalityGroup + `\s+Output\s+Flex\s+\(Long\)\s+-\s+Predictions$`), "output", "token", "thinking_flex_long_context"},
+	{mustCompile(`(?i)^(.+?)\s+Thinking\s+` + modalityGroup + `\s+Output\s+Flex\s+-\s+Predictions$`), "output", "token", "thinking_flex"},
+	{mustCompile(`(?i)^(.+?)\s+Thinking\s+` + modalityGroup + `\s+Output\s+\(Long\)\s+-\s+Batch\s+Predictions$`), "output", "token", "thinking_batch_long_context"},
+	{mustCompile(`(?i)^(.+?)\s+Thinking\s+` + modalityGroup + `\s+Output\s+-\s+Batch\s+Predictions$`), "output", "token", "thinking_batch"},
+	{mustCompile(`(?i)^(.+?)\s+Thinking\s+` + modalityGroup + `\s+Output\s+\(Long\)\s+-\s+Predictions$`), "output", "token", "thinking_long_context"},
+	{mustCompile(`(?i)^(.+?)\s+Thinking\s+` + modalityGroup + `\s+Output\s+-\s+Predictions$`), "output", "token", "thinking"},
+
+	// Gemini output — "(Thinking On...)" parenthetical style
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Output\s+Priority\s+\(Thinking\s+On\s+and\s+Long\)\s+-\s+Predictions$`), "output", "token", "thinking_priority_long_context"},
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Output\s+Priority\s+\(Thinking\s+On\)\s+-\s+Predictions$`), "output", "token", "thinking_priority"},
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Output\s+\(Thinking\s+On\s+and\s+Long\)\s+-\s+Batch\s+Predictions$`), "output", "token", "thinking_batch_long_context"},
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Output\s+\(Thinking\s+On\s+and\s+Long\)\s+-\s+Predictions$`), "output", "token", "thinking_long_context"},
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Output\s+\(Thinking\s+On\)\s+-\s+Batch\s+Predictions$`), "output", "token", "thinking_batch"},
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Output\s+\(Thinking\s+On\)\s+-\s+Predictions$`), "output", "token", "thinking"},
+
+	// Gemini output — Live (before generic)
+	{mustCompile(`(?i)^(.+?)\s+Live\s+` + modalityGroup + `\s+Output\s+-\s+Predictions$`), "output", "token", "live"},
+
+	// Gemini output — Priority / Flex (before generic)
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Output\s+Priority\s+\(Long\)\s+-\s+Predictions$`), "output", "token", "priority_long_context"},
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Output\s+Priority\s+-\s+Predictions$`), "output", "token", "priority"},
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Output\s+Flex\s+\(Long\)\s+-\s+Predictions$`), "output", "token", "flex_long_context"},
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Output\s+Flex\s+-\s+Predictions$`), "output", "token", "flex"},
+
+	// Gemini output — standard
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Output\s+\(Long\)\s+-\s+Batch\s+Predictions$`), "output", "token", "batch_long_context"},
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Output\s+Long\s+Context\s+-\s+Batch\s+Predictions$`), "output", "token", "batch_long_context"},
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Output\s+-\s+Batch\s+Predictions$`), "output", "token", "batch"},
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Output\s+\(Long\)\s+-\s+Predictions$`), "output", "token", "long_context"},
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Output\s+-\s+Predictions$`), "output", "token", "on_demand"},
+
+	// Gemini input — Live (before generic)
+	{mustCompile(`(?i)^(.+?)\s+Live\s+` + modalityGroup + `\s+Input\s+-\s+Predictions$`), "input", "token", "live"},
+
+	// Gemini input — 1.5 cached style (before generic)
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Cached\s+Input\s+\(Long\)\s+-\s+Predictions$`), "input", "token", "cached_long_context"},
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Cached\s+Input\s+-\s+Predictions$`), "input", "token", "cached"},
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Input\s+Cache\s+Storage\s+-\s+Predictions$`), "input", "token", "cache_storage"},
+
+	// Gemini input — Priority (before generic)
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Input\s+Priority\s+\(Long\)\s+-\s+Predictions$`), "input", "token", "priority_long_context"},
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Input\s+Priority\s+-\s+Predictions$`), "input", "token", "priority"},
+
+	// Gemini input — standard
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Input\s+\(Long\)\s+-\s+Batch\s+Predictions$`), "input", "token", "batch_long_context"},
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Input\s+Long\s+Context\s+-\s+Batch\s+Predictions$`), "input", "token", "batch_long_context"},
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Input\s+-\s+Batch\s+Predictions$`), "input", "token", "batch"},
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Input\s+\(Long\)\s+-\s+Predictions$`), "input", "token", "long_context"},
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Input\s+-\s+Predictions$`), "input", "token", "on_demand"},
+
+	// Gemini caching 2.0+ style ("Input" before modality) — more specific before less specific
+	{mustCompile(`(?i)^(.+?)\s+Input\s+` + modalityGroup + `\s+Caching\s+Storage$`), "input", "token", "cache_storage"},
+	{mustCompile(`(?i)^(.+?)\s+Input\s+` + modalityGroup + `\s+Caching\s+Batch\s+\(Long\)$`), "input", "token", "cached_batch_long_context"},
+	{mustCompile(`(?i)^(.+?)\s+Input\s+` + modalityGroup + `\s+Caching\s+Batch$`), "input", "token", "cached_batch"},
+	{mustCompile(`(?i)^(.+?)\s+Input\s+` + modalityGroup + `\s+Caching\s+Flex\s+\(Long\)$`), "input", "token", "cached_flex_long_context"},
+	{mustCompile(`(?i)^(.+?)\s+Input\s+` + modalityGroup + `\s+Caching\s+Flex$`), "input", "token", "cached_flex"},
+	{mustCompile(`(?i)^(.+?)\s+Input\s+` + modalityGroup + `\s+Caching\s+Priority\s+\(Long\)$`), "input", "token", "cached_priority_long_context"},
+	{mustCompile(`(?i)^(.+?)\s+Input\s+` + modalityGroup + `\s+Caching\s+Priority$`), "input", "token", "cached_priority"},
+	{mustCompile(`(?i)^(.+?)\s+Input\s+` + modalityGroup + `\s+Caching\s+\(Long\)$`), "input", "token", "cached_long_context"},
+	{mustCompile(`(?i)^(.+?)\s+Input\s+` + modalityGroup + `\s+Caching$`), "input", "token", "cached"},
+
+	// Gemini caching alternate style ("modality" before "Input Caching")
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Input\s+Caching\s+Storage$`), "input", "token", "cache_storage"},
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Input\s+Caching\s+Priority\s+\(Long\)$`), "input", "token", "cached_priority_long_context"},
+	{mustCompile(`(?i)^(.+?)\s+` + modalityGroup + `\s+Input\s+Caching\s+Priority$`), "input", "token", "cached_priority"},
+
+	// MaaS token format — specific before generic
+	{regexp.MustCompile(`(?i)^(.+?)\s+Batch\s+Input\s+Tokens?$`), "input", "token", "batch"},
+	{regexp.MustCompile(`(?i)^(.+?)\s+Batch\s+Output\s+Tokens?$`), "output", "token", "batch"},
+	{regexp.MustCompile(`(?i)^(.+?)\s+Cached(?:\s+Text)?\s+Input\s+Tokens?$`), "input", "token", "cached"},
+	{regexp.MustCompile(`(?i)^(.+?)\s+Input\s+Tokens?$`), "input", "token", "on_demand"},
+	{regexp.MustCompile(`(?i)^(.+?)\s+Output\s+Tokens?$`), "output", "token", "on_demand"},
+
+	// Character-billed models
+	{regexp.MustCompile(`(?i)^(.+?)\s+Input\s+Characters?$`), "input", "char", "on_demand"},
+	{regexp.MustCompile(`(?i)^(.+?)\s+Output\s+Characters?$`), "output", "char", "on_demand"},
+}
+
+// ComputePricing holds per-hour prices for a Vertex AI compute node.
+type ComputePricing struct {
+	OnDemandPerHour float64
+	SpotPerHour     float64
+}
+
+// Snapshot is an immutable view of the Vertex AI pricing data.
+type Snapshot struct {
+	// tokenInput[region][model][tier] = price per 1k input tokens (only set if a SKU exists)
+	tokenInput map[string]map[string]map[string]float64
+	// tokenOutput[region][model][tier] = price per 1k output tokens (only set if a SKU exists)
+	tokenOutput map[string]map[string]map[string]float64
+	// charInput[region][model][tier] = price per 1k input characters (only set if a SKU exists)
+	charInput map[string]map[string]map[string]float64
+	// charOutput[region][model][tier] = price per 1k output characters (only set if a SKU exists)
+	charOutput map[string]map[string]map[string]float64
+	// compute[region][machineType][useCase] = ComputePricing
+	compute map[string]map[string]map[string]*ComputePricing
+	// reranking[region][model] = price per 1k ranking requests (USD)
+	reranking map[string]map[string]float64
+}
+
+// PricingMap stores Vertex AI pricing and refreshes atomically.
+type PricingMap struct {
+	gcpClient client.Client
+	logger    *slog.Logger
+	current   atomic.Pointer[Snapshot]
+}
+
+// NewPricingMap initialises and populates a PricingMap.
+func NewPricingMap(ctx context.Context, logger *slog.Logger, gcpClient client.Client) (*PricingMap, error) {
+	pm := &PricingMap{gcpClient: gcpClient, logger: logger}
+	if err := pm.Populate(ctx); err != nil {
+		return nil, err
+	}
+	return pm, nil
+}
+
+// Snapshot returns an immutable copy of the current pricing data.
+func (pm *PricingMap) Snapshot() Snapshot {
+	if s := pm.current.Load(); s != nil {
+		return *s
+	}
+	return Snapshot{}
+}
+
+// Populate fetches the latest Vertex AI SKUs and updates the pricing map.
+// Discovery Engine SKUs (reranking) are fetched non-fatally; reranking metrics
+// are omitted if the service is unavailable.
+func (pm *PricingMap) Populate(ctx context.Context) error {
+	serviceName, err := pm.gcpClient.GetServiceName(ctx, vertexAIServiceName)
+	if err != nil {
+		return fmt.Errorf("failed to get Vertex AI service name: %w", err)
+	}
+	skus := pm.gcpClient.GetPricing(ctx, serviceName)
+	if len(skus) == 0 {
+		return fmt.Errorf("no SKUs found for Vertex AI service")
+	}
+
+	if deSvcName, err := pm.gcpClient.GetServiceName(ctx, discoveryEngineServiceName); err != nil {
+		pm.logger.Warn("failed to get Discovery Engine service name, reranking metrics will be unavailable", "error", err)
+	} else {
+		skus = append(skus, pm.gcpClient.GetPricing(ctx, deSvcName)...)
+	}
+
+	return pm.ParseSkus(skus)
+}
+
+// ParseSkus parses the provided SKUs and updates the pricing map atomically.
+// Unknown SKUs are logged at debug level and skipped.
+func (pm *PricingMap) ParseSkus(skus []*billingpb.Sku) error {
+	snap := &Snapshot{
+		tokenInput:  make(map[string]map[string]map[string]float64),
+		tokenOutput: make(map[string]map[string]map[string]float64),
+		charInput:   make(map[string]map[string]map[string]float64),
+		charOutput:  make(map[string]map[string]map[string]float64),
+		compute:     make(map[string]map[string]map[string]*ComputePricing),
+		reranking:   make(map[string]map[string]float64),
+	}
+
+	for _, sku := range skus {
+		if sku == nil {
+			continue
+		}
+		desc := strings.TrimSpace(sku.GetDescription())
+		regions := skuRegions(sku)
+
+		matched := false
+		for _, pat := range skuPatterns {
+			matches := pat.re.FindStringSubmatch(desc)
+			if len(matches) == 0 {
+				continue
+			}
+			model := normalizeModelName(matches[1])
+			price := normalizeToPerK(priceFromSku(sku), sku)
+			var target map[string]map[string]map[string]float64
+			switch {
+			case pat.direction == "input" && pat.billingType == "token":
+				target = snap.tokenInput
+			case pat.direction == "output" && pat.billingType == "token":
+				target = snap.tokenOutput
+			case pat.direction == "input" && pat.billingType == "char":
+				target = snap.charInput
+			default:
+				target = snap.charOutput
+			}
+			applyPrice(target, model, pat.tier, price, regions)
+			matched = true
+			break
+		}
+		if matched {
+			continue
+		}
+
+		if matches := computeRegex.FindStringSubmatch(desc); len(matches) > 0 {
+			isSpot := strings.TrimSpace(matches[1]) != ""
+			useCase := strings.ToLower(matches[2])
+			machineType := strings.ToLower(matches[3])
+			price := priceFromSku(sku)
+			for _, region := range regions {
+				if region == "" {
+					continue
+				}
+				if snap.compute[region] == nil {
+					snap.compute[region] = make(map[string]map[string]*ComputePricing)
+				}
+				if snap.compute[region][machineType] == nil {
+					snap.compute[region][machineType] = make(map[string]*ComputePricing)
+				}
+				if snap.compute[region][machineType][useCase] == nil {
+					snap.compute[region][machineType][useCase] = &ComputePricing{}
+				}
+				cp := snap.compute[region][machineType][useCase]
+				if isSpot {
+					cp.SpotPerHour = price
+				} else {
+					cp.OnDemandPerHour = price
+				}
+			}
+			continue
+		}
+
+		if matches := rerankRegex.FindStringSubmatch(desc); len(matches) > 0 {
+			model := normalizeModelName(matches[1])
+			price := normalizeToPerK(priceFromSku(sku), sku)
+			for _, region := range regions {
+				if region == "" {
+					continue
+				}
+				if snap.reranking[region] == nil {
+					snap.reranking[region] = make(map[string]float64)
+				}
+				snap.reranking[region][model] = price
+			}
+			continue
+		}
+
+		pm.logger.Debug("skipping unknown Vertex AI SKU", "description", desc)
+	}
+
+	pm.current.Store(snap)
+	return nil
+}
+
+// applyPrice writes a price into the target region/model/tier map for each region.
+// Only regions with a non-empty name are written.
+func applyPrice(target map[string]map[string]map[string]float64, model, tier string, price float64, regions []string) {
+	for _, region := range regions {
+		if region == "" {
+			continue
+		}
+		if target[region] == nil {
+			target[region] = make(map[string]map[string]float64)
+		}
+		if target[region][model] == nil {
+			target[region][model] = make(map[string]float64)
+		}
+		target[region][model][tier] = price
+	}
+}
+
+// priceFromSku extracts the unit price from the last tiered rate of a SKU.
+// Vertex AI SKUs today use flat pricing: the first tier is a $0 free allowance and the
+// last tier is the steady-state paid rate. Taking the last rate is correct for this structure.
+// If GCP introduces volume discounts on a SKU (descending price at higher tiers), the last
+// rate would be the discounted tier rather than the base rate. Re-evaluate this if such SKUs appear.
+func priceFromSku(sku *billingpb.Sku) float64 {
+	if sku == nil || len(sku.GetPricingInfo()) == 0 {
+		return 0
+	}
+	expression := sku.GetPricingInfo()[0].GetPricingExpression()
+	if expression == nil || len(expression.GetTieredRates()) == 0 {
+		return 0
+	}
+	rate := expression.GetTieredRates()[len(expression.GetTieredRates())-1].GetUnitPrice()
+	if rate == nil {
+		return 0
+	}
+	return float64(rate.GetUnits()) + float64(rate.GetNanos())/1e9
+}
+
+// normalizeToPerK scales the price to per-1k units.
+// GCP SKUs with a UsageUnit starting with "k" (e.g. "k{char}")
+// are already per-1k units. Otherwise the price is per-unit and is multiplied by 1000.
+func normalizeToPerK(price float64, sku *billingpb.Sku) float64 {
+	if sku == nil || len(sku.GetPricingInfo()) == 0 {
+		return price * 1000
+	}
+	expression := sku.GetPricingInfo()[0].GetPricingExpression()
+	if expression == nil {
+		return price * 1000
+	}
+	usageUnit := strings.ToLower(expression.GetUsageUnit())
+	if strings.HasPrefix(usageUnit, "k") {
+		return price
+	}
+	return price * 1000
+}
+
+// skuRegions returns the list of regions a SKU applies to.
+// Falls back to ["global"] for SKUs with no region information (e.g. Gemini token SKUs).
+func skuRegions(sku *billingpb.Sku) []string {
+	if sku == nil {
+		return nil
+	}
+	if len(sku.GetServiceRegions()) > 0 {
+		return sku.GetServiceRegions()
+	}
+	if geo := sku.GetGeoTaxonomy(); geo != nil && len(geo.GetRegions()) > 0 {
+		return geo.GetRegions()
+	}
+	return []string{"global"}
+}
+
+// modelGardenMaaSPrefix is the billing prefix GCP prepends to some Model Garden
+// Model-as-a-Service SKUs. It appears on one token direction (input or output) but
+// not the other, causing the same model to normalize to two different IDs.
+const modelGardenMaaSPrefix = "Cloud Vertex AI Model Garden Model as a Service "
+
+// normalizeModelName converts a model name from a SKU description to a canonical slug.
+// The Model Garden MaaS prefix is stripped first so that input and output SKUs for
+// the same model share the same ID.
+// Example: "1.5 Flash" → "1.5-flash"
+// Example: "Cloud Vertex AI Model Garden Model as a Service Llama 4 Maverick" → "llama-4-maverick"
+func normalizeModelName(raw string) string {
+	stripped := strings.TrimPrefix(raw, modelGardenMaaSPrefix)
+	return strings.ToLower(strings.ReplaceAll(strings.TrimSpace(stripped), " ", "-"))
+}

--- a/pkg/google/vertex/pricing_map_test.go
+++ b/pkg/google/vertex/pricing_map_test.go
@@ -1,0 +1,354 @@
+package vertex
+
+import (
+	"testing"
+
+	"cloud.google.com/go/billing/apiv1/billingpb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/type/money"
+)
+
+func TestParseSkus_TokenInputSKU(t *testing.T) {
+	pm := &PricingMap{logger: testLogger()}
+	err := pm.ParseSkus([]*billingpb.Sku{
+		newTokenSKU("Gemini 1.5 Flash Input tokens", "us-central1", "k{char}", 0, 1250000),
+	})
+	require.NoError(t, err)
+
+	snap := pm.Snapshot()
+	require.NotNil(t, snap.tokenInput["us-central1"])
+	assert.InDelta(t, 0.00125, snap.tokenInput["us-central1"]["gemini-1.5-flash"]["on_demand"], 1e-9)
+}
+
+func TestParseSkus_TokenOutputSKU(t *testing.T) {
+	pm := &PricingMap{logger: testLogger()}
+	err := pm.ParseSkus([]*billingpb.Sku{
+		newTokenSKU("Gemini 1.5 Flash Output tokens", "us-central1", "k{char}", 0, 5000000),
+	})
+	require.NoError(t, err)
+
+	snap := pm.Snapshot()
+	assert.InDelta(t, 0.005, snap.tokenOutput["us-central1"]["gemini-1.5-flash"]["on_demand"], 1e-9)
+}
+
+func TestParseSkus_TokenSKUNormalizesPerUnitPrice(t *testing.T) {
+	// A SKU with no "k" prefix in UsageUnit should be multiplied by 1000.
+	pm := &PricingMap{logger: testLogger()}
+	err := pm.ParseSkus([]*billingpb.Sku{
+		newTokenSKU("Gemini 1.0 Pro Input tokens", "us-central1", "char", 0, 1250),
+	})
+	require.NoError(t, err)
+
+	snap := pm.Snapshot()
+	assert.InDelta(t, 0.00125, snap.tokenInput["us-central1"]["gemini-1.0-pro"]["on_demand"], 1e-9)
+}
+
+func TestParseSkus_ComputeOnDemand(t *testing.T) {
+	pm := &PricingMap{logger: testLogger()}
+	err := pm.ParseSkus([]*billingpb.Sku{
+		newComputeSKU("Custom Training n1-standard-4 running in us-central1", "us-central1", 0, 500000000),
+	})
+	require.NoError(t, err)
+
+	snap := pm.Snapshot()
+	require.NotNil(t, snap.compute["us-central1"])
+	require.NotNil(t, snap.compute["us-central1"]["n1-standard-4"])
+	require.NotNil(t, snap.compute["us-central1"]["n1-standard-4"]["training"])
+	assert.InDelta(t, 0.5, snap.compute["us-central1"]["n1-standard-4"]["training"].OnDemandPerHour, 1e-9)
+	assert.Equal(t, 0.0, snap.compute["us-central1"]["n1-standard-4"]["training"].SpotPerHour)
+}
+
+func TestParseSkus_ComputeSpot(t *testing.T) {
+	pm := &PricingMap{logger: testLogger()}
+	err := pm.ParseSkus([]*billingpb.Sku{
+		newComputeSKU("Spot Custom Prediction n1-highmem-8 running in europe-west1", "europe-west1", 0, 150000000),
+	})
+	require.NoError(t, err)
+
+	snap := pm.Snapshot()
+	require.NotNil(t, snap.compute["europe-west1"]["n1-highmem-8"]["prediction"])
+	assert.InDelta(t, 0.15, snap.compute["europe-west1"]["n1-highmem-8"]["prediction"].SpotPerHour, 1e-9)
+	assert.Equal(t, 0.0, snap.compute["europe-west1"]["n1-highmem-8"]["prediction"].OnDemandPerHour)
+}
+
+func TestParseSkus_CharacterSKUsRoutedSeparately(t *testing.T) {
+	// Character-priced models must land in snap.characters, not snap.tokens.
+	pm := &PricingMap{logger: testLogger()}
+	err := pm.ParseSkus([]*billingpb.Sku{
+		newTokenSKU("Translation LLM Input Characters", "global", "count", 0, 50000),
+		newTokenSKU("Translation LLM Output Characters", "global", "count", 0, 150000),
+		newTokenSKU("Llama 4 Scout Input Tokens", "global", "count", 0, 170000),
+	})
+	require.NoError(t, err)
+
+	snap := pm.Snapshot()
+
+	// Character-priced SKUs go to char maps.
+	assert.InDelta(t, 0.05, snap.charInput["global"]["translation-llm"]["on_demand"], 1e-9)
+	assert.InDelta(t, 0.15, snap.charOutput["global"]["translation-llm"]["on_demand"], 1e-9)
+
+	// Token-priced SKUs still go to token maps.
+	assert.InDelta(t, 0.17, snap.tokenInput["global"]["llama-4-scout"]["on_demand"], 1e-9)
+
+	// Character-priced model must not appear in token maps.
+	assert.Zero(t, snap.tokenInput["global"]["translation-llm"])
+	assert.Zero(t, snap.tokenOutput["global"]["translation-llm"])
+}
+
+func TestParseSkus_RerankingSKU(t *testing.T) {
+	pm := &PricingMap{logger: testLogger()}
+	err := pm.ParseSkus([]*billingpb.Sku{
+		// usageUnit "k{request}" is already per-1k, price passes through unchanged.
+		newTokenSKU("Semantic Ranker API Ranking Requests", "global", "k{request}", 0, 1000000),
+	})
+	require.NoError(t, err)
+
+	snap := pm.Snapshot()
+	require.NotNil(t, snap.reranking["global"])
+	assert.InDelta(t, 0.001, snap.reranking["global"]["semantic-ranker-api"], 1e-9)
+}
+
+func TestParseSkus_ModelGardenMaaSPrefixStripped(t *testing.T) {
+	// GCP sometimes prefixes Model Garden MaaS output SKUs with a long billing path
+	// while the input SKU uses the short name. Both should normalize to the same model ID.
+	pm := &PricingMap{logger: testLogger()}
+	err := pm.ParseSkus([]*billingpb.Sku{
+		newTokenSKU("Llama 4 Maverick Input tokens", "global", "k{char}", 0, 350000),
+		newTokenSKU("Cloud Vertex AI Model Garden Model as a Service Llama 4 Maverick Output tokens", "global", "k{char}", 0, 1150000),
+	})
+	require.NoError(t, err)
+
+	snap := pm.Snapshot()
+	assert.InDelta(t, 0.00035, snap.tokenInput["global"]["llama-4-maverick"]["on_demand"], 1e-9)
+	assert.InDelta(t, 0.00115, snap.tokenOutput["global"]["llama-4-maverick"]["on_demand"], 1e-9)
+	// The long-prefix key must not exist as a separate entry.
+	assert.Zero(t, snap.tokenInput["global"]["cloud-vertex-ai-model-garden-model-as-a-service-llama-4-maverick"])
+}
+
+func TestParseSkus_UnknownSKUsIgnored(t *testing.T) {
+	pm := &PricingMap{logger: testLogger()}
+	err := pm.ParseSkus([]*billingpb.Sku{
+		newComputeSKU("Some Unknown Vertex AI SKU", "us-central1", 0, 100000000),
+		newTokenSKU("Gemini 1.5 Flash Input tokens", "us-central1", "k{char}", 0, 1250000),
+	})
+	require.NoError(t, err)
+
+	snap := pm.Snapshot()
+	assert.Len(t, snap.tokenInput["us-central1"], 1)
+	assert.Empty(t, snap.compute)
+}
+
+func TestParseSkus_NilSKUIgnored(t *testing.T) {
+	pm := &PricingMap{logger: testLogger()}
+	err := pm.ParseSkus([]*billingpb.Sku{nil})
+	require.NoError(t, err)
+}
+
+func TestParseSkus_GlobalFallbackForTokenSKUWithNoRegion(t *testing.T) {
+	// Gemini token SKUs have no ServiceRegions or GeoTaxonomy; they should be
+	// emitted under region="global".
+	sku := &billingpb.Sku{
+		Description: "Gemini 1.5 Flash Input tokens",
+		PricingInfo: []*billingpb.PricingInfo{
+			{
+				PricingExpression: &billingpb.PricingExpression{
+					UsageUnit: "k{char}",
+					TieredRates: []*billingpb.PricingExpression_TierRate{
+						{UnitPrice: &money.Money{Nanos: 1250000}},
+					},
+				},
+			},
+		},
+	}
+
+	pm := &PricingMap{logger: testLogger()}
+	err := pm.ParseSkus([]*billingpb.Sku{sku})
+	require.NoError(t, err)
+
+	snap := pm.Snapshot()
+	require.NotNil(t, snap.tokenInput["global"])
+	assert.InDelta(t, 0.00125, snap.tokenInput["global"]["gemini-1.5-flash"]["on_demand"], 1e-9)
+}
+
+func TestParseSkus_MultipleRegions(t *testing.T) {
+	sku := &billingpb.Sku{
+		Description:    "Gemini 1.5 Pro Input tokens",
+		ServiceRegions: []string{"us-central1", "europe-west1"},
+		PricingInfo: []*billingpb.PricingInfo{
+			{
+				PricingExpression: &billingpb.PricingExpression{
+					UsageUnit: "k{char}",
+					TieredRates: []*billingpb.PricingExpression_TierRate{
+						{UnitPrice: &money.Money{Nanos: 1250000}},
+					},
+				},
+			},
+		},
+	}
+
+	pm := &PricingMap{logger: testLogger()}
+	err := pm.ParseSkus([]*billingpb.Sku{sku})
+	require.NoError(t, err)
+
+	snap := pm.Snapshot()
+	assert.NotZero(t, snap.tokenInput["us-central1"]["gemini-1.5-pro"]["on_demand"])
+	assert.NotZero(t, snap.tokenInput["europe-west1"]["gemini-1.5-pro"]["on_demand"])
+}
+
+func TestParseSkus_GeminiBatchInputSKU(t *testing.T) {
+	pm := &PricingMap{logger: testLogger()}
+	err := pm.ParseSkus([]*billingpb.Sku{
+		newTokenSKU("Gemini 2.5 Flash Text Input - Batch Predictions", "us-central1", "k{char}", 0, 75000),
+	})
+	require.NoError(t, err)
+
+	snap := pm.Snapshot()
+	assert.InDelta(t, 0.000075, snap.tokenInput["us-central1"]["gemini-2.5-flash"]["batch"], 1e-9)
+}
+
+func TestParseSkus_GeminiOnDemandInputSKU(t *testing.T) {
+	pm := &PricingMap{logger: testLogger()}
+	err := pm.ParseSkus([]*billingpb.Sku{
+		newTokenSKU("Gemini 2.5 Flash Text Input - Predictions", "us-central1", "k{char}", 0, 150000),
+	})
+	require.NoError(t, err)
+
+	snap := pm.Snapshot()
+	assert.NotZero(t, snap.tokenInput["us-central1"]["gemini-2.5-flash"]["on_demand"])
+}
+
+func TestParseSkus_GeminiThinkingOutputSKU(t *testing.T) {
+	pm := &PricingMap{logger: testLogger()}
+	err := pm.ParseSkus([]*billingpb.Sku{
+		newTokenSKU("Gemini 2.5 Flash Thinking Text Output - Predictions", "global", "k{char}", 0, 350000),
+	})
+	require.NoError(t, err)
+
+	snap := pm.Snapshot()
+	assert.NotZero(t, snap.tokenOutput["global"]["gemini-2.5-flash"]["thinking"])
+}
+
+func TestParseSkus_GeminiCachedInputSKU(t *testing.T) {
+	pm := &PricingMap{logger: testLogger()}
+	err := pm.ParseSkus([]*billingpb.Sku{
+		newTokenSKU("Gemini 2.0 Flash Input Text Caching", "global", "k{char}", 0, 25000),
+	})
+	require.NoError(t, err)
+
+	snap := pm.Snapshot()
+	assert.NotZero(t, snap.tokenInput["global"]["gemini-2.0-flash"]["cached"])
+}
+
+func TestParseSkus_GeminiLiveInputSKU(t *testing.T) {
+	pm := &PricingMap{logger: testLogger()}
+	err := pm.ParseSkus([]*billingpb.Sku{
+		newTokenSKU("Gemini 2.5 Flash Live Text Input - Predictions", "global", "k{char}", 0, 100000),
+	})
+	require.NoError(t, err)
+
+	snap := pm.Snapshot()
+	assert.NotZero(t, snap.tokenInput["global"]["gemini-2.5-flash"]["live"])
+}
+
+func TestParseSkus_MaaSBatchSKU(t *testing.T) {
+	pm := &PricingMap{logger: testLogger()}
+	err := pm.ParseSkus([]*billingpb.Sku{
+		newTokenSKU("Cloud Vertex AI Model Garden Model as a Service Llama 4 Maverick Batch Input Token", "global", "k{char}", 0, 200000),
+	})
+	require.NoError(t, err)
+
+	snap := pm.Snapshot()
+	assert.NotZero(t, snap.tokenInput["global"]["llama-4-maverick"]["batch"])
+}
+
+func TestParseSkus_MaaSCachedSKU(t *testing.T) {
+	pm := &PricingMap{logger: testLogger()}
+	err := pm.ParseSkus([]*billingpb.Sku{
+		newTokenSKU("Cloud Vertex AI Model Garden Model as a Service DeepSeek-V3.1 Cached Text Input Token", "global", "k{char}", 0, 100000),
+	})
+	require.NoError(t, err)
+
+	snap := pm.Snapshot()
+	assert.NotZero(t, snap.tokenInput["global"]["deepseek-v3.1"]["cached"])
+}
+
+func TestParseSkus_MaaSOnDemandSKU(t *testing.T) {
+	pm := &PricingMap{logger: testLogger()}
+	err := pm.ParseSkus([]*billingpb.Sku{
+		newTokenSKU("Cloud Vertex AI Model Garden Model as a Service Llama 4 Scout Input Tokens", "global", "k{char}", 0, 170000),
+	})
+	require.NoError(t, err)
+
+	snap := pm.Snapshot()
+	assert.NotZero(t, snap.tokenInput["global"]["llama-4-scout"]["on_demand"])
+}
+
+func TestRegexPatterns(t *testing.T) {
+	t.Run("computeRegex", func(t *testing.T) {
+		cases := []struct {
+			input string
+			match bool
+		}{
+			{"Custom Training n1-standard-4 running in us-central1", true},
+			{"Spot Custom Prediction n1-highmem-8 running in europe-west1", true},
+			{"Custom Prediction n2-standard-8 running in asia-east1", true},
+			{"SPOT CUSTOM TRAINING n1-standard-4 RUNNING IN us-central1", true},         // case insensitive
+			{"Custom n1-standard-4 running in us-central1", false},                      // missing Training/Prediction
+			{"Preemptible Custom Training n1-standard-4 running in us-central1", false}, // wrong preemptible prefix
+			{"Gemini 1.5 Flash Input tokens", false},
+		}
+		for _, tc := range cases {
+			assert.Equal(t, tc.match, computeRegex.MatchString(tc.input), "input: %q", tc.input)
+		}
+	})
+
+	t.Run("rerankRegex", func(t *testing.T) {
+		cases := []struct {
+			input string
+			match bool
+		}{
+			{"Semantic Ranker API Ranking Requests", true},
+			{"Semantic Ranker API Ranking Request", true}, // singular
+			{"Some Model Ranking requests", true},         // case insensitive
+			{"Gemini 1.5 Flash Input tokens", false},
+			{"Ranking Requests", false}, // no model prefix
+		}
+		for _, tc := range cases {
+			assert.Equal(t, tc.match, rerankRegex.MatchString(tc.input), "input: %q", tc.input)
+		}
+	})
+}
+
+func newTokenSKU(description, region, usageUnit string, units int64, nanos int32) *billingpb.Sku {
+	return &billingpb.Sku{
+		Description:    description,
+		ServiceRegions: []string{region},
+		PricingInfo: []*billingpb.PricingInfo{
+			{
+				PricingExpression: &billingpb.PricingExpression{
+					UsageUnit: usageUnit,
+					TieredRates: []*billingpb.PricingExpression_TierRate{
+						{UnitPrice: &money.Money{Units: units, Nanos: nanos}},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newComputeSKU(description, region string, units int64, nanos int32) *billingpb.Sku {
+	return &billingpb.Sku{
+		Description:    description,
+		ServiceRegions: []string{region},
+		PricingInfo: []*billingpb.PricingInfo{
+			{
+				PricingExpression: &billingpb.PricingExpression{
+					TieredRates: []*billingpb.PricingExpression_TierRate{
+						{UnitPrice: &money.Money{Units: units, Nanos: nanos}},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/google/vertex/vertex.go
+++ b/pkg/google/vertex/vertex.go
@@ -1,0 +1,228 @@
+package vertex
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	cloudcostexporter "github.com/grafana/cloudcost-exporter"
+	"github.com/grafana/cloudcost-exporter/pkg/google/client"
+	"github.com/grafana/cloudcost-exporter/pkg/provider"
+	"github.com/grafana/cloudcost-exporter/pkg/utils"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	subsystem            = "gcp_vertex"
+	PriceRefreshInterval = 24 * time.Hour
+)
+
+var (
+	vertexTokenInputDesc = utils.GenerateDesc(
+		cloudcostexporter.MetricPrefix, subsystem, utils.InputTokenCostSuffix,
+		"Vertex AI input cost in USD per 1k tokens, for models billed by token. Character-billed models use the character metric.",
+		[]string{"model_id", "family", "region", "price_tier"},
+	)
+	vertexTokenOutputDesc = utils.GenerateDesc(
+		cloudcostexporter.MetricPrefix, subsystem, utils.OutputTokenCostSuffix,
+		"Vertex AI output cost in USD per 1k tokens, for models billed by token. Character-billed models use the character metric.",
+		[]string{"model_id", "family", "region", "price_tier"},
+	)
+	vertexCharacterInputDesc = utils.GenerateDesc(
+		cloudcostexporter.MetricPrefix, subsystem, utils.CharacterInputCostSuffix,
+		"Vertex AI input character cost in USD per 1k characters (models billed per character, e.g. translation models).",
+		[]string{"model_id", "family", "region", "price_tier"},
+	)
+	vertexCharacterOutputDesc = utils.GenerateDesc(
+		cloudcostexporter.MetricPrefix, subsystem, utils.CharacterOutputCostSuffix,
+		"Vertex AI output character cost in USD per 1k characters (models billed per character, e.g. translation models).",
+		[]string{"model_id", "family", "region", "price_tier"},
+	)
+	vertexComputeCostDesc = utils.GenerateDesc(
+		cloudcostexporter.MetricPrefix, subsystem, utils.InstanceTotalCostSuffix,
+		"Vertex AI custom training and online prediction node cost in USD per hour.",
+		[]string{"machine_type", "use_case", "region", "price_tier"},
+	)
+	vertexRerankCostDesc = utils.GenerateDesc(
+		cloudcostexporter.MetricPrefix, subsystem, utils.SearchUnitCostSuffix,
+		"Vertex AI reranking cost in USD per 1k ranking requests.",
+		[]string{"model_id", "family", "region"},
+	)
+)
+
+// Collector collects Vertex AI pricing metrics.
+type Collector struct {
+	pricingMap *PricingMap
+	logger     *slog.Logger
+}
+
+// New creates and initialises a Vertex AI Collector.
+// Pricing is fetched at construction time; an error means the collector cannot be used.
+func New(ctx context.Context, logger *slog.Logger, gcpClient client.Client) (*Collector, error) {
+	logger = logger.With("collector", subsystem)
+
+	pm, err := NewPricingMap(ctx, logger, gcpClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize pricing map: %w", err)
+	}
+
+	go func() {
+		ticker := time.NewTicker(PriceRefreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := pm.Populate(ctx); err != nil {
+					logger.Error("failed to refresh vertex pricing", "error", err)
+				}
+			}
+		}
+	}()
+
+	return &Collector{
+		pricingMap: pm,
+		logger:     logger,
+	}, nil
+}
+
+// Register implements provider.Collector.
+func (c *Collector) Register(_ provider.Registry) error {
+	return nil
+}
+
+// Describe implements provider.Collector.
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
+	ch <- vertexTokenInputDesc
+	ch <- vertexTokenOutputDesc
+	ch <- vertexCharacterInputDesc
+	ch <- vertexCharacterOutputDesc
+	ch <- vertexComputeCostDesc
+	ch <- vertexRerankCostDesc
+	return nil
+}
+
+// Name implements provider.Collector.
+func (c *Collector) Name() string {
+	return subsystem
+}
+
+// Collect emits Vertex AI pricing metrics.
+func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	snapshot := c.pricingMap.Snapshot()
+	for region, models := range snapshot.tokenInput {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		for model, tiers := range models {
+			for tier, price := range tiers {
+				ch <- prometheus.MustNewConstMetric(vertexTokenInputDesc, prometheus.GaugeValue,
+					price, model, familyFromModelID(model), region, tier)
+			}
+		}
+	}
+	for region, models := range snapshot.tokenOutput {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		for model, tiers := range models {
+			for tier, price := range tiers {
+				ch <- prometheus.MustNewConstMetric(vertexTokenOutputDesc, prometheus.GaugeValue,
+					price, model, familyFromModelID(model), region, tier)
+			}
+		}
+	}
+	for region, models := range snapshot.charInput {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		for model, tiers := range models {
+			for tier, price := range tiers {
+				ch <- prometheus.MustNewConstMetric(vertexCharacterInputDesc, prometheus.GaugeValue,
+					price, model, familyFromModelID(model), region, tier)
+			}
+		}
+	}
+	for region, models := range snapshot.charOutput {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		for model, tiers := range models {
+			for tier, price := range tiers {
+				ch <- prometheus.MustNewConstMetric(vertexCharacterOutputDesc, prometheus.GaugeValue,
+					price, model, familyFromModelID(model), region, tier)
+			}
+		}
+	}
+	for region, machines := range snapshot.compute {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		for machineType, useCases := range machines {
+			for useCase, pricing := range useCases {
+				if pricing.OnDemandPerHour > 0 {
+					ch <- prometheus.MustNewConstMetric(vertexComputeCostDesc, prometheus.GaugeValue,
+						pricing.OnDemandPerHour, machineType, useCase, region, "on_demand")
+				}
+				if pricing.SpotPerHour > 0 {
+					ch <- prometheus.MustNewConstMetric(vertexComputeCostDesc, prometheus.GaugeValue,
+						pricing.SpotPerHour, machineType, useCase, region, "spot")
+				}
+			}
+		}
+	}
+	for region, models := range snapshot.reranking {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		for model, price := range models {
+			ch <- prometheus.MustNewConstMetric(vertexRerankCostDesc, prometheus.GaugeValue,
+				price, model, familyFromModelID(model), region)
+		}
+	}
+	return nil
+}
+
+// familyFromModelID derives the model provider family from a normalised model ID.
+// Gemini, Gemma, and Discovery Engine reranking models are Google's. Model Garden
+// 3rd-party models embed the model name inside a long prefix, so Contains is used
+// throughout. Unknown prefixes return "unknown" rather than assuming a provider.
+func familyFromModelID(model string) string {
+	switch {
+	case strings.HasPrefix(model, "gemini"):
+		return "google"
+	case strings.Contains(model, "gemma"):
+		return "google" // Gemma is Google DeepMind's open model family
+	case strings.HasPrefix(model, "semantic"):
+		return "google" // Discovery Engine reranking is a Google service
+	case strings.Contains(model, "translation"):
+		return "google" // Cloud Translation models are a Google service
+	case strings.Contains(model, "deepseek"):
+		return "deepseek"
+	case strings.Contains(model, "llama"):
+		return "meta"
+	case strings.Contains(model, "qwen"):
+		return "alibaba"
+	case strings.Contains(model, "minimax"):
+		return "minimax"
+	case strings.Contains(model, "kimi"):
+		return "moonshot"
+	default:
+		return "unknown"
+	}
+}

--- a/pkg/google/vertex/vertex_test.go
+++ b/pkg/google/vertex/vertex_test.go
@@ -1,0 +1,342 @@
+package vertex
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+
+	"cloud.google.com/go/billing/apiv1/billingpb"
+	managedkafkapb "cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
+	"github.com/grafana/cloudcost-exporter/pkg/google/client"
+	gcmetrics "github.com/grafana/cloudcost-exporter/pkg/google/metrics"
+	"github.com/grafana/cloudcost-exporter/pkg/utils"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/compute/v1"
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
+)
+
+func TestNew_FailsIfPricingInitFails(t *testing.T) {
+	_, err := New(t.Context(), testLogger(),
+		&stubVertexClient{serviceNameErr: fmt.Errorf("billing API down")})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to initialize pricing map")
+}
+
+func TestNew_FailsIfNoPricingDataReturned(t *testing.T) {
+	_, err := New(t.Context(), testLogger(),
+		&stubVertexClient{serviceName: "services/vertex-ai", skus: nil})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to initialize pricing map")
+}
+
+func TestCollect_EmitsTokenMetrics(t *testing.T) {
+	c, err := New(t.Context(), testLogger(),
+		&stubVertexClient{
+			serviceName: "services/vertex-ai",
+			skus: []*billingpb.Sku{
+				newTokenSKU("Gemini 1.5 Flash Input tokens", "us-central1", "k{char}", 0, 1250000),
+				newTokenSKU("Gemini 1.5 Flash Output tokens", "us-central1", "k{char}", 0, 5000000),
+			},
+		})
+	require.NoError(t, err)
+
+	results, err := collectVertexMetrics(t, c)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	inputMetric := metricByName(results, "cloudcost_gcp_vertex_input_usd_per_1k_tokens")
+	require.NotNil(t, inputMetric)
+	assert.Equal(t, "gemini-1.5-flash", inputMetric.Labels["model_id"])
+	assert.Equal(t, "google", inputMetric.Labels["family"])
+	assert.Equal(t, "us-central1", inputMetric.Labels["region"])
+	assert.Equal(t, "on_demand", inputMetric.Labels["price_tier"])
+	assert.InDelta(t, 0.00125, inputMetric.Value, 1e-9)
+
+	outputMetric := metricByName(results, "cloudcost_gcp_vertex_output_usd_per_1k_tokens")
+	require.NotNil(t, outputMetric)
+	assert.Equal(t, "gemini-1.5-flash", outputMetric.Labels["model_id"])
+	assert.Equal(t, "google", outputMetric.Labels["family"])
+	assert.Equal(t, "us-central1", outputMetric.Labels["region"])
+	assert.Equal(t, "on_demand", outputMetric.Labels["price_tier"])
+	assert.InDelta(t, 0.005, outputMetric.Value, 1e-9)
+}
+
+func TestCollect_EmitsCharacterMetrics(t *testing.T) {
+	c, err := New(t.Context(), testLogger(),
+		&stubVertexClient{
+			serviceName: "services/vertex-ai",
+			skus: []*billingpb.Sku{
+				newTokenSKU("Translation LLM Input Characters", "global", "count", 0, 50000),
+				newTokenSKU("Translation LLM Output Characters", "global", "count", 0, 150000),
+			},
+		})
+	require.NoError(t, err)
+
+	results, err := collectVertexMetrics(t, c)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	inputMetric := metricByName(results, "cloudcost_gcp_vertex_input_usd_per_1k_characters")
+	require.NotNil(t, inputMetric)
+	assert.Equal(t, "translation-llm", inputMetric.Labels["model_id"])
+	assert.Equal(t, "google", inputMetric.Labels["family"])
+	assert.Equal(t, "global", inputMetric.Labels["region"])
+	assert.Equal(t, "on_demand", inputMetric.Labels["price_tier"])
+	assert.InDelta(t, 0.05, inputMetric.Value, 1e-9)
+
+	outputMetric := metricByName(results, "cloudcost_gcp_vertex_output_usd_per_1k_characters")
+	require.NotNil(t, outputMetric)
+	assert.Equal(t, "translation-llm", outputMetric.Labels["model_id"])
+	assert.Equal(t, "google", outputMetric.Labels["family"])
+	assert.Equal(t, "global", outputMetric.Labels["region"])
+	assert.Equal(t, "on_demand", outputMetric.Labels["price_tier"])
+	assert.InDelta(t, 0.15, outputMetric.Value, 1e-9)
+}
+
+func TestFamilyFromModelID(t *testing.T) {
+	cases := []struct {
+		model  string
+		family string
+	}{
+		{"gemini-1.5-flash", "google"},
+		{"gemini-embedding-001", "google"},
+		{"gemma-4", "google"},
+		{"cloud-vertex-ai-model-garden-model-as-a-service-gemma-4", "google"},
+		{"semantic-ranker-api", "google"},
+		{"cloud-vertex-ai-model-garden-model-as-a-service-deepseek-r1-0528", "deepseek"},
+		{"cloud-vertex-ai-model-garden-model-as-a-service-llama-4-maverick", "meta"},
+		{"llama-4-maverick", "meta"},
+		{"cloud-vertex-ai-model-garden-model-as-a-service-qwen3-235b-a22b-instruct-2507", "alibaba"},
+		{"cloud-vertex-ai-model-garden-model-as-a-service-glm-5", "unknown"},
+		{"cloud-vertex-ai-model-garden-model-as-a-service-minimax-m2", "minimax"},
+		{"cloud-vertex-ai-model-garden-model-as-a-service-kimi-k2-thinking", "moonshot"},
+		{"adaptive-machine-translation", "google"},
+		{"translation-llm", "google"},
+		{"mistral-large", "unknown"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.model, func(t *testing.T) {
+			assert.Equal(t, tc.family, familyFromModelID(tc.model))
+		})
+	}
+}
+
+func TestCollect_EmitsComputeMetrics(t *testing.T) {
+	c, err := New(t.Context(), testLogger(),
+		&stubVertexClient{
+			serviceName: "services/vertex-ai",
+			skus: []*billingpb.Sku{
+				newComputeSKU("Custom Training n1-standard-4 running in us-central1", "us-central1", 0, 500000000),
+				newComputeSKU("Spot Custom Training n1-standard-4 running in us-central1", "us-central1", 0, 150000000),
+			},
+		})
+	require.NoError(t, err)
+
+	results, err := collectVertexMetrics(t, c)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	onDemand := metricByLabel(results, "cloudcost_gcp_vertex_instance_total_usd_per_hour", "price_tier", "on_demand")
+	require.NotNil(t, onDemand)
+	assert.Equal(t, "n1-standard-4", onDemand.Labels["machine_type"])
+	assert.Equal(t, "training", onDemand.Labels["use_case"])
+	assert.Equal(t, "us-central1", onDemand.Labels["region"])
+	assert.InDelta(t, 0.5, onDemand.Value, 1e-9)
+
+	spot := metricByLabel(results, "cloudcost_gcp_vertex_instance_total_usd_per_hour", "price_tier", "spot")
+	require.NotNil(t, spot)
+	assert.InDelta(t, 0.15, spot.Value, 1e-9)
+}
+
+func TestCollect_OmitsOnDemandComputeMetricWhenPriceIsZero(t *testing.T) {
+	c, err := New(t.Context(), testLogger(),
+		&stubVertexClient{
+			serviceName: "services/vertex-ai",
+			skus: []*billingpb.Sku{
+				newComputeSKU("Spot Custom Training n1-standard-4 running in us-central1", "us-central1", 0, 150000000),
+			},
+		})
+	require.NoError(t, err)
+
+	results, err := collectVertexMetrics(t, c)
+	require.NoError(t, err)
+
+	assert.Nil(t, metricByLabel(results, "cloudcost_gcp_vertex_instance_total_usd_per_hour", "price_tier", "on_demand"))
+	assert.NotNil(t, metricByLabel(results, "cloudcost_gcp_vertex_instance_total_usd_per_hour", "price_tier", "spot"))
+}
+
+func TestCollect_EmitsRerankingMetrics(t *testing.T) {
+	c, err := New(t.Context(), testLogger(),
+		&stubVertexClient{
+			serviceName: "services/vertex-ai",
+			skus: []*billingpb.Sku{
+				newTokenSKU("Gemini 1.5 Flash Input tokens", "us-central1", "k{char}", 0, 1250000),
+			},
+			deSkus: []*billingpb.Sku{
+				newTokenSKU("Semantic Ranker API Ranking Requests", "global", "k{request}", 0, 1000000),
+			},
+		})
+	require.NoError(t, err)
+
+	results, err := collectVertexMetrics(t, c)
+	require.NoError(t, err)
+
+	rerank := metricByName(results, "cloudcost_gcp_vertex_search_unit_usd_per_1k_search_units")
+	require.NotNil(t, rerank)
+	assert.Equal(t, "semantic-ranker-api", rerank.Labels["model_id"])
+	assert.Equal(t, "google", rerank.Labels["family"]) // "semantic" prefix maps to google
+	assert.Equal(t, "global", rerank.Labels["region"])
+	assert.InDelta(t, 0.001, rerank.Value, 1e-9)
+}
+
+func TestCollect_DiscoveryEngineUnavailable_RerankingOmitted(t *testing.T) {
+	c, err := New(t.Context(), testLogger(),
+		&stubVertexClient{
+			serviceName:      "services/vertex-ai",
+			deServiceNameErr: fmt.Errorf("Discovery Engine Ranking API not found; check that Vertex AI Search is enabled in the GCP project"),
+			skus: []*billingpb.Sku{
+				newTokenSKU("Gemini 1.5 Flash Input tokens", "us-central1", "k{char}", 0, 1250000),
+			},
+		})
+	require.NoError(t, err)
+
+	results, err := collectVertexMetrics(t, c)
+	require.NoError(t, err)
+
+	assert.Nil(t, metricByName(results, "cloudcost_gcp_vertex_search_unit_usd_per_1k_search_units"))
+	assert.NotNil(t, metricByName(results, "cloudcost_gcp_vertex_input_usd_per_1k_tokens"))
+}
+
+func TestCollect_ContextCancellation(t *testing.T) {
+	c, err := New(t.Context(), testLogger(),
+		&stubVertexClient{
+			serviceName: "services/vertex-ai",
+			skus: []*billingpb.Sku{
+				newTokenSKU("Gemini 1.5 Flash Input tokens", "us-central1", "k{char}", 0, 1250000),
+			},
+		})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	ch := make(chan prometheus.Metric, 10)
+	err = c.Collect(ctx, ch)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// stubVertexClient implements client.Client for tests.
+type stubVertexClient struct {
+	serviceName      string
+	serviceNameErr   error
+	deServiceNameErr error
+	skus             []*billingpb.Sku
+	deSkus           []*billingpb.Sku // Discovery Engine SKUs
+}
+
+func (s *stubVertexClient) GetServiceName(_ context.Context, svc string) (string, error) {
+	if s.serviceNameErr != nil {
+		return "", s.serviceNameErr
+	}
+	if svc == discoveryEngineServiceName {
+		if s.deServiceNameErr != nil {
+			return "", s.deServiceNameErr
+		}
+		return "services/discovery-engine", nil
+	}
+	return s.serviceName, nil
+}
+
+func (s *stubVertexClient) ExportRegionalDiscounts(_ context.Context, _ *gcmetrics.Metrics) error {
+	return nil
+}
+
+func (s *stubVertexClient) ExportGCPCostData(_ context.Context, _ string, _ *gcmetrics.Metrics) float64 {
+	return 0
+}
+
+func (s *stubVertexClient) ExportBucketInfo(_ context.Context, _ []string, _ *gcmetrics.Metrics) error {
+	return nil
+}
+
+func (s *stubVertexClient) GetPricing(_ context.Context, svcName string) []*billingpb.Sku {
+	if svcName == "services/discovery-engine" {
+		return s.deSkus
+	}
+	return s.skus
+}
+
+func (s *stubVertexClient) GetZones(_ string) ([]*compute.Zone, error) {
+	return nil, nil
+}
+
+func (s *stubVertexClient) GetRegions(_ string) ([]*compute.Region, error) {
+	return nil, nil
+}
+
+func (s *stubVertexClient) ListInstancesInZone(_ string, _ string) ([]*client.MachineSpec, error) {
+	return nil, nil
+}
+
+func (s *stubVertexClient) ListDisks(_ context.Context, _ string, _ string) ([]*compute.Disk, error) {
+	return nil, nil
+}
+
+func (s *stubVertexClient) ListForwardingRules(_ context.Context, _ string, _ string) ([]*compute.ForwardingRule, error) {
+	return nil, nil
+}
+
+func (s *stubVertexClient) ListSQLInstances(_ context.Context, _ string) ([]*sqladmin.DatabaseInstance, error) {
+	return nil, nil
+}
+
+func (s *stubVertexClient) ListManagedKafkaLocations(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (s *stubVertexClient) ListManagedKafkaClusters(_ context.Context, _ string, _ string) ([]*managedkafkapb.Cluster, error) {
+	return nil, nil
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func collectVertexMetrics(t *testing.T, c *Collector) ([]*utils.MetricResult, error) {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 10)
+	if err := c.Collect(t.Context(), ch); err != nil {
+		close(ch)
+		return nil, err
+	}
+	close(ch)
+	var results []*utils.MetricResult
+	for metric := range ch {
+		if r := utils.ReadMetrics(metric); r != nil {
+			results = append(results, r)
+		}
+	}
+	return results, nil
+}
+
+func metricByName(metrics []*utils.MetricResult, fqName string) *utils.MetricResult {
+	for _, m := range metrics {
+		if m.FqName == fqName {
+			return m
+		}
+	}
+	return nil
+}
+
+func metricByLabel(metrics []*utils.MetricResult, fqName, labelKey, labelValue string) *utils.MetricResult {
+	for _, m := range metrics {
+		if m.FqName == fqName && m.Labels[labelKey] == labelValue {
+			return m
+		}
+	}
+	return nil
+}

--- a/pkg/utils/consts.go
+++ b/pkg/utils/consts.go
@@ -31,6 +31,12 @@ const (
 	InputTokenCostSuffix = "input_usd_per_1k_tokens"
 	// OutputTokenCostSuffix is the suffix for per-1k-output-token cost metrics.
 	OutputTokenCostSuffix = "output_usd_per_1k_tokens"
+	// CharacterInputCostSuffix is the suffix for per-1k-input-character cost metrics.
+	// Used for models billed per character rather than per token (e.g. translation models).
+	CharacterInputCostSuffix = "input_usd_per_1k_characters"
+	// CharacterOutputCostSuffix is the suffix for per-1k-output-character cost metrics.
+	// Used for models billed per character rather than per token (e.g. translation models).
+	CharacterOutputCostSuffix = "output_usd_per_1k_characters"
 	// SearchUnitCostSuffix is the suffix for per-1k-search-unit cost metrics (e.g. Cohere Rerank).
 	SearchUnitCostSuffix = "search_unit_usd_per_1k_search_units"
 )


### PR DESCRIPTION
Part of #930

## Summary

- Adds a `vertex` collector to the GCP provider
- Emits list-price token cost metrics from the GCP Billing API for Gemini and third-party Model Garden models, with a `price_tier` label covering on_demand, batch, thinking, cached, and other running modes
- Emits character cost metrics for character-billed models (e.g. translation)
- Emits custom training and prediction node compute pricing (`instance_total_usd_per_hour`) with `on_demand` and `spot` tiers
- Emits reranking cost metrics via the Cloud Discovery Engine billing service

## New Metrics

- `cloudcost_gcp_vertex_input_usd_per_1k_tokens`
- `cloudcost_gcp_vertex_output_usd_per_1k_tokens`
- `cloudcost_gcp_vertex_input_usd_per_1k_characters`
- `cloudcost_gcp_vertex_output_usd_per_1k_characters`
- `cloudcost_gcp_vertex_instance_total_usd_per_hour`
- `cloudcost_gcp_vertex_search_unit_usd_per_1k_search_units`

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [x] Metrics match documented names and labels in `docs/metrics/gcp/vertex.md`