### PR TITLE
feat(aws/bedrock): add marketplace pricing for Claude 4.x and Cohere models 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@
   - [Release Process](contribute/releases.md)
 - [Metrics](metrics/README.md) - See what each service exposes
   - [Providers](metrics/providers.md)
-  - **AWS:** [EC2](metrics/aws/ec2.md), [S3](metrics/aws/s3.md), [RDS](metrics/aws/rds.md), [MSK](metrics/aws/msk.md), [ELB](metrics/aws/elb.md), [NAT Gateway](metrics/aws/natgateway.md), [VPC](metrics/aws/vpc.md)
+  - **AWS:** [EC2](metrics/aws/ec2.md), [S3](metrics/aws/s3.md), [RDS](metrics/aws/rds.md), [MSK](metrics/aws/msk.md), [ELB](metrics/aws/elb.md), [NAT Gateway](metrics/aws/natgateway.md), [VPC](metrics/aws/vpc.md), [Bedrock](metrics/aws/bedrock.md)
   - **GCP:** [GKE](metrics/gcp/gke.md), [GCS](metrics/gcp/gcs.md), [Cloud SQL](metrics/gcp/cloudsql.md), [Managed Kafka](metrics/gcp/managedkafka.md), [CLB](metrics/gcp/clb.md), [VPC](metrics/gcp/vpc.md)
   - **Azure:** [AKS](metrics/azure/aks.md), [blob](metrics/azure/blob.md), [Event Hubs](metrics/azure/eventhubs.md)
 - [Deploying](deploying/aws/README.md) - Run the exporter

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -9,6 +9,7 @@
 - **[ELB](./aws/elb.md)** - Elastic Load Balancers (ALB, NLB)
 - **[NAT Gateway](./aws/natgateway.md)** - Network Address Translation gateways
 - **[VPC](./aws/vpc.md)** - VPC endpoints and services
+- **[Bedrock](./aws/bedrock.md)** - Foundation model token and search-unit pricing (first-party and Marketplace)
 
 ## GCP Services
 

--- a/docs/metrics/aws/bedrock.md
+++ b/docs/metrics/aws/bedrock.md
@@ -12,8 +12,8 @@ The Bedrock collector exports list-price cost metrics for AWS Bedrock foundation
 
 Prices come from two AWS Pricing API service codes, merged into the same metrics:
 
-- **`AmazonBedrock`** — first-party and earlier models (Claude 2/3, Amazon Nova and Titan).
-- **`AmazonBedrockFoundationModels`** — Bedrock Marketplace models, including Claude 4.x, Cohere Rerank and Embed, Meta Llama, AI21, Writer Palmyra, and TwelveLabs.
+- **`AmazonBedrock`** — Amazon-native models (Nova, Titan) plus most third-party text models with an explicit `provider` attribute (Anthropic, Meta, Mistral, DeepSeek, Qwen, Google, and others).
+- **`AmazonBedrockFoundationModels`** — Bedrock Marketplace models, including Claude 4.x, Cohere Rerank and Embed, Writer Palmyra, AI21 Jamba, and TwelveLabs.
 
 See [Pricing sources](#pricing-sources) for how the two are combined.
 
@@ -42,18 +42,20 @@ Restrict which model families are emitted with `--aws.bedrock.families` (a regex
   - `AmazonBedrock` emits the `usagetype` slug as published (e.g. `Claude3Sonnet`, `NovaPro`, `Llama4-Scout-17B`).
   - `AmazonBedrockFoundationModels` emits the `servicename` lowercased with spaces replaced by hyphens (e.g. `claude-sonnet-4.6`, `cohere-rerank-v3.5`, `palmyra-x5`).
 
-  `model_id` is a normalized label derived from pricing metadata, not a canonical Bedrock model ID or ARN. A few legacy Claude models (`Claude3Haiku`/`claude-3-haiku`, `Claude3Sonnet`/`claude-3-sonnet`, `ClaudeInstant`/`claude-instant`) are priced under both service codes and so appear under both conventions; the prices agree where the two overlap.
-- **`family`**: Model provider, derived from the pricing metadata. One of `anthropic`, `amazon`, `cohere`, `meta`, `ai21`, `stability`, `writer`, `twelvelabs`, or `unknown` for an unrecognized provider. Amazon-developed models with no provider attribute (Nova, Titan) use `amazon`. Filter with `--aws.bedrock.families`.
+  `model_id` is a normalized label derived from pricing metadata, not a canonical Bedrock model ID or ARN. The Claude 2.x, Claude Instant, Claude 3 Haiku, and Claude 3 Sonnet generation is priced under both service codes; the collector emits it once from `AmazonBedrock` and skips the `AmazonBedrockFoundationModels` duplicates, so each model appears under a single `model_id`.
+- **`family`**: Model provider, normalized to lowercase (spaces become underscores) from the `AmazonBedrock` `provider` attribute, or derived from the `AmazonBedrockFoundationModels` `servicename`. The set tracks whatever AWS publishes, so it is open-ended; observed values include `anthropic`, `amazon`, `cohere`, `meta`, `ai21`, `mistral`, `deepseek`, `google`, `qwen`, `nvidia`, `openai`, `writer`, and `twelvelabs`. Amazon-developed models with no provider attribute (Nova, Titan) use `amazon`. A marketplace `servicename` with no recognized provider falls back to `unknown`. Filter with `--aws.bedrock.families`.
 - **`price_tier`**: Inference tier:
   - Token metrics: `on_demand`, `on_demand_batch`, `on_demand_flex`, `on_demand_priority`, `cross_region`, `cross_region_batch`, `cross_region_flex`, `cross_region_priority`.
   - Search-unit metrics: `on_demand`, `cross_region`.
 
 ## Pricing sources
 
-The collector fetches `AmazonBedrock` and `AmazonBedrockFoundationModels` per region and merges them into one metric set. SKUs are matched by description; image, video, audio, cache, provisioned-throughput, and guardrail SKUs are skipped.
+The collector fetches `AmazonBedrock` and `AmazonBedrockFoundationModels` per region and merges them into one metric set. Each SKU's direction, family, model, and price tier are parsed from its `usagetype` and `servicename`; image, video, audio, cache, provisioned-throughput, and guardrail SKUs are skipped.
 
 - `AmazonBedrock` publishes token prices per 1000 tokens directly.
 - `AmazonBedrockFoundationModels` publishes token prices per 1,000,000 tokens (converted to per-1000) and search-unit prices per single unit (converted to per-1000).
+
+Where both service codes price the same model (the Claude 2.x / Instant / 3 Haiku / 3 Sonnet generation), the `AmazonBedrockFoundationModels` copy is skipped so the model is reported once.
 
 `AmazonBedrockFoundationModels` pricing is best-effort: if that service code is unavailable, the collector logs a warning and continues to emit `AmazonBedrock` pricing rather than failing.
 

--- a/docs/metrics/aws/bedrock.md
+++ b/docs/metrics/aws/bedrock.md
@@ -1,10 +1,10 @@
 # AWS Bedrock Metrics
 
-| Metric name                                               | Metric type | Description                                                   | Labels                                                                                                                                                                |
-|-----------------------------------------------------------|-------------|---------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `cloudcost_aws_bedrock_input_usd_per_1k_tokens`           | Gauge       | AWS Bedrock input token price in USD per 1000 tokens          | `account_id`=<AWS account ID> <br/> `region`=<AWS region> <br/> `model_id`=<model slug> <br/> `family`=<model provider> <br/> `price_tier`=<see price_tier> |
-| `cloudcost_aws_bedrock_output_usd_per_1k_tokens`          | Gauge       | AWS Bedrock output token price in USD per 1000 tokens         | `account_id`=<AWS account ID> <br/> `region`=<AWS region> <br/> `model_id`=<model slug> <br/> `family`=<model provider> <br/> `price_tier`=<see price_tier> |
-| `cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units` | Gauge     | AWS Bedrock search unit price in USD per 1000 search units (e.g. Cohere Rerank) | `account_id`=<AWS account ID> <br/> `region`=<AWS region> <br/> `model_id`=<model slug> <br/> `family`=<model provider> <br/> `price_tier`=<see price_tier> |
+| Metric name                                              | Metric type | Description                                                                      | Labels                                                                                                                                                              |
+|----------------------------------------------------------|-------------|---------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| cloudcost_aws_bedrock_input_usd_per_1k_tokens            | Gauge       | Input token price for an AWS Bedrock model. Cost represented in USD/1000 tokens  | `account_id`=&lt;AWS account ID&gt; <br/> `region`=&lt;AWS region&gt; <br/> `model_id`=&lt;model slug&gt; <br/> `family`=&lt;model provider&gt; <br/> `price_tier`=&lt;see Labels&gt; |
+| cloudcost_aws_bedrock_output_usd_per_1k_tokens           | Gauge       | Output token price for an AWS Bedrock model. Cost represented in USD/1000 tokens | `account_id`=&lt;AWS account ID&gt; <br/> `region`=&lt;AWS region&gt; <br/> `model_id`=&lt;model slug&gt; <br/> `family`=&lt;model provider&gt; <br/> `price_tier`=&lt;see Labels&gt; |
+| cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units | Gauge      | Search unit price for an AWS Bedrock model (e.g. Cohere Rerank). Cost represented in USD/1000 search units | `account_id`=&lt;AWS account ID&gt; <br/> `region`=&lt;AWS region&gt; <br/> `model_id`=&lt;model slug&gt; <br/> `family`=&lt;model provider&gt; <br/> `price_tier`=&lt;see Labels&gt; |
 
 ## Overview
 
@@ -15,40 +15,40 @@ Prices come from two AWS Pricing API service codes, merged into the same metrics
 - **`AmazonBedrock`** — Amazon-native models (Nova, Titan) plus most third-party text models with an explicit `provider` attribute (Anthropic, Meta, Mistral, DeepSeek, Qwen, Google, and others).
 - **`AmazonBedrockFoundationModels`** — Bedrock Marketplace models, including Claude 4.x, Cohere Rerank and Embed, Writer Palmyra, AI21 Jamba, and TwelveLabs.
 
-See [Pricing sources](#pricing-sources) for how the two are combined.
+See [Pricing Sources](#pricing-sources) for how the two are combined.
 
 ## Configuration
 
-Add `bedrock` to your AWS services configuration:
+Enable the Bedrock collector by adding `bedrock` to your AWS services configuration:
 
 ```yaml
 aws:
-  services: ["bedrock"]
+  services: ["ec2", "s3", "bedrock"]
   regions: ["us-east-1", "us-west-2"]
 ```
 
 Or via command line:
 ```bash
---aws.services=bedrock
+--aws.services=ec2,s3,bedrock
 ```
 
 Restrict which model families are emitted with `--aws.bedrock.families` (a regex matched against the `family` label). The default `.*` emits all families.
 
 ## Labels
 
-- **`account_id`**: AWS account ID (12-digit), resolved via STS `GetCallerIdentity`
-- **`region`**: AWS region for which the price applies
-- **`model_id`**: Normalized model identifier. The two pricing sources use different conventions:
+- **account_id**: The AWS account ID (12-digit), resolved via STS GetCallerIdentity
+- **region**: The AWS region for which the price applies
+- **model_id**: Normalized model identifier. The two pricing sources use different conventions:
   - `AmazonBedrock` emits the `usagetype` slug as published (e.g. `Claude3Sonnet`, `NovaPro`, `Llama4-Scout-17B`).
   - `AmazonBedrockFoundationModels` emits the `servicename` lowercased with spaces replaced by hyphens (e.g. `claude-sonnet-4.6`, `cohere-rerank-v3.5`, `palmyra-x5`).
 
   `model_id` is a normalized label derived from pricing metadata, not a canonical Bedrock model ID or ARN. The Claude 2.x, Claude Instant, Claude 3 Haiku, and Claude 3 Sonnet generation is priced under both service codes; the collector emits it once from `AmazonBedrock` and skips the `AmazonBedrockFoundationModels` duplicates, so each model appears under a single `model_id`.
-- **`family`**: Model provider, normalized to lowercase (spaces become underscores) from the `AmazonBedrock` `provider` attribute, or derived from the `AmazonBedrockFoundationModels` `servicename`. The set tracks whatever AWS publishes, so it is open-ended; observed values include `anthropic`, `amazon`, `cohere`, `meta`, `ai21`, `mistral`, `deepseek`, `google`, `qwen`, `nvidia`, `openai`, `writer`, and `twelvelabs`. Amazon-developed models with no provider attribute (Nova, Titan) use `amazon`. A marketplace `servicename` with no recognized provider falls back to `unknown`. Filter with `--aws.bedrock.families`.
-- **`price_tier`**: Inference tier:
+- **family**: Model provider, normalized to lowercase (spaces become underscores) from the `AmazonBedrock` `provider` attribute, or derived from the `AmazonBedrockFoundationModels` `servicename`. The set tracks whatever AWS publishes, so it is open-ended; observed values include `anthropic`, `amazon`, `cohere`, `meta`, `ai21`, `mistral`, `deepseek`, `google`, `qwen`, `nvidia`, `openai`, `writer`, and `twelvelabs`. Amazon-developed models with no provider attribute (Nova, Titan) use `amazon`. A marketplace `servicename` with no recognized provider falls back to `unknown`. Filter with `--aws.bedrock.families`.
+- **price_tier**: Inference tier:
   - Token metrics: `on_demand`, `on_demand_batch`, `on_demand_flex`, `on_demand_priority`, `cross_region`, `cross_region_batch`, `cross_region_flex`, `cross_region_priority`.
   - Search-unit metrics: `on_demand`, `cross_region`.
 
-## Pricing sources
+## Pricing Sources
 
 The collector fetches `AmazonBedrock` and `AmazonBedrockFoundationModels` per region and merges them into one metric set. Each SKU's direction, family, model, and price tier are parsed from its `usagetype` and `servicename`; image, video, audio, cache, provisioned-throughput, and guardrail SKUs are skipped.
 
@@ -83,3 +83,5 @@ Required permissions for Bedrock metrics collection:
     ]
 }
 ```
+
+**Note:** Bedrock metrics are collected via the AWS Pricing API only. No Bedrock-specific API calls are required, as the exporter provides pricing rates rather than tracking individual Bedrock resources.

--- a/docs/metrics/aws/bedrock.md
+++ b/docs/metrics/aws/bedrock.md
@@ -45,10 +45,12 @@ Restrict which model families are emitted with `--aws.bedrock.families` (a regex
 
   `model_id` is a normalized label derived from pricing metadata, not a canonical Bedrock model ID or ARN. Because both sources normalize to the same `model_id`, a model priced under both (e.g. the legacy Claude generation) merges into one set of series: identical prices dedupe, and a price one source lacks (the standard source prices some legacy Claude models for input only) is filled in by the other.
 - **family**: Model provider, normalized to lowercase (spaces become underscores) from the `AmazonBedrock` `provider` attribute, or derived from the `AmazonBedrockFoundationModels` `servicename`. The set tracks whatever AWS publishes, so it is open-ended; observed values include `anthropic`, `amazon`, `cohere`, `meta`, `ai21`, `mistral`, `deepseek`, `google`, `qwen`, `nvidia`, `openai`, `writer`, and `twelvelabs`. Amazon-developed models with no provider attribute (Nova, Titan) use `amazon`. A marketplace `servicename` with no recognized provider falls back to `unknown`. Filter with `--aws.bedrock.families`.
-- **price_tier**: Inference tier.
-  - Token metrics: `on_demand`, `on_demand_batch`, `on_demand_flex`, `on_demand_priority`, `cross_region`, `cross_region_batch`, `cross_region_flex`, `cross_region_priority`.
-  - Prompt caching (token metrics, marketplace source): `cache_read`, `cache_write_5m`, `cache_write_1h`, and their `cross_region_*` / `*_latency_optimized` variants. Reads are a single rate; writes split by cache TTL (5-minute default vs 1-hour). Cache storage (priced per token-hour) is not emitted. Caching for Amazon-native models (Nova/Titan) in the `AmazonBedrock` source is not emitted.
-  - Search-unit metrics: `on_demand`, `cross_region`.
+- **price_tier**: Inference tier, composed of an optional `cross_region` prefix, a base operation, and an optional quota suffix, joined by `_`. The parts stack, so values like `on_demand`, `on_demand_batch`, `cross_region`, `cross_region_batch`, `cross_region_cache_read` all occur.
+  - Base operation (token metrics): `on_demand`, or a prompt-cache operation `cache_read`, `cache_write_5m`, `cache_write_1h`. Cache reads are a single rate; writes split by TTL (5-minute default vs 1-hour).
+  - Quota suffix: `batch`, `flex`, `priority`, or `latency_optimized` (e.g. `on_demand_batch`, `on_demand_latency_optimized`, `cache_write_1h`).
+  - Cross-region: any of the above prefixed with `cross_region` (e.g. `cross_region`, `cross_region_batch`, `cross_region_cache_write_1h`).
+  - Search-unit metrics use only `on_demand` and `cross_region`.
+  - Prompt caching is emitted only from the marketplace source. Cache storage (priced per token-hour) and caching for Amazon-native models (Nova/Titan) in the `AmazonBedrock` source are not emitted.
 
 ## Pricing Sources
 

--- a/docs/metrics/aws/bedrock.md
+++ b/docs/metrics/aws/bedrock.md
@@ -23,13 +23,13 @@ Enable the Bedrock collector by adding `bedrock` to your AWS services configurat
 
 ```yaml
 aws:
-  services: ["ec2", "s3", "bedrock"]
+  services: ["bedrock"]
   regions: ["us-east-1", "us-west-2"]
 ```
 
 Or via command line:
 ```bash
---aws.services=ec2,s3,bedrock
+--aws.services=bedrock
 ```
 
 Restrict which model families are emitted with `--aws.bedrock.families` (a regex matched against the `family` label). The default `.*` emits all families.
@@ -44,7 +44,7 @@ Restrict which model families are emitted with `--aws.bedrock.families` (a regex
   - Models that AWS prices per modality under one name carry the modality (e.g. `nova-sonic-text`, `nova-sonic-speech`).
 
   `model_id` is a normalized label derived from pricing metadata, not a canonical Bedrock model ID or ARN. Because both sources normalize to the same `model_id`, a model priced under both (e.g. the legacy Claude generation) merges into one set of series: identical prices dedupe, and a price one source lacks (the standard source prices some legacy Claude models for input only) is filled in by the other.
-- **family**: Model provider, normalized to lowercase (spaces become underscores) from the `AmazonBedrock` `provider` attribute, or derived from the `AmazonBedrockFoundationModels` `servicename`. The set tracks whatever AWS publishes, so it is open-ended; observed values include `anthropic`, `amazon`, `cohere`, `meta`, `ai21`, `mistral`, `deepseek`, `google`, `qwen`, `nvidia`, `openai`, `writer`, and `twelvelabs`. Amazon-developed models with no provider attribute (Nova, Titan) use `amazon`. A marketplace `servicename` with no recognized provider falls back to `unknown`. Filter with `--aws.bedrock.families`.
+- **family**: Model provider, normalized to lowercase (spaces become underscores) from the `AmazonBedrock` `provider` attribute, or derived from the `AmazonBedrockFoundationModels` `servicename`. The set tracks whatever AWS publishes, so it is open-ended; examples include `anthropic`, `amazon`, `cohere`, `meta`, `ai21`, `mistral`, `deepseek`, `google`, `qwen`, `nvidia`, `openai`, `writer`, and `twelvelabs` (not exhaustive, and the list grows as AWS adds providers). Amazon-developed models with no provider attribute (Nova, Titan) use `amazon`. A marketplace `servicename` with no recognized provider falls back to `unknown`. Filter with `--aws.bedrock.families`.
 - **price_tier**: Inference tier, composed of an optional `cross_region` prefix, a base operation, and an optional quota suffix, joined by `_`. The parts stack, so values like `on_demand`, `on_demand_batch`, `cross_region`, `cross_region_batch`, `cross_region_cache_read` all occur.
   - Base operation (token metrics): `on_demand`, or a prompt-cache operation `cache_read`, `cache_write_5m`, `cache_write_1h`. Cache reads are a single rate; writes split by TTL (5-minute default vs 1-hour).
   - Quota suffix: `batch`, `flex`, `priority`, or `latency_optimized` (e.g. `on_demand_batch`, `on_demand_latency_optimized`, `cache_write_1h`).

--- a/docs/metrics/aws/bedrock.md
+++ b/docs/metrics/aws/bedrock.md
@@ -45,13 +45,14 @@ Restrict which model families are emitted with `--aws.bedrock.families` (a regex
 
   `model_id` is a normalized label derived from pricing metadata, not a canonical Bedrock model ID or ARN. Because both sources normalize to the same `model_id`, a model priced under both (e.g. the legacy Claude generation) merges into one set of series: identical prices dedupe, and a price one source lacks (the standard source prices some legacy Claude models for input only) is filled in by the other.
 - **family**: Model provider, normalized to lowercase (spaces become underscores) from the `AmazonBedrock` `provider` attribute, or derived from the `AmazonBedrockFoundationModels` `servicename`. The set tracks whatever AWS publishes, so it is open-ended; observed values include `anthropic`, `amazon`, `cohere`, `meta`, `ai21`, `mistral`, `deepseek`, `google`, `qwen`, `nvidia`, `openai`, `writer`, and `twelvelabs`. Amazon-developed models with no provider attribute (Nova, Titan) use `amazon`. A marketplace `servicename` with no recognized provider falls back to `unknown`. Filter with `--aws.bedrock.families`.
-- **price_tier**: Inference tier:
+- **price_tier**: Inference tier.
   - Token metrics: `on_demand`, `on_demand_batch`, `on_demand_flex`, `on_demand_priority`, `cross_region`, `cross_region_batch`, `cross_region_flex`, `cross_region_priority`.
+  - Prompt caching (token metrics, marketplace source): `cache_read`, `cache_write_5m`, `cache_write_1h`, and their `cross_region_*` / `*_latency_optimized` variants. Reads are a single rate; writes split by cache TTL (5-minute default vs 1-hour). Cache storage (priced per token-hour) is not emitted. Caching for Amazon-native models (Nova/Titan) in the `AmazonBedrock` source is not emitted.
   - Search-unit metrics: `on_demand`, `cross_region`.
 
 ## Pricing Sources
 
-The collector fetches `AmazonBedrock` and `AmazonBedrockFoundationModels` per region and merges them into one metric set. Each SKU's direction, family, model, and price tier are parsed from its `usagetype` and `servicename`; image, video, audio, cache, provisioned-throughput, and guardrail SKUs are skipped.
+The collector fetches `AmazonBedrock` and `AmazonBedrockFoundationModels` per region and merges them into one metric set. Each SKU's direction, family, model, and price tier are parsed from its `usagetype` and `servicename`; image, video, audio, cache-storage, provisioned-throughput, and guardrail SKUs are skipped. Prompt-cache read/write SKUs from the marketplace source are emitted on the input metric as `cache_*` price tiers.
 
 - `AmazonBedrock` publishes token prices per 1000 tokens directly.
 - `AmazonBedrockFoundationModels` publishes token prices per 1,000,000 tokens (converted to per-1000) and search-unit prices per single unit (converted to per-1000).
@@ -63,7 +64,7 @@ When both service codes price the same model (the legacy Claude generation), the
 ## Notes
 
 - Pricing data is fetched from the AWS Pricing API (`us-east-1` endpoint) and refreshed every 24 hours
-- Image, video, audio, cache, provisioned-throughput, and guardrail SKUs are skipped; only token and search-unit SKUs are emitted
+- Image, video, audio, cache-storage, provisioned-throughput, and guardrail SKUs are skipped; token (including prompt-cache read/write), and search-unit SKUs are emitted
 - `model_id` is a normalized pricing identifier, not the canonical Bedrock model ARN
 
 ## IAM Permissions

--- a/docs/metrics/aws/bedrock.md
+++ b/docs/metrics/aws/bedrock.md
@@ -38,9 +38,10 @@ Restrict which model families are emitted with `--aws.bedrock.families` (a regex
 
 - **account_id**: The AWS account ID (12-digit), resolved via STS GetCallerIdentity
 - **region**: The AWS region for which the price applies
-- **model_id**: Normalized model identifier. The two pricing sources use different conventions:
-  - `AmazonBedrock` emits the `usagetype` slug as published (e.g. `Claude3Sonnet`, `NovaPro`, `Llama4-Scout-17B`).
-  - `AmazonBedrockFoundationModels` emits the `servicename` lowercased with spaces replaced by hyphens (e.g. `claude-sonnet-4.6`, `cohere-rerank-v3.5`, `palmyra-x5`).
+- **model_id**: Normalized model identifier, lowercase with spaces replaced by hyphens, uniform across both pricing sources (e.g. `claude-3-sonnet`, `claude-sonnet-4.6`, `nova-pro`, `llama-3.1-405b`, `cohere-rerank-v3.5`).
+  - `AmazonBedrock` derives it from the human-readable `model` attribute, falling back to the normalized `usagetype` slug for the few SKUs (some Titan, Rerank) that lack `model`.
+  - `AmazonBedrockFoundationModels` derives it from the `servicename`.
+  - Models that AWS prices per modality under one name carry the modality (e.g. `nova-sonic-text`, `nova-sonic-speech`).
 
   `model_id` is a normalized label derived from pricing metadata, not a canonical Bedrock model ID or ARN. The Claude 2.x, Claude Instant, Claude 3 Haiku, and Claude 3 Sonnet generation is priced under both service codes; the collector emits it once from `AmazonBedrock` and skips the `AmazonBedrockFoundationModels` duplicates, so each model appears under a single `model_id`.
 - **family**: Model provider, normalized to lowercase (spaces become underscores) from the `AmazonBedrock` `provider` attribute, or derived from the `AmazonBedrockFoundationModels` `servicename`. The set tracks whatever AWS publishes, so it is open-ended; observed values include `anthropic`, `amazon`, `cohere`, `meta`, `ai21`, `mistral`, `deepseek`, `google`, `qwen`, `nvidia`, `openai`, `writer`, and `twelvelabs`. Amazon-developed models with no provider attribute (Nova, Titan) use `amazon`. A marketplace `servicename` with no recognized provider falls back to `unknown`. Filter with `--aws.bedrock.families`.

--- a/docs/metrics/aws/bedrock.md
+++ b/docs/metrics/aws/bedrock.md
@@ -2,13 +2,20 @@
 
 | Metric name                                               | Metric type | Description                                                   | Labels                                                                                                                                                                |
 |-----------------------------------------------------------|-------------|---------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `cloudcost_aws_bedrock_input_usd_per_1k_tokens`           | Gauge       | AWS Bedrock input token price in USD per 1000 tokens          | `account_id`=<AWS account ID> <br/> `region`=<AWS region> <br/> `model_id`=<model slug> <br/> `family`=<model provider> <br/> `price_tier`=<on_demand\|on_demand_batch\|on_demand_flex\|on_demand_priority\|cross_region> |
-| `cloudcost_aws_bedrock_output_usd_per_1k_tokens`          | Gauge       | AWS Bedrock output token price in USD per 1000 tokens         | `account_id`=<AWS account ID> <br/> `region`=<AWS region> <br/> `model_id`=<model slug> <br/> `family`=<model provider> <br/> `price_tier`=<on_demand\|on_demand_batch\|on_demand_flex\|on_demand_priority\|cross_region> |
-| `cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units` | Gauge     | AWS Bedrock search unit price in USD per 1000 search units (e.g. Cohere Rerank) | `account_id`=<AWS account ID> <br/> `region`=<AWS region> <br/> `model_id`=<model slug> <br/> `family`=<model provider> <br/> `price_tier`=<on_demand\|cross_region> |
+| `cloudcost_aws_bedrock_input_usd_per_1k_tokens`           | Gauge       | AWS Bedrock input token price in USD per 1000 tokens          | `account_id`=<AWS account ID> <br/> `region`=<AWS region> <br/> `model_id`=<model slug> <br/> `family`=<model provider> <br/> `price_tier`=<see price_tier> |
+| `cloudcost_aws_bedrock_output_usd_per_1k_tokens`          | Gauge       | AWS Bedrock output token price in USD per 1000 tokens         | `account_id`=<AWS account ID> <br/> `region`=<AWS region> <br/> `model_id`=<model slug> <br/> `family`=<model provider> <br/> `price_tier`=<see price_tier> |
+| `cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units` | Gauge     | AWS Bedrock search unit price in USD per 1000 search units (e.g. Cohere Rerank) | `account_id`=<AWS account ID> <br/> `region`=<AWS region> <br/> `model_id`=<model slug> <br/> `family`=<model provider> <br/> `price_tier`=<see price_tier> |
 
 ## Overview
 
-The Bedrock collector exports list-price token cost metrics for AWS Bedrock foundation models across all configured regions. These are pricing rates, not measured spend. Multiply rates by token usage (e.g. from CloudWatch `AWS/Bedrock` metrics) to compute estimated cost.
+The Bedrock collector exports list-price cost metrics for AWS Bedrock foundation models across all configured regions. These are pricing rates, not measured spend. Multiply rates by token or search-unit usage (e.g. from CloudWatch `AWS/Bedrock` metrics) to compute estimated cost.
+
+Prices come from two AWS Pricing API service codes, merged into the same metrics:
+
+- **`AmazonBedrock`** — first-party and earlier models (Claude 2/3, Amazon Nova and Titan).
+- **`AmazonBedrockFoundationModels`** — Bedrock Marketplace models, including Claude 4.x, Cohere Rerank and Embed, Meta Llama, AI21, Writer Palmyra, and TwelveLabs.
+
+See [Pricing sources](#pricing-sources) for how the two are combined.
 
 ## Configuration
 
@@ -25,19 +32,36 @@ Or via command line:
 --aws.services=bedrock
 ```
 
+Restrict which model families are emitted with `--aws.bedrock.families` (a regex matched against the `family` label). The default `.*` emits all families.
+
 ## Labels
 
 - **`account_id`**: AWS account ID (12-digit), resolved via STS `GetCallerIdentity`
 - **`region`**: AWS region for which the price applies
-- **`model_id`**: Model slug from the AWS Pricing API `usagetype` field (e.g. `Claude3Sonnet`, `Llama4-Scout-17B`, `Nova2.0Pro`)
-- **`family`**: Model provider — `anthropic` (Claude models) or `amazon` (Nova, Titan). Models with no provider attribute use `amazon`. Only these two families are emitted; remove the family filter in `encodeBedrockPriceJSON` to include all providers.
-- **`price_tier`**: Inference tier: `on_demand`, `on_demand_batch`, `on_demand_flex`, `on_demand_priority`, or `cross_region`
+- **`model_id`**: Normalized model identifier. The two pricing sources use different conventions:
+  - `AmazonBedrock` emits the `usagetype` slug as published (e.g. `Claude3Sonnet`, `NovaPro`, `Llama4-Scout-17B`).
+  - `AmazonBedrockFoundationModels` emits the `servicename` lowercased with spaces replaced by hyphens (e.g. `claude-sonnet-4.6`, `cohere-rerank-v3.5`, `palmyra-x5`).
+
+  `model_id` is a normalized label derived from pricing metadata, not a canonical Bedrock model ID or ARN. A few legacy Claude models (`Claude3Haiku`/`claude-3-haiku`, `Claude3Sonnet`/`claude-3-sonnet`, `ClaudeInstant`/`claude-instant`) are priced under both service codes and so appear under both conventions; the prices agree where the two overlap.
+- **`family`**: Model provider, derived from the pricing metadata. One of `anthropic`, `amazon`, `cohere`, `meta`, `ai21`, `stability`, `writer`, `twelvelabs`, or `unknown` for an unrecognized provider. Amazon-developed models with no provider attribute (Nova, Titan) use `amazon`. Filter with `--aws.bedrock.families`.
+- **`price_tier`**: Inference tier:
+  - Token metrics: `on_demand`, `on_demand_batch`, `on_demand_flex`, `on_demand_priority`, `cross_region`, `cross_region_batch`, `cross_region_flex`, `cross_region_priority`.
+  - Search-unit metrics: `on_demand`, `cross_region`.
+
+## Pricing sources
+
+The collector fetches `AmazonBedrock` and `AmazonBedrockFoundationModels` per region and merges them into one metric set. SKUs are matched by description; image, video, audio, cache, provisioned-throughput, and guardrail SKUs are skipped.
+
+- `AmazonBedrock` publishes token prices per 1000 tokens directly.
+- `AmazonBedrockFoundationModels` publishes token prices per 1,000,000 tokens (converted to per-1000) and search-unit prices per single unit (converted to per-1000).
+
+`AmazonBedrockFoundationModels` pricing is best-effort: if that service code is unavailable, the collector logs a warning and continues to emit `AmazonBedrock` pricing rather than failing.
 
 ## Notes
 
 - Pricing data is fetched from the AWS Pricing API (`us-east-1` endpoint) and refreshed every 24 hours
-- Image, video, audio, cache, and guardrail SKUs are skipped; only text token SKUs are emitted
-- `model_id` is the pricing SKU slug, not the canonical Bedrock model ARN
+- Image, video, audio, cache, provisioned-throughput, and guardrail SKUs are skipped; only token and search-unit SKUs are emitted
+- `model_id` is a normalized pricing identifier, not the canonical Bedrock model ARN
 
 ## IAM Permissions
 

--- a/docs/metrics/aws/bedrock.md
+++ b/docs/metrics/aws/bedrock.md
@@ -43,7 +43,7 @@ Restrict which model families are emitted with `--aws.bedrock.families` (a regex
   - `AmazonBedrockFoundationModels` derives it from the `servicename`.
   - Models that AWS prices per modality under one name carry the modality (e.g. `nova-sonic-text`, `nova-sonic-speech`).
 
-  `model_id` is a normalized label derived from pricing metadata, not a canonical Bedrock model ID or ARN. The Claude 2.x, Claude Instant, Claude 3 Haiku, and Claude 3 Sonnet generation is priced under both service codes; the collector emits it once from `AmazonBedrock` and skips the `AmazonBedrockFoundationModels` duplicates, so each model appears under a single `model_id`.
+  `model_id` is a normalized label derived from pricing metadata, not a canonical Bedrock model ID or ARN. Because both sources normalize to the same `model_id`, a model priced under both (e.g. the legacy Claude generation) merges into one set of series: identical prices dedupe, and a price one source lacks (the standard source prices some legacy Claude models for input only) is filled in by the other.
 - **family**: Model provider, normalized to lowercase (spaces become underscores) from the `AmazonBedrock` `provider` attribute, or derived from the `AmazonBedrockFoundationModels` `servicename`. The set tracks whatever AWS publishes, so it is open-ended; observed values include `anthropic`, `amazon`, `cohere`, `meta`, `ai21`, `mistral`, `deepseek`, `google`, `qwen`, `nvidia`, `openai`, `writer`, and `twelvelabs`. Amazon-developed models with no provider attribute (Nova, Titan) use `amazon`. A marketplace `servicename` with no recognized provider falls back to `unknown`. Filter with `--aws.bedrock.families`.
 - **price_tier**: Inference tier:
   - Token metrics: `on_demand`, `on_demand_batch`, `on_demand_flex`, `on_demand_priority`, `cross_region`, `cross_region_batch`, `cross_region_flex`, `cross_region_priority`.
@@ -56,7 +56,7 @@ The collector fetches `AmazonBedrock` and `AmazonBedrockFoundationModels` per re
 - `AmazonBedrock` publishes token prices per 1000 tokens directly.
 - `AmazonBedrockFoundationModels` publishes token prices per 1,000,000 tokens (converted to per-1000) and search-unit prices per single unit (converted to per-1000).
 
-Where both service codes price the same model (the Claude 2.x / Instant / 3 Haiku / 3 Sonnet generation), the `AmazonBedrockFoundationModels` copy is skipped so the model is reported once.
+When both service codes price the same model (the legacy Claude generation), they share a `model_id`, so per-region/direction/tier entries dedupe and any price only one source carries is retained. Overlapping prices are identical across the two sources.
 
 `AmazonBedrockFoundationModels` pricing is best-effort: if that service code is unavailable, the collector logs a warning and continues to emit `AmazonBedrock` pricing rather than failing.
 

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -283,10 +283,9 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 			collector, err := bedrock.New(ctx, &bedrock.Config{
 				Regions:       regions,
 				PricingClient: awsBedrockClient,
-				Logger:        logger,
 				AccountID:     config.AccountID,
 				FamilyFilter:  config.BedrockFamilyFilter,
-			})
+			}, logger)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
 					slog.String("service", service),

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -23,11 +24,26 @@ const (
 	subsystem   = "aws_bedrock"
 	serviceName = "bedrock"
 
-	priceTierOnDemand    = "on_demand"
-	priceTierCrossRegion = "cross_region"
+	priceTierOnDemand         = "on_demand"
+	priceTierOnDemandBatch    = "on_demand_batch"
+	priceTierOnDemandFlex     = "on_demand_flex"
+	priceTierOnDemandPriority = "on_demand_priority"
+	priceTierCrossRegion      = "cross_region"
 
-	// compositeKeySep separates the four fields encoded in the pricingstore usagetype key.
+	// compositeKeySep separates the four fields encoded in the pricingstore usagetype key:
+	// family|direction|model_id|price_tier
 	compositeKeySep = "|"
+
+	// searchUnitsPerKilo converts from per-unit pricing (as published by the AWS Pricing API)
+	// to per-1000-units pricing (as emitted by SearchUnitCostDesc).
+	searchUnitsPerKilo = 1000.0
+
+	// marketplacePerMillionToPerKilo converts marketplace token pricing ($/1M tokens) to $/1K tokens.
+	// $/1M ÷ 1000 = $/1K.
+	marketplacePerMillionToPerKilo = 1000.0
+
+	// marketplaceSuffix is appended to every model name in the AmazonBedrockFoundationModels API.
+	marketplaceSuffix = " (Amazon Bedrock Edition)"
 )
 
 var (
@@ -72,6 +88,26 @@ type bedrockProductInfo struct {
 	} `json:"terms"`
 }
 
+// bedrockMarketplaceProductInfo represents a SKU from the AmazonBedrockFoundationModels
+// service code. Unlike bedrockProductInfo, it has no inferenceType or provider — the model
+// and family are encoded in servicename, and the direction is encoded in the usagetype suffix.
+type bedrockMarketplaceProductInfo struct {
+	Product struct {
+		Attributes struct {
+			UsageType   string `json:"usagetype"`
+			RegionCode  string `json:"regionCode"`
+			ServiceName string `json:"servicename"`
+		} `json:"attributes"`
+	} `json:"product"`
+	Terms struct {
+		OnDemand map[string]struct {
+			PriceDimensions map[string]struct {
+				PricePerUnit map[string]string `json:"pricePerUnit"`
+			} `json:"priceDimensions"`
+		} `json:"OnDemand"`
+	} `json:"terms"`
+}
+
 type Config struct {
 	Regions       []ec2types.Region
 	PricingClient client.Client
@@ -99,7 +135,7 @@ func New(ctx context.Context, config *Config) (*Collector, error) {
 		return nil, fmt.Errorf("invalid bedrock family filter %q: %w", config.FamilyFilter, err)
 	}
 
-	pricingStore, err := pricingstore.NewPricingStore(ctx, logger, config.Regions, newPriceFetcher(config.PricingClient, familyFilter))
+	pricingStore, err := pricingstore.NewPricingStore(ctx, logger, config.Regions, newPriceFetcher(config.PricingClient, familyFilter, logger))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pricing store: %w", err)
 	}
@@ -198,56 +234,106 @@ func (c *Collector) Register(_ provider.Registry) error {
 // TermMatch filter on GetProducts, so each invocation returns only that region's SKUs.
 // The pricingstore fans out one call per configured region; do NOT replace this with a
 // single call, or the resulting snapshot will lose regional separation.
-func newPriceFetcher(pricingClient client.Client, familyFilter *regexp.Regexp) pricingstore.PriceFetchFunc {
+func newPriceFetcher(pricingClient client.Client, familyFilter *regexp.Regexp, logger *slog.Logger) pricingstore.PriceFetchFunc {
 	return func(ctx context.Context, region string) ([]string, error) {
-		rawItems, err := pricingClient.ListBedrockPrices(ctx, region)
+		standard, err := pricingClient.ListBedrockPrices(ctx, region)
 		if err != nil {
 			return nil, err
 		}
-		return preprocessBedrockPrices(rawItems, familyFilter), nil
+		marketplace, err := pricingClient.ListBedrockMarketplacePrices(ctx, region)
+		if err != nil {
+			return nil, err
+		}
+		result := preprocessBedrockPrices(standard, familyFilter, logger)
+		result = append(result, preprocessBedrockMarketplacePrices(marketplace, familyFilter, logger)...)
+		return result, nil
 	}
 }
 
-func preprocessBedrockPrices(rawItems []string, familyFilter *regexp.Regexp) []string {
+func preprocessBedrockPrices(rawItems []string, familyFilter *regexp.Regexp, logger *slog.Logger) []string {
 	result := make([]string, 0, len(rawItems))
 	for _, raw := range rawItems {
-		if processed, ok := encodeBedrockPriceJSON(raw, familyFilter); ok {
+		processed, ok, err := encodeBedrockPriceJSON(raw, familyFilter)
+		if err != nil {
+			logger.Warn("skipping Bedrock standard pricing SKU", "error", err)
+		}
+		if ok {
 			result = append(result, processed)
 		}
 	}
 	return result
 }
 
-// Returns ok=false for non-text-token types, parse failures, unrecognized usagetype formats,
-// or families not matched by familyFilter.
-func encodeBedrockPriceJSON(raw string, familyFilter *regexp.Regexp) (string, bool) {
+// Returns ok=false with a nil error for intentional skips (unrecognised type, family filter).
+// Returns ok=false with a non-nil error for unexpected failures (bad JSON, price parse error).
+func encodeBedrockPriceJSON(raw string, familyFilter *regexp.Regexp) (string, bool, error) {
 	var info bedrockProductInfo
 	if err := json.Unmarshal([]byte(raw), &info); err != nil {
-		return "", false
+		return "", false, fmt.Errorf("unmarshalling SKU: %w", err)
 	}
 
 	attrs := &info.Product.Attributes
 	direction, ok := classifyInferenceType(attrs.InferenceType)
 	if !ok {
-		return "", false
+		// Fallback for SKUs where inferenceType is absent (e.g. AmazonRerank-v1-searchunits).
+		direction, ok = classifyByUsageType(attrs.UsageType)
+		if !ok {
+			return "", false, nil
+		}
 	}
 
 	modelID, priceTier := parseBedrockModelID(attrs.UsageType)
 	if modelID == "" {
-		return "", false
+		return "", false, nil
 	}
 
 	family := normalizeProvider(attrs.Provider)
 	if !familyFilter.MatchString(family) {
-		return "", false
+		return "", false, nil
 	}
+
+	// The Pricing API publishes search unit prices per single unit; scale to per-1k to match
+	// the SearchUnitCostDesc metric name.
+	if direction == "search" {
+		if err := scaleSearchUnitPrices(&info); err != nil {
+			return "", false, fmt.Errorf("scaling search unit prices for %q: %w", attrs.UsageType, err)
+		}
+	}
+
 	attrs.UsageType = strings.Join([]string{family, direction, modelID, priceTier}, compositeKeySep)
 
 	modified, err := json.Marshal(&info)
 	if err != nil {
-		return "", false
+		return "", false, fmt.Errorf("marshalling SKU %q: %w", attrs.UsageType, err)
 	}
-	return string(modified), true
+	return string(modified), true, nil
+}
+
+// classifyByUsageType is a fallback for SKUs where inferenceType is absent.
+func classifyByUsageType(usagetype string) (direction string, ok bool) {
+	if strings.Contains(strings.ToLower(usagetype), "searchunits") {
+		return "search", true
+	}
+	return "", false
+}
+
+// scaleSearchUnitPrices multiplies all USD prices in the SKU by searchUnitsPerKilo.
+// PricePerUnit is a map (reference type) so the modification is in-place.
+func scaleSearchUnitPrices(info *bedrockProductInfo) error {
+	for _, term := range info.Terms.OnDemand {
+		for _, pd := range term.PriceDimensions {
+			usd, ok := pd.PricePerUnit["USD"]
+			if !ok {
+				continue
+			}
+			price, err := strconv.ParseFloat(usd, 64)
+			if err != nil {
+				return err
+			}
+			pd.PricePerUnit["USD"] = strconv.FormatFloat(price*searchUnitsPerKilo, 'f', -1, 64)
+		}
+	}
+	return nil
 }
 
 func classifyInferenceType(inferenceType string) (direction string, ok bool) {
@@ -279,6 +365,7 @@ var tokenTypeMarkers = []string{
 	"-input-tokens",
 	"-output-tokens",
 	"-search-units",
+	"-searchunits", // Rerank usagetype format (e.g. AmazonRerank-v1-searchunits)
 }
 
 func parseBedrockModelID(usagetype string) (modelID, priceTier string) {
@@ -303,11 +390,11 @@ func extractPriceTier(suffix string) string {
 	}
 	switch {
 	case strings.HasSuffix(lower, "-batch"):
-		return "on_demand_batch"
+		return priceTierOnDemandBatch
 	case strings.HasSuffix(lower, "-flex"):
-		return "on_demand_flex"
+		return priceTierOnDemandFlex
 	case strings.HasSuffix(lower, "-priority"):
-		return "on_demand_priority"
+		return priceTierOnDemandPriority
 	default:
 		return priceTierOnDemand
 	}
@@ -319,4 +406,156 @@ func normalizeProvider(provider string) string {
 		return "amazon"
 	}
 	return strings.ReplaceAll(strings.ToLower(provider), " ", "_")
+}
+
+func preprocessBedrockMarketplacePrices(rawItems []string, familyFilter *regexp.Regexp, logger *slog.Logger) []string {
+	result := make([]string, 0, len(rawItems))
+	for _, raw := range rawItems {
+		processed, ok, err := encodeBedrockMarketplacePriceJSON(raw, familyFilter)
+		if err != nil {
+			logger.Warn("skipping Bedrock marketplace pricing SKU", "error", err)
+		}
+		if ok {
+			result = append(result, processed)
+		}
+	}
+	return result
+}
+
+// encodeBedrockMarketplacePriceJSON processes a SKU from AmazonBedrockFoundationModels.
+// It re-encodes the SKU with the composite key in usagetype so pricingstore can store it.
+// Prices are converted from $/1M tokens to $/1K tokens; search unit prices from $/unit to $/1K units.
+// Returns ok=false with a nil error for intentional skips; non-nil error for unexpected failures.
+func encodeBedrockMarketplacePriceJSON(raw string, familyFilter *regexp.Regexp) (string, bool, error) {
+	var info bedrockMarketplaceProductInfo
+	if err := json.Unmarshal([]byte(raw), &info); err != nil {
+		return "", false, fmt.Errorf("unmarshalling marketplace SKU: %w", err)
+	}
+
+	attrs := &info.Product.Attributes
+	modelID := strings.ReplaceAll(strings.TrimSuffix(attrs.ServiceName, marketplaceSuffix), " ", "_")
+	if modelID == "" {
+		return "", false, nil
+	}
+
+	family := familyFromServiceName(attrs.ServiceName)
+	if !familyFilter.MatchString(family) {
+		return "", false, nil
+	}
+
+	direction, ok := classifyMarketplaceUsageType(attrs.UsageType)
+	if !ok {
+		return "", false, nil
+	}
+
+	priceTier := extractMarketplacePriceTier(attrs.UsageType)
+
+	for _, term := range info.Terms.OnDemand {
+		for _, pd := range term.PriceDimensions {
+			usd, ok := pd.PricePerUnit["USD"]
+			if !ok {
+				continue
+			}
+			price, err := strconv.ParseFloat(usd, 64)
+			if err != nil {
+				return "", false, fmt.Errorf("parsing price for %q: %w", attrs.UsageType, err)
+			}
+			var converted float64
+			if direction == "search" {
+				// Marketplace publishes $/search unit; metric is $/1K search units.
+				converted = price * searchUnitsPerKilo
+			} else {
+				// Marketplace publishes $/1M tokens; metric is $/1K tokens.
+				converted = price / marketplacePerMillionToPerKilo
+			}
+			pd.PricePerUnit["USD"] = strconv.FormatFloat(converted, 'f', -1, 64)
+		}
+	}
+
+	attrs.UsageType = strings.Join([]string{family, direction, modelID, priceTier}, compositeKeySep)
+
+	modified, err := json.Marshal(&info)
+	if err != nil {
+		return "", false, fmt.Errorf("marshalling marketplace SKU %q: %w", attrs.UsageType, err)
+	}
+	return string(modified), true, nil
+}
+
+// familyFromServiceName extracts the provider family from a marketplace servicename.
+// E.g. "Claude Sonnet 4.6 (Amazon Bedrock Edition)" → "anthropic".
+func familyFromServiceName(servicename string) string {
+	lower := strings.ToLower(servicename)
+	switch {
+	case strings.HasPrefix(lower, "claude"):
+		return "anthropic"
+	case strings.HasPrefix(lower, "cohere"):
+		return "cohere"
+	case strings.HasPrefix(lower, "meta"):
+		return "meta"
+	case strings.HasPrefix(lower, "jamba"), strings.HasPrefix(lower, "jurassic"):
+		return "ai21"
+	case strings.HasPrefix(lower, "stable"):
+		return "stability"
+	case strings.HasPrefix(lower, "palmyra"):
+		return "writer"
+	case strings.HasPrefix(lower, "twelvelabs"):
+		return "twelvelabs"
+	default:
+		if i := strings.Index(lower, " "); i >= 0 {
+			return lower[:i]
+		}
+		return lower
+	}
+}
+
+// classifyMarketplaceUsageType determines the metric direction from the usagetype suffix.
+// The AmazonBedrockFoundationModels usagetype encodes direction in the segment after "MP:region_".
+func classifyMarketplaceUsageType(usagetype string) (direction string, ok bool) {
+	lower := strings.ToLower(usagetype)
+	// lctx (long context) SKUs share the direction/tier of standard SKUs and would overwrite
+	// their prices; skip until long context is modelled as its own price tier.
+	for _, skip := range []string{"image", "video", "audio", "provisionedthroughput", "created_image", "request", "cache", "lctx"} {
+		if strings.Contains(lower, skip) {
+			return "", false
+		}
+	}
+	switch {
+	case strings.Contains(lower, "inputtokencount"), strings.Contains(lower, "input_tokens"):
+		return "input", true
+	case strings.Contains(lower, "outputtokencount"), strings.Contains(lower, "output_tokens"):
+		return "output", true
+	case strings.Contains(lower, "search_units"):
+		return "search", true
+	default:
+		return "", false
+	}
+}
+
+// extractMarketplacePriceTier derives price tier from the marketplace usagetype suffix.
+// Cross-region ("global") and quota-tier ("batch", "priority", "flex") can stack —
+// check batch/priority/flex before the global catch-all.
+func extractMarketplacePriceTier(usagetype string) string {
+	lower := strings.ToLower(usagetype)
+	isCrossRegion := strings.Contains(lower, "_global")
+
+	var quotaTier string
+	switch {
+	case strings.Contains(lower, "_batch"):
+		quotaTier = priceTierOnDemandBatch
+	case strings.Contains(lower, "_priority"):
+		quotaTier = priceTierOnDemandPriority
+	case strings.Contains(lower, "_flex"):
+		quotaTier = priceTierOnDemandFlex
+	}
+
+	if isCrossRegion && quotaTier != "" {
+		return priceTierCrossRegion + "_" + strings.TrimPrefix(quotaTier, "on_demand_")
+	}
+	if isCrossRegion {
+		return priceTierCrossRegion
+	}
+	if quotaTier != "" {
+		return quotaTier
+	}
+	return priceTierOnDemand
 }

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -445,6 +445,13 @@ func encodeBedrockMarketplacePriceJSON(raw string, familyFilter *regexp.Regexp) 
 		return "", false, nil
 	}
 
+	// The marketplace catalog re-lists the Claude 2.x / Instant / 3 Haiku / 3 Sonnet generation
+	// that the standard AmazonBedrock source already prices. Skip those here so each model is
+	// reported under one model_id. Claude 3 Opus, 3.5/3.7, and 4.x are marketplace-only and pass.
+	if _, legacy := legacyMarketplaceModelIDs[modelID]; legacy {
+		return "", false, nil
+	}
+
 	family := familyFromServiceName(attrs.ServiceName)
 	if !familyFilter.MatchString(family) {
 		return "", false, nil
@@ -488,13 +495,38 @@ func encodeBedrockMarketplacePriceJSON(raw string, familyFilter *regexp.Regexp) 
 	return string(modified), true, nil
 }
 
+// multiHyphen matches runs of two or more hyphens, produced when a servicename contains a
+// " - " separator (the surrounding spaces each become a hyphen alongside the literal one).
+var multiHyphen = regexp.MustCompile(`-{2,}`)
+
+// legacyMarketplaceModelIDs are normalized model_ids the standard AmazonBedrock source already
+// prices (Claude 2.x as Claude2.0/Claude2.1, Claude Instant as ClaudeInstant, plus Claude3Haiku
+// and Claude3Sonnet). The AmazonBedrockFoundationModels catalog re-lists this generation, which
+// would emit the same model twice under different model_ids; skip them in the marketplace path.
+var legacyMarketplaceModelIDs = map[string]struct{}{
+	"claude":              {},
+	"claude-100k":         {},
+	"claude-instant":      {},
+	"claude-instant-100k": {},
+	"claude-3-haiku":      {},
+	"claude-3-sonnet":     {},
+}
+
 // normalizeModelID converts a marketplace servicename into a canonical model_id slug:
-// lowercase with spaces replaced by hyphens. This matches the convention used by the
+// lowercase, with spaces replaced by hyphens. This matches the convention used by the
 // GCP vertex collector (pkg/google/vertex), so model IDs are uniform across the AI
 // pricing collectors.
-// Example: "Claude Sonnet 4.6" → "claude-sonnet-4.6"
+//
+// Parenthesis characters are dropped but their content is kept, so context variants stay
+// distinct (e.g. "Claude (100K)" → "claude-100k", not "claude"). Runs of hyphens from
+// " - " separators are collapsed, and leading/trailing hyphens are trimmed.
+// Example: "Cohere Embed 3 Model - English" → "cohere-embed-3-model-english"
 func normalizeModelID(raw string) string {
-	return strings.ToLower(strings.ReplaceAll(strings.TrimSpace(raw), " ", "-"))
+	s := strings.ToLower(strings.TrimSpace(raw))
+	s = strings.NewReplacer("(", "", ")", "").Replace(s)
+	s = strings.ReplaceAll(s, " ", "-")
+	s = multiHyphen.ReplaceAllString(s, "-")
+	return strings.Trim(s, "-")
 }
 
 // familyFromServiceName extracts the provider family from a marketplace servicename.

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -118,7 +118,6 @@ type bedrockMarketplaceProductInfo struct {
 type Config struct {
 	Regions       []ec2types.Region
 	PricingClient client.Client
-	Logger        *slog.Logger
 	AccountID     string
 	FamilyFilter  string // regex matched against the family label; see --aws.bedrock.families flag
 }
@@ -131,11 +130,8 @@ type Collector struct {
 	familyFilter *regexp.Regexp
 }
 
-func New(ctx context.Context, config *Config) (*Collector, error) {
-	logger := slog.Default()
-	if config.Logger != nil {
-		logger = config.Logger.With("collector", serviceName)
-	}
+func New(ctx context.Context, config *Config, logger *slog.Logger) (*Collector, error) {
+	logger = logger.With("collector", serviceName)
 
 	familyFilter, err := regexp.Compile(config.FamilyFilter)
 	if err != nil {

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -521,6 +521,10 @@ func encodeBedrockMarketplacePriceJSON(raw string, familyFilter *regexp.Regexp) 
 // " - " separator (the surrounding spaces each become a hyphen alongside the literal one).
 var multiHyphen = regexp.MustCompile(`-{2,}`)
 
+// cacheWriteTTL matches the TTL token in a cache-write usagetype (e.g. "1h", "5m"). A bare write
+// carries no token and defaults to 5 minutes; an unrecognized token means a TTL we do not model.
+var cacheWriteTTL = regexp.MustCompile(`\d+[hm]`)
+
 // normalizeModelID converts a marketplace servicename into a canonical model_id slug:
 // lowercase, with spaces replaced by hyphens, so model IDs are uniform across the AI
 // pricing collectors.
@@ -641,11 +645,17 @@ func marketplaceCacheOp(usagetype string) (op string, skip bool) {
 	case strings.Contains(lower, "cacheread") || strings.Contains(lower, "cache_read"):
 		return priceTierCacheRead, false
 	case strings.Contains(lower, "cachewrite") || strings.Contains(lower, "cache_write"):
-		if strings.Contains(lower, "1h") {
+		// Recognize the write TTL explicitly. AWS bills the bare write (no TTL token) at the
+		// 5-minute default and tags the 1-hour write with "1h". Any other TTL token is one we do
+		// not model yet, so skip it and surface it rather than silently labeling it a 5m write.
+		switch cacheWriteTTL.FindString(lower) {
+		case "", "5m":
+			return priceTierCacheWrite5m, false
+		case "1h":
 			return priceTierCacheWrite1h, false
+		default:
+			return "", true
 		}
-		// AWS bills the bare write (no TTL token) at the 5-minute default.
-		return priceTierCacheWrite5m, false
 	default:
 		// Cache storage (per token-hour, a different unit) and any cache shape that is neither a
 		// read nor a write: drop it rather than mislabel it as a 5-minute write.

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -30,6 +30,12 @@ const (
 	priceTierOnDemandPriority = "on_demand_priority"
 	priceTierCrossRegion      = "cross_region"
 
+	// Prompt-caching operations, emitted as price_tier values on the input metric. Reads are a
+	// single rate; writes split by cache TTL (5-minute default vs 1-hour).
+	priceTierCacheRead    = "cache_read"
+	priceTierCacheWrite5m = "cache_write_5m"
+	priceTierCacheWrite1h = "cache_write_1h"
+
 	// compositeKeySep separates the four fields encoded in the pricingstore usagetype key:
 	// family|direction|model_id|price_tier
 	compositeKeySep = "|"
@@ -462,12 +468,22 @@ func encodeBedrockMarketplacePriceJSON(raw string, familyFilter *regexp.Regexp) 
 		return "", false, nil
 	}
 
-	direction, ok := classifyMarketplaceUsageType(attrs.UsageType)
-	if !ok {
+	// Cache read/write are input-token operations; storage is per token-hour (a different unit)
+	// so it is skipped. Non-cache SKUs fall through to the normal direction classifier.
+	cacheOp, storage := marketplaceCacheOp(attrs.UsageType)
+	if storage {
 		return "", false, nil
 	}
+	direction := "input"
+	if cacheOp == "" {
+		var ok bool
+		direction, ok = classifyMarketplaceUsageType(attrs.UsageType)
+		if !ok {
+			return "", false, nil
+		}
+	}
 
-	priceTier := extractMarketplacePriceTier(attrs.UsageType)
+	priceTier := extractMarketplacePriceTier(attrs.UsageType, cacheOp)
 
 	for _, term := range info.Terms.OnDemand {
 		for _, pd := range term.PriceDimensions {
@@ -567,8 +583,9 @@ func familyFromServiceName(servicename string) string {
 func classifyMarketplaceUsageType(usagetype string) (direction string, ok bool) {
 	lower := strings.ToLower(usagetype)
 	// lctx (long context) SKUs share the direction/tier of standard SKUs and would overwrite
-	// their prices; skip until long context is modelled as its own price tier.
-	for _, skip := range []string{"image", "video", "audio", "provisionedthroughput", "created_image", "request", "cache", "lctx"} {
+	// their prices; skip until long context is modelled as its own price tier. Cache SKUs are
+	// handled by the caller before this point.
+	for _, skip := range []string{"image", "video", "audio", "provisionedthroughput", "created_image", "request", "lctx"} {
 		if strings.Contains(lower, skip) {
 			return "", false
 		}
@@ -588,28 +605,65 @@ func classifyMarketplaceUsageType(usagetype string) (direction string, ok bool) 
 // extractMarketplacePriceTier derives price tier from the marketplace usagetype suffix.
 // Cross-region ("global") and quota-tier ("batch", "priority", "flex") can stack —
 // check batch/priority/flex before the global catch-all.
-func extractMarketplacePriceTier(usagetype string) string {
-	lower := strings.ToLower(usagetype)
-	isCrossRegion := strings.Contains(lower, "_global")
+// composeTier builds a price_tier from its parts: an optional cross-region prefix, the base
+// operation (on_demand or a cache_* op), and an optional quota tier suffix (batch/flex/priority/
+// latency_optimized). Components stack, e.g. cross_region_cache_read, cache_write_1h,
+// on_demand_batch. Each distinct combination gets a distinct value, so SKUs that differ only by a
+// qualifier do not collide on one key.
+func composeTier(crossRegion bool, op, quota string) string {
+	if op == "" {
+		op = priceTierOnDemand
+	}
+	parts := make([]string, 0, 3)
+	if crossRegion {
+		parts = append(parts, priceTierCrossRegion)
+	}
+	// Drop a redundant on_demand when cross-region already carries the base meaning, matching the
+	// established names (cross_region, not cross_region_on_demand).
+	if !crossRegion || op != priceTierOnDemand {
+		parts = append(parts, op)
+	}
+	if quota != "" {
+		parts = append(parts, quota)
+	}
+	return strings.Join(parts, "_")
+}
 
-	var quotaTier string
+// marketplaceCacheOp returns the cache operation for a marketplace usagetype, and whether it is a
+// cache-storage SKU. Storage is priced per token-hour (a different unit), so the caller skips it.
+// Returns "" for non-cache SKUs. Reads are a single rate; writes split by 5-minute vs 1-hour TTL.
+func marketplaceCacheOp(usagetype string) (op string, storage bool) {
+	lower := strings.ToLower(usagetype)
+	if !strings.Contains(lower, "cache") {
+		return "", false
+	}
+	if strings.Contains(lower, "storage") {
+		return "", true
+	}
+	if strings.Contains(lower, "cacheread") || strings.Contains(lower, "cache_read") {
+		return priceTierCacheRead, false
+	}
+	if strings.Contains(lower, "1h") {
+		return priceTierCacheWrite1h, false
+	}
+	return priceTierCacheWrite5m, false
+}
+
+func extractMarketplacePriceTier(usagetype, cacheOp string) string {
+	lower := strings.ToLower(usagetype)
+	crossRegion := strings.Contains(lower, "_global")
+
+	var quota string
 	switch {
 	case strings.Contains(lower, "_batch"):
-		quotaTier = priceTierOnDemandBatch
+		quota = "batch"
 	case strings.Contains(lower, "_priority"):
-		quotaTier = priceTierOnDemandPriority
+		quota = "priority"
 	case strings.Contains(lower, "_flex"):
-		quotaTier = priceTierOnDemandFlex
+		quota = "flex"
+	case strings.Contains(lower, "latencyoptimized"):
+		quota = "latency_optimized"
 	}
 
-	if isCrossRegion && quotaTier != "" {
-		return priceTierCrossRegion + "_" + strings.TrimPrefix(quotaTier, "on_demand_")
-	}
-	if isCrossRegion {
-		return priceTierCrossRegion
-	}
-	if quotaTier != "" {
-		return quotaTier
-	}
-	return priceTierOnDemand
+	return composeTier(crossRegion, cacheOp, quota)
 }

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -457,13 +457,6 @@ func encodeBedrockMarketplacePriceJSON(raw string, familyFilter *regexp.Regexp) 
 		return "", false, nil
 	}
 
-	// The marketplace catalog re-lists the Claude 2.x / Instant / 3 Haiku / 3 Sonnet generation
-	// that the standard AmazonBedrock source already prices. Skip those here so each model is
-	// reported under one model_id. Claude 3 Opus, 3.5/3.7, and 4.x are marketplace-only and pass.
-	if _, legacy := legacyMarketplaceModelIDs[modelID]; legacy {
-		return "", false, nil
-	}
-
 	family := familyFromServiceName(attrs.ServiceName)
 	if !familyFilter.MatchString(family) {
 		return "", false, nil
@@ -510,19 +503,6 @@ func encodeBedrockMarketplacePriceJSON(raw string, familyFilter *regexp.Regexp) 
 // multiHyphen matches runs of two or more hyphens, produced when a servicename contains a
 // " - " separator (the surrounding spaces each become a hyphen alongside the literal one).
 var multiHyphen = regexp.MustCompile(`-{2,}`)
-
-// legacyMarketplaceModelIDs are normalized model_ids the standard AmazonBedrock source already
-// prices (Claude 2.x as Claude2.0/Claude2.1, Claude Instant as ClaudeInstant, plus Claude3Haiku
-// and Claude3Sonnet). The AmazonBedrockFoundationModels catalog re-lists this generation, which
-// would emit the same model twice under different model_ids; skip them in the marketplace path.
-var legacyMarketplaceModelIDs = map[string]struct{}{
-	"claude":              {},
-	"claude-100k":         {},
-	"claude-instant":      {},
-	"claude-instant-100k": {},
-	"claude-3-haiku":      {},
-	"claude-3-sonnet":     {},
-}
 
 // normalizeModelID converts a marketplace servicename into a canonical model_id slug:
 // lowercase, with spaces replaced by hyphens. This matches the convention used by the

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -77,6 +77,7 @@ type bedrockProductInfo struct {
 			RegionCode    string `json:"regionCode"`
 			InferenceType string `json:"inferenceType"`
 			Provider      string `json:"provider"`
+			Model         string `json:"model"`
 		} `json:"attributes"`
 	} `json:"product"`
 	Terms struct {
@@ -289,9 +290,20 @@ func encodeBedrockPriceJSON(raw string, familyFilter *regexp.Regexp) (string, bo
 		}
 	}
 
-	modelID, priceTier := parseBedrockModelID(attrs.UsageType)
-	if modelID == "" {
+	slug, priceTier := parseBedrockModelID(attrs.UsageType)
+	if slug == "" {
 		return "", false, nil
+	}
+
+	// Prefer the human-readable `model` attribute, normalized to the same lowercase-hyphen slug
+	// the marketplace source uses (e.g. "Claude 3 Sonnet" -> "claude-3-sonnet"), so model_id is
+	// uniform across both sources. Append the modality segment (e.g. -speech/-text) so models
+	// that AWS prices per modality under one `model` name (Nova Sonic) stay distinct instead of
+	// colliding on one key. SKUs without a `model` attribute (some Titan, Rerank) fall back to
+	// the normalized usagetype slug, keeping the same lowercase-hyphen style.
+	modelID := normalizeModelID(slug)
+	if normalized := normalizeModelID(attrs.Model); normalized != "" {
+		modelID = normalized + modalitySuffix(attrs.UsageType)
 	}
 
 	family := normalizeProvider(attrs.Provider)
@@ -527,6 +539,21 @@ func normalizeModelID(raw string) string {
 	s = strings.ReplaceAll(s, " ", "-")
 	s = multiHyphen.ReplaceAllString(s, "-")
 	return strings.Trim(s, "-")
+}
+
+// modalitySuffix returns the modality segment of a standard usagetype when present. AWS prices
+// some models (Nova Sonic) per modality at different rates while publishing a single `model`
+// name, so the modality must be folded into model_id to keep the variants distinct.
+func modalitySuffix(usagetype string) string {
+	lower := strings.ToLower(usagetype)
+	switch {
+	case strings.Contains(lower, "-speech-"):
+		return "-speech"
+	case strings.Contains(lower, "-text-"):
+		return "-text"
+	default:
+		return ""
+	}
 }
 
 // familyFromServiceName extracts the provider family from a marketplace servicename.

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -240,11 +240,18 @@ func newPriceFetcher(pricingClient client.Client, familyFilter *regexp.Regexp, l
 		if err != nil {
 			return nil, err
 		}
+		result := preprocessBedrockPrices(standard, familyFilter, logger)
+
+		// Marketplace pricing is best-effort. A failure fetching AmazonBedrockFoundationModels
+		// must not drop the standard AmazonBedrock pricing, so log and continue with the
+		// standard SKUs rather than failing the whole collector.
 		marketplace, err := pricingClient.ListBedrockMarketplacePrices(ctx, region)
 		if err != nil {
-			return nil, err
+			logger.LogAttrs(ctx, slog.LevelWarn, "failed to fetch Bedrock marketplace pricing, continuing with standard pricing only",
+				slog.String("region", region),
+				slog.String("error", err.Error()))
+			return result, nil
 		}
-		result := preprocessBedrockPrices(standard, familyFilter, logger)
 		result = append(result, preprocessBedrockMarketplacePrices(marketplace, familyFilter, logger)...)
 		return result, nil
 	}
@@ -433,7 +440,7 @@ func encodeBedrockMarketplacePriceJSON(raw string, familyFilter *regexp.Regexp) 
 	}
 
 	attrs := &info.Product.Attributes
-	modelID := strings.ReplaceAll(strings.TrimSuffix(attrs.ServiceName, marketplaceSuffix), " ", "_")
+	modelID := normalizeModelID(strings.TrimSuffix(attrs.ServiceName, marketplaceSuffix))
 	if modelID == "" {
 		return "", false, nil
 	}
@@ -481,8 +488,19 @@ func encodeBedrockMarketplacePriceJSON(raw string, familyFilter *regexp.Regexp) 
 	return string(modified), true, nil
 }
 
+// normalizeModelID converts a marketplace servicename into a canonical model_id slug:
+// lowercase with spaces replaced by hyphens. This matches the convention used by the
+// GCP vertex collector (pkg/google/vertex), so model IDs are uniform across the AI
+// pricing collectors.
+// Example: "Claude Sonnet 4.6" → "claude-sonnet-4.6"
+func normalizeModelID(raw string) string {
+	return strings.ToLower(strings.ReplaceAll(strings.TrimSpace(raw), " ", "-"))
+}
+
 // familyFromServiceName extracts the provider family from a marketplace servicename.
 // E.g. "Claude Sonnet 4.6 (Amazon Bedrock Edition)" → "anthropic".
+// Unrecognised providers return "unknown" rather than guessing from the first word,
+// which keeps the family label bounded and predictable.
 func familyFromServiceName(servicename string) string {
 	lower := strings.ToLower(servicename)
 	switch {
@@ -501,10 +519,7 @@ func familyFromServiceName(servicename string) string {
 	case strings.HasPrefix(lower, "twelvelabs"):
 		return "twelvelabs"
 	default:
-		if i := strings.Index(lower, " "); i >= 0 {
-			return lower[:i]
-		}
-		return lower
+		return "unknown"
 	}
 }
 

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -517,8 +517,7 @@ func encodeBedrockMarketplacePriceJSON(raw string, familyFilter *regexp.Regexp) 
 var multiHyphen = regexp.MustCompile(`-{2,}`)
 
 // normalizeModelID converts a marketplace servicename into a canonical model_id slug:
-// lowercase, with spaces replaced by hyphens. This matches the convention used by the
-// GCP vertex collector (pkg/google/vertex), so model IDs are uniform across the AI
+// lowercase, with spaces replaced by hyphens, so model IDs are uniform across the AI
 // pricing collectors.
 //
 // Parenthesis characters are dropped but their content is kept, so context variants stay

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -466,8 +466,13 @@ func encodeBedrockMarketplacePriceJSON(raw string, familyFilter *regexp.Regexp) 
 
 	// Cache read/write are input-token operations; storage is per token-hour (a different unit)
 	// so it is skipped. Non-cache SKUs fall through to the normal direction classifier.
-	cacheOp, storage := marketplaceCacheOp(attrs.UsageType)
-	if storage {
+	cacheOp, skipCache := marketplaceCacheOp(attrs.UsageType)
+	if skipCache {
+		// Storage (per token-hour, a different unit) is an expected skip; anything else is an
+		// unrecognized cache shape worth surfacing so we add it rather than mislabel it.
+		if !strings.Contains(strings.ToLower(attrs.UsageType), "storage") {
+			return "", false, fmt.Errorf("unrecognized cache SKU, skipping: %q", attrs.UsageType)
+		}
 		return "", false, nil
 	}
 	direction := "input"
@@ -627,21 +632,25 @@ func composeTier(crossRegion bool, op, quota string) string {
 // marketplaceCacheOp returns the cache operation for a marketplace usagetype, and whether it is a
 // cache-storage SKU. Storage is priced per token-hour (a different unit), so the caller skips it.
 // Returns "" for non-cache SKUs. Reads are a single rate; writes split by 5-minute vs 1-hour TTL.
-func marketplaceCacheOp(usagetype string) (op string, storage bool) {
+func marketplaceCacheOp(usagetype string) (op string, skip bool) {
 	lower := strings.ToLower(usagetype)
 	if !strings.Contains(lower, "cache") {
 		return "", false
 	}
-	if strings.Contains(lower, "storage") {
+	switch {
+	case strings.Contains(lower, "cacheread") || strings.Contains(lower, "cache_read"):
+		return priceTierCacheRead, false
+	case strings.Contains(lower, "cachewrite") || strings.Contains(lower, "cache_write"):
+		if strings.Contains(lower, "1h") {
+			return priceTierCacheWrite1h, false
+		}
+		// AWS bills the bare write (no TTL token) at the 5-minute default.
+		return priceTierCacheWrite5m, false
+	default:
+		// Cache storage (per token-hour, a different unit) and any cache shape that is neither a
+		// read nor a write: drop it rather than mislabel it as a 5-minute write.
 		return "", true
 	}
-	if strings.Contains(lower, "cacheread") || strings.Contains(lower, "cache_read") {
-		return priceTierCacheRead, false
-	}
-	if strings.Contains(lower, "1h") {
-		return priceTierCacheWrite1h, false
-	}
-	return priceTierCacheWrite5m, false
 }
 
 func extractMarketplacePriceTier(usagetype, cacheOp string) string {

--- a/pkg/aws/bedrock/bedrock_test.go
+++ b/pkg/aws/bedrock/bedrock_test.go
@@ -26,6 +26,10 @@ func TestNew_Succeeds(t *testing.T) {
 		ListBedrockPrices(gomock.Any(), "us-east-1").
 		Return([]string{inputPriceJSON("us-east-1", "USE1", "Claude3Sonnet", "Anthropic", "0.00300")}, nil).
 		Times(1)
+	pricingClient.EXPECT().
+		ListBedrockMarketplacePrices(gomock.Any(), "us-east-1").
+		Return([]string{}, nil).
+		Times(1)
 
 	collector, err := New(t.Context(), &Config{
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
@@ -69,6 +73,10 @@ func TestCollect_EmitsInputAndOutputTokenMetrics(t *testing.T) {
 			inputPriceJSON("us-east-1", "USE1", "Claude3Sonnet", "Anthropic", "0.00300"),
 			outputPriceJSON("us-east-1", "USE1", "Claude3Sonnet", "Anthropic", "0.01500"),
 		}, nil).
+		Times(1)
+	pricingClient.EXPECT().
+		ListBedrockMarketplacePrices(gomock.Any(), "us-east-1").
+		Return([]string{}, nil).
 		Times(1)
 
 	collector, err := New(t.Context(), &Config{
@@ -115,6 +123,10 @@ func TestCollect_EmitsMetricsForMultipleModels(t *testing.T) {
 			outputPriceJSON("us-east-1", "USE1", "NovaPro", "", "0.00320"),
 		}, nil).
 		Times(1)
+	pricingClient.EXPECT().
+		ListBedrockMarketplacePrices(gomock.Any(), "us-east-1").
+		Return([]string{}, nil).
+		Times(1)
 
 	collector, err := New(t.Context(), &Config{
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
@@ -139,6 +151,10 @@ func TestCollect_LabelsCrossRegionPriceTier(t *testing.T) {
 		Return([]string{
 			crossRegionInputPriceJSON("us-east-1", "USE1", "NovaPremier", "", "0.00600"),
 		}, nil).
+		Times(1)
+	pricingClient.EXPECT().
+		ListBedrockMarketplacePrices(gomock.Any(), "us-east-1").
+		Return([]string{}, nil).
 		Times(1)
 
 	collector, err := New(t.Context(), &Config{
@@ -169,6 +185,10 @@ func TestCollect_LabelsBatchPriceTier(t *testing.T) {
 		Return([]string{
 			batchInputPriceJSON("us-east-1", "USE1", "Claude3Sonnet", "Anthropic", "0.00150"),
 		}, nil).
+		Times(1)
+	pricingClient.EXPECT().
+		ListBedrockMarketplacePrices(gomock.Any(), "us-east-1").
+		Return([]string{}, nil).
 		Times(1)
 
 	collector, err := New(t.Context(), &Config{
@@ -202,6 +222,10 @@ func TestCollect_FamilyFilterRegexFiltersOtherFamilies(t *testing.T) {
 			searchUnitPriceJSON("us-east-1", "USE1", "cohere.rerank-english-v3", "Cohere", "0.00200"),
 		}, nil).
 		Times(1)
+	pricingClient.EXPECT().
+		ListBedrockMarketplacePrices(gomock.Any(), "us-east-1").
+		Return([]string{}, nil).
+		Times(1)
 
 	collector, err := New(t.Context(), &Config{
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
@@ -233,6 +257,10 @@ func TestCollect_FamilyFilterDefaultEmitsAllFamilies(t *testing.T) {
 			inputPriceJSON("us-east-1", "USE1", "Llama4-Scout-17B", "Meta", "0.00017"),
 			inputPriceJSON("us-east-1", "USE1", "NovaPro", "", "0.00080"),
 		}, nil).
+		Times(1)
+	pricingClient.EXPECT().
+		ListBedrockMarketplacePrices(gomock.Any(), "us-east-1").
+		Return([]string{}, nil).
 		Times(1)
 
 	collector, err := New(t.Context(), &Config{
@@ -281,6 +309,10 @@ func TestCollect_SkipsNonTextTokenSKUs(t *testing.T) {
 			rawPriceJSON("us-east-1", "USE1-Guardrail-AutomatedReasoningPolicyUnitsConsumed", "", "", "0.00017"),
 		}, nil).
 		Times(1)
+	pricingClient.EXPECT().
+		ListBedrockMarketplacePrices(gomock.Any(), "us-east-1").
+		Return([]string{}, nil).
+		Times(1)
 
 	collector, err := New(t.Context(), &Config{
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
@@ -302,6 +334,10 @@ func TestCollect_ReturnsContextErrWhenContextCancelled(t *testing.T) {
 	pricingClient := mockclient.NewMockClient(ctrl)
 	pricingClient.EXPECT().
 		ListBedrockPrices(gomock.Any(), "us-east-1").
+		Return([]string{}, nil).
+		Times(1)
+	pricingClient.EXPECT().
+		ListBedrockMarketplacePrices(gomock.Any(), "us-east-1").
 		Return([]string{}, nil).
 		Times(1)
 
@@ -511,4 +547,219 @@ func metricByName(results []*utils.MetricResult, fqName string) *utils.MetricRes
 		}
 	}
 	return nil
+}
+
+// marketplacePriceJSON builds a minimal AmazonBedrockFoundationModels SKU JSON item.
+func marketplacePriceJSON(servicename, usagetype, regionCode, price string) string {
+	return fmt.Sprintf(
+		`{"product":{"attributes":{"usagetype":%q,"regionCode":%q,"servicename":%q}},"terms":{"OnDemand":{"term1":{"priceDimensions":{"dim1":{"pricePerUnit":{"USD":%q}}}}}}}`,
+		usagetype, regionCode, servicename, price,
+	)
+}
+
+func TestFamilyFromServiceName(t *testing.T) {
+	tests := []struct {
+		servicename string
+		want        string
+	}{
+		{"Claude Sonnet 4.6 (Amazon Bedrock Edition)", "anthropic"},
+		{"Claude Opus 4 (Amazon Bedrock Edition)", "anthropic"},
+		{"Cohere Rerank v3.5 (Amazon Bedrock Edition)", "cohere"},
+		{"Cohere Embed 4 Model (Amazon Bedrock Edition)", "cohere"},
+		{"Meta Llama 2 Chat 70B (Amazon Bedrock Edition)", "meta"},
+		{"Jamba 1.5 Large (Amazon Bedrock Edition)", "ai21"},
+		{"Jurassic-2 Ultra (Amazon Bedrock Edition)", "ai21"},
+		{"Stable Diffusion 3 Large v1.0 (Amazon Bedrock Edition)", "stability"},
+		{"Palmyra X5 (Amazon Bedrock Edition)", "writer"},
+		{"TwelveLabs Marengo Embed 3.0 (Amazon Bedrock Edition)", "twelvelabs"},
+		{"Unknown Model (Amazon Bedrock Edition)", "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.servicename, func(t *testing.T) {
+			assert.Equal(t, tt.want, familyFromServiceName(tt.servicename))
+		})
+	}
+}
+
+func TestClassifyMarketplaceUsageType(t *testing.T) {
+	tests := []struct {
+		usagetype     string
+		wantDirection string
+		wantOK        bool
+	}{
+		{"USE1-MP:USE1_InputTokenCount-Units", "input", true},
+		{"USE1-MP:USE1_InputTokenCount_Global-Units", "input", true},
+		{"USE1-MP:USE1_InputTokenCount_Global_Batch-Units", "input", true},
+		{"USE1-MP:USE1_OutputTokenCount-Units", "output", true},
+		{"USE1-MP:USE1_OutputTokenCount_Global-Units", "output", true},
+		{"USE1-MP:USE1_search_units-Units", "search", true},
+		// SKUs that must be skipped:
+		{"USE1-MP:USE1_InputImageCount-Units", "", false},
+		{"USE1-MP:USE1_ProvisionedThroughput_1MonthCommit_ModelUnits_Usage-Units", "", false},
+		{"USE1-MP:USE1_created_image-Units", "", false},
+		// Cache tokens contain "InputTokenCount" but must be skipped — explicit guard against misclassification.
+		{"USE1-MP:USE1_CacheReadInputTokenCount-Units", "", false},
+		{"USE1-MP:USE1_CacheWriteInputTokenCount-Units", "", false},
+		{"USE1-MP:USE1_CacheWrite1hInputTokenCount_Global-Units", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.usagetype, func(t *testing.T) {
+			direction, ok := classifyMarketplaceUsageType(tt.usagetype)
+			assert.Equal(t, tt.wantDirection, direction)
+			assert.Equal(t, tt.wantOK, ok)
+		})
+	}
+}
+
+func TestExtractMarketplacePriceTier(t *testing.T) {
+	tests := []struct {
+		usagetype string
+		want      string
+	}{
+		{"USE1-MP:USE1_InputTokenCount-Units", "on_demand"},
+		{"USE1-MP:USE1_InputTokenCount_Global-Units", "cross_region"},
+		{"USE1-MP:USE1_InputTokenCount_Batch-Units", "on_demand_batch"},
+		{"USE1-MP:USE1_InputTokenCount_Global_Batch-Units", "cross_region_batch"},
+		{"USE1-MP:USE1_OutputTokenCount_Global-Units", "cross_region"},
+		{"USE1-MP:USE1_search_units-Units", "on_demand"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.usagetype, func(t *testing.T) {
+			assert.Equal(t, tt.want, extractMarketplacePriceTier(tt.usagetype))
+		})
+	}
+}
+
+func TestCollect_EmitsMarketplaceTokenMetrics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pricingClient := mockclient.NewMockClient(ctrl)
+	pricingClient.EXPECT().
+		ListBedrockPrices(gomock.Any(), "us-east-1").
+		Return([]string{}, nil).
+		Times(1)
+	pricingClient.EXPECT().
+		ListBedrockMarketplacePrices(gomock.Any(), "us-east-1").
+		Return([]string{
+			// Claude Sonnet 4.6: $3.00/M input, $15.00/M output — expect $0.003/1K and $0.015/1K
+			marketplacePriceJSON("Claude Sonnet 4.6 (Amazon Bedrock Edition)", "USE1-MP:USE1_InputTokenCount-Units", "us-east-1", "3.0"),
+			marketplacePriceJSON("Claude Sonnet 4.6 (Amazon Bedrock Edition)", "USE1-MP:USE1_OutputTokenCount-Units", "us-east-1", "15.0"),
+		}, nil).
+		Times(1)
+
+	collector, err := New(t.Context(), &Config{
+		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
+		PricingClient: pricingClient,
+		Logger:        testLogger(),
+		AccountID:     "123456789012",
+	})
+	require.NoError(t, err)
+
+	results, err := collectMetricResults(t, collector)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	inputMetric := metricByName(results, "cloudcost_aws_bedrock_token_input_usd_per_1k_tokens")
+	require.NotNil(t, inputMetric)
+	assert.Equal(t, "Claude_Sonnet_4.6", inputMetric.Labels["model_id"])
+	assert.Equal(t, "anthropic", inputMetric.Labels["family"])
+	assert.Equal(t, "on_demand", inputMetric.Labels["price_tier"])
+	assert.InDelta(t, 0.003, inputMetric.Value, 1e-9)
+
+	outputMetric := metricByName(results, "cloudcost_aws_bedrock_token_output_usd_per_1k_tokens")
+	require.NotNil(t, outputMetric)
+	assert.InDelta(t, 0.015, outputMetric.Value, 1e-9)
+}
+
+func TestCollect_EmitsMarketplaceSearchUnitMetrics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pricingClient := mockclient.NewMockClient(ctrl)
+	pricingClient.EXPECT().
+		ListBedrockPrices(gomock.Any(), "us-east-1").
+		Return([]string{}, nil).
+		Times(1)
+	pricingClient.EXPECT().
+		ListBedrockMarketplacePrices(gomock.Any(), "us-east-1").
+		Return([]string{
+			// Cohere Rerank v3.5: $0.002/search unit — expect $2.00/1K search units
+			marketplacePriceJSON("Cohere Rerank v3.5 (Amazon Bedrock Edition)", "USE1-MP:USE1_search_units-Units", "us-east-1", "0.002"),
+		}, nil).
+		Times(1)
+
+	collector, err := New(t.Context(), &Config{
+		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
+		PricingClient: pricingClient,
+		Logger:        testLogger(),
+		AccountID:     "123456789012",
+	})
+	require.NoError(t, err)
+
+	results, err := collectMetricResults(t, collector)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	m := results[0]
+	assert.Equal(t, "cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units", m.FqName)
+	assert.Equal(t, "Cohere_Rerank_v3.5", m.Labels["model_id"])
+	assert.Equal(t, "cohere", m.Labels["family"])
+	assert.InDelta(t, 2.0, m.Value, 1e-9)
+}
+
+func TestCollect_MarketplaceFamilyFilterApplied(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pricingClient := mockclient.NewMockClient(ctrl)
+	pricingClient.EXPECT().
+		ListBedrockPrices(gomock.Any(), "us-east-1").
+		Return([]string{}, nil).
+		Times(1)
+	pricingClient.EXPECT().
+		ListBedrockMarketplacePrices(gomock.Any(), "us-east-1").
+		Return([]string{
+			marketplacePriceJSON("Claude Sonnet 4.6 (Amazon Bedrock Edition)", "USE1-MP:USE1_InputTokenCount-Units", "us-east-1", "3.0"),
+			marketplacePriceJSON("Cohere Rerank v3.5 (Amazon Bedrock Edition)", "USE1-MP:USE1_search_units-Units", "us-east-1", "0.002"),
+		}, nil).
+		Times(1)
+
+	collector, err := New(t.Context(), &Config{
+		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
+		PricingClient: pricingClient,
+		FamilyFilter:  "anthropic",
+		Logger:        testLogger(),
+		AccountID:     "123456789012",
+	})
+	require.NoError(t, err)
+
+	results, err := collectMetricResults(t, collector)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "anthropic", results[0].Labels["family"])
+}
+
+func TestNew_ReturnsErrorWhenMarketplacePricingAPIUnavailable(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pricingClient := mockclient.NewMockClient(ctrl)
+	pricingClient.EXPECT().
+		ListBedrockPrices(gomock.Any(), "us-east-1").
+		Return([]string{}, nil).
+		Times(1)
+	pricingClient.EXPECT().
+		ListBedrockMarketplacePrices(gomock.Any(), "us-east-1").
+		Return(nil, fmt.Errorf("marketplace API unavailable")).
+		Times(1)
+
+	collector, err := New(t.Context(), &Config{
+		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
+		PricingClient: pricingClient,
+		Logger:        testLogger(),
+	})
+
+	assert.Nil(t, collector)
+	require.Error(t, err)
 }

--- a/pkg/aws/bedrock/bedrock_test.go
+++ b/pkg/aws/bedrock/bedrock_test.go
@@ -764,10 +764,7 @@ func TestClassifyMarketplaceUsageType(t *testing.T) {
 		{"USE1-MP:USE1_InputImageCount-Units", "", false},
 		{"USE1-MP:USE1_ProvisionedThroughput_1MonthCommit_ModelUnits_Usage-Units", "", false},
 		{"USE1-MP:USE1_created_image-Units", "", false},
-		// Cache tokens contain "InputTokenCount" but must be skipped — explicit guard against misclassification.
-		{"USE1-MP:USE1_CacheReadInputTokenCount-Units", "", false},
-		{"USE1-MP:USE1_CacheWriteInputTokenCount-Units", "", false},
-		{"USE1-MP:USE1_CacheWrite1hInputTokenCount_Global-Units", "", false},
+		// Cache SKUs are handled by marketplaceCacheOp before this classifier; see TestMarketplaceCacheOp.
 	}
 	for _, tt := range tests {
 		t.Run(tt.usagetype, func(t *testing.T) {
@@ -781,20 +778,97 @@ func TestClassifyMarketplaceUsageType(t *testing.T) {
 func TestExtractMarketplacePriceTier(t *testing.T) {
 	tests := []struct {
 		usagetype string
+		cacheOp   string
 		want      string
 	}{
-		{"USE1-MP:USE1_InputTokenCount-Units", "on_demand"},
-		{"USE1-MP:USE1_InputTokenCount_Global-Units", "cross_region"},
-		{"USE1-MP:USE1_InputTokenCount_Batch-Units", "on_demand_batch"},
-		{"USE1-MP:USE1_InputTokenCount_Global_Batch-Units", "cross_region_batch"},
-		{"USE1-MP:USE1_OutputTokenCount_Global-Units", "cross_region"},
-		{"USE1-MP:USE1_search_units-Units", "on_demand"},
+		{"USE1-MP:USE1_InputTokenCount-Units", "", "on_demand"},
+		{"USE1-MP:USE1_InputTokenCount_Global-Units", "", "cross_region"},
+		{"USE1-MP:USE1_InputTokenCount_Batch-Units", "", "on_demand_batch"},
+		{"USE1-MP:USE1_InputTokenCount_Global_Batch-Units", "", "cross_region_batch"},
+		{"USE1-MP:USE1_OutputTokenCount_Global-Units", "", "cross_region"},
+		{"USE1-MP:USE1_search_units-Units", "", "on_demand"},
+		// Latency-optimized is its own quota tier (does not collide with on_demand).
+		{"USE1-MP:USE1_InputTokenCount_LatencyOptimized-Units", "", "on_demand_latency_optimized"},
+		// Cache operations fold into the tier and stack with cross-region.
+		{"USE1-MP:USE1_CacheReadInputTokenCount-Units", "cache_read", "cache_read"},
+		{"USE1-MP:USE1_CacheReadInputTokenCount_Global-Units", "cache_read", "cross_region_cache_read"},
+		{"USE1-MP:USE1_CacheWriteInputTokenCount-Units", "cache_write_5m", "cache_write_5m"},
+		{"USE1-MP:USE1_CacheWrite1hInputTokenCount-Units", "cache_write_1h", "cache_write_1h"},
+		{"USE1-MP:USE1_CacheWrite1hInputTokenCount_Global-Units", "cache_write_1h", "cross_region_cache_write_1h"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.usagetype, func(t *testing.T) {
-			assert.Equal(t, tt.want, extractMarketplacePriceTier(tt.usagetype))
+			assert.Equal(t, tt.want, extractMarketplacePriceTier(tt.usagetype, tt.cacheOp))
 		})
 	}
+}
+
+func TestMarketplaceCacheOp(t *testing.T) {
+	tests := []struct {
+		usagetype   string
+		wantOp      string
+		wantStorage bool
+	}{
+		{"USE1-MP:USE1_CacheReadInputTokenCount-Units", "cache_read", false},
+		{"USE1-MP:USE1_CacheReadInputTokenCount_Global-Units", "cache_read", false},
+		{"USE1-MP:USE1_CacheWriteInputTokenCount-Units", "cache_write_5m", false},
+		{"USE1-MP:USE1_CacheWrite1hInputTokenCount-Units", "cache_write_1h", false},
+		{"USE1-MP:USE1_cache_write_tokens_1h_standard-Units", "cache_write_1h", false},
+		{"USE1-MP:USE1_InputTokenCount-Units", "", false}, // not cache
+		{"USE1-MP:USE1_CacheStorage-Units", "", true},     // storage skipped
+	}
+	for _, tt := range tests {
+		t.Run(tt.usagetype, func(t *testing.T) {
+			op, storage := marketplaceCacheOp(tt.usagetype)
+			assert.Equal(t, tt.wantOp, op)
+			assert.Equal(t, tt.wantStorage, storage)
+		})
+	}
+}
+
+func TestCollect_EmitsMarketplaceCacheMetrics(t *testing.T) {
+	// Cache read/write are emitted on the input metric with cache_* price_tier values; storage
+	// (per token-hour) is skipped.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pricingClient := mockclient.NewMockClient(ctrl)
+	pricingClient.EXPECT().
+		ListBedrockPrices(gomock.Any(), "us-east-1").
+		Return([]string{}, nil).
+		Times(1)
+	pricingClient.EXPECT().
+		ListBedrockMarketplacePrices(gomock.Any(), "us-east-1").
+		Return([]string{
+			marketplacePriceJSON("Claude Sonnet 4.6 (Amazon Bedrock Edition)", "USE1-MP:USE1_CacheReadInputTokenCount-Units", "us-east-1", "0.3"),
+			marketplacePriceJSON("Claude Sonnet 4.6 (Amazon Bedrock Edition)", "USE1-MP:USE1_CacheWriteInputTokenCount-Units", "us-east-1", "3.75"),
+			marketplacePriceJSON("Claude Sonnet 4.6 (Amazon Bedrock Edition)", "USE1-MP:USE1_CacheWrite1hInputTokenCount_Global-Units", "us-east-1", "6.0"),
+			// Storage SKU must be skipped.
+			marketplacePriceJSON("Claude Sonnet 4.6 (Amazon Bedrock Edition)", "USE1-MP:USE1_CacheStorage-Units", "us-east-1", "0.07"),
+		}, nil).
+		Times(1)
+
+	collector, err := New(t.Context(), &Config{
+		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
+		PricingClient: pricingClient,
+		Logger:        testLogger(),
+		AccountID:     "123456789012",
+	})
+	require.NoError(t, err)
+
+	results, err := collectMetricResults(t, collector)
+	require.NoError(t, err)
+	require.Len(t, results, 3, "read + write_5m + write_1h emitted; storage skipped")
+
+	byTier := map[string]float64{}
+	for _, r := range results {
+		require.Equal(t, "cloudcost_aws_bedrock_input_usd_per_1k_tokens", r.FqName)
+		require.Equal(t, "claude-sonnet-4.6", r.Labels["model_id"])
+		byTier[r.Labels["price_tier"]] = r.Value
+	}
+	assert.InDelta(t, 0.0003, byTier["cache_read"], 1e-9)      // 0.3/1M
+	assert.InDelta(t, 0.00375, byTier["cache_write_5m"], 1e-9) // 3.75/1M
+	assert.InDelta(t, 0.006, byTier["cross_region_cache_write_1h"], 1e-9)
 }
 
 func TestCollect_EmitsMarketplaceTokenMetrics(t *testing.T) {

--- a/pkg/aws/bedrock/bedrock_test.go
+++ b/pkg/aws/bedrock/bedrock_test.go
@@ -662,7 +662,7 @@ func TestCollect_EmitsMarketplaceTokenMetrics(t *testing.T) {
 
 	inputMetric := metricByName(results, "cloudcost_aws_bedrock_token_input_usd_per_1k_tokens")
 	require.NotNil(t, inputMetric)
-	assert.Equal(t, "Claude_Sonnet_4.6", inputMetric.Labels["model_id"])
+	assert.Equal(t, "claude-sonnet-4.6", inputMetric.Labels["model_id"])
 	assert.Equal(t, "anthropic", inputMetric.Labels["family"])
 	assert.Equal(t, "on_demand", inputMetric.Labels["price_tier"])
 	assert.InDelta(t, 0.003, inputMetric.Value, 1e-9)
@@ -703,7 +703,7 @@ func TestCollect_EmitsMarketplaceSearchUnitMetrics(t *testing.T) {
 
 	m := results[0]
 	assert.Equal(t, "cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units", m.FqName)
-	assert.Equal(t, "Cohere_Rerank_v3.5", m.Labels["model_id"])
+	assert.Equal(t, "cohere-rerank-v3.5", m.Labels["model_id"])
 	assert.Equal(t, "cohere", m.Labels["family"])
 	assert.InDelta(t, 2.0, m.Value, 1e-9)
 }
@@ -740,14 +740,16 @@ func TestCollect_MarketplaceFamilyFilterApplied(t *testing.T) {
 	assert.Equal(t, "anthropic", results[0].Labels["family"])
 }
 
-func TestNew_ReturnsErrorWhenMarketplacePricingAPIUnavailable(t *testing.T) {
+func TestNew_DegradesToStandardPricingWhenMarketplaceAPIUnavailable(t *testing.T) {
+	// Marketplace pricing is best-effort: a marketplace API failure must not drop standard
+	// Bedrock pricing or fail collector creation.
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	pricingClient := mockclient.NewMockClient(ctrl)
 	pricingClient.EXPECT().
 		ListBedrockPrices(gomock.Any(), "us-east-1").
-		Return([]string{}, nil).
+		Return([]string{inputPriceJSON("us-east-1", "USE1", "Claude3Sonnet", "Anthropic", "0.00300")}, nil).
 		Times(1)
 	pricingClient.EXPECT().
 		ListBedrockMarketplacePrices(gomock.Any(), "us-east-1").
@@ -758,8 +760,16 @@ func TestNew_ReturnsErrorWhenMarketplacePricingAPIUnavailable(t *testing.T) {
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		PricingClient: pricingClient,
 		Logger:        testLogger(),
+		AccountID:     "123456789012",
 	})
+	require.NoError(t, err)
+	require.NotNil(t, collector)
 
-	assert.Nil(t, collector)
-	require.Error(t, err)
+	results, err := collectMetricResults(t, collector)
+	require.NoError(t, err)
+
+	// Standard pricing still flows through despite the marketplace failure.
+	inputMetric := metricByName(results, "cloudcost_aws_bedrock_token_input_usd_per_1k_tokens")
+	require.NotNil(t, inputMetric)
+	assert.Equal(t, "Claude3Sonnet", inputMetric.Labels["model_id"])
 }

--- a/pkg/aws/bedrock/bedrock_test.go
+++ b/pkg/aws/bedrock/bedrock_test.go
@@ -557,6 +557,73 @@ func marketplacePriceJSON(servicename, usagetype, regionCode, price string) stri
 	)
 }
 
+func TestCollect_SkipsLegacyClaudeCoveredByStandardSource(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pricingClient := mockclient.NewMockClient(ctrl)
+	pricingClient.EXPECT().
+		ListBedrockPrices(gomock.Any(), "us-east-1").
+		Return([]string{}, nil).
+		Times(1)
+	pricingClient.EXPECT().
+		ListBedrockMarketplacePrices(gomock.Any(), "us-east-1").
+		Return([]string{
+			// Legacy generation the standard source already prices: must be skipped.
+			marketplacePriceJSON("Claude 3 Sonnet (Amazon Bedrock Edition)", "USE1-MP:USE1_InputTokenCount-Units", "us-east-1", "3.0"),
+			marketplacePriceJSON("Claude 3 Haiku (Amazon Bedrock Edition)", "USE1-MP:USE1_InputTokenCount-Units", "us-east-1", "0.25"),
+			marketplacePriceJSON("Claude Instant (Amazon Bedrock Edition)", "USE1-MP:USE1_InputTokenCount-Units", "us-east-1", "0.8"),
+			// Marketplace-only: must pass through.
+			marketplacePriceJSON("Claude 3 Opus (Amazon Bedrock Edition)", "USE1-MP:USE1_InputTokenCount-Units", "us-east-1", "15.0"),
+			marketplacePriceJSON("Claude Sonnet 4.6 (Amazon Bedrock Edition)", "USE1-MP:USE1_InputTokenCount-Units", "us-east-1", "3.0"),
+		}, nil).
+		Times(1)
+
+	collector, err := New(t.Context(), &Config{
+		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
+		PricingClient: pricingClient,
+		Logger:        testLogger(),
+		AccountID:     "123456789012",
+	})
+	require.NoError(t, err)
+
+	results, err := collectMetricResults(t, collector)
+	require.NoError(t, err)
+
+	emitted := map[string]bool{}
+	for _, r := range results {
+		emitted[r.Labels["model_id"]] = true
+	}
+	assert.False(t, emitted["claude-3-sonnet"], "legacy claude-3-sonnet should be skipped")
+	assert.False(t, emitted["claude-3-haiku"], "legacy claude-3-haiku should be skipped")
+	assert.False(t, emitted["claude-instant"], "legacy claude-instant should be skipped")
+	assert.True(t, emitted["claude-3-opus"], "marketplace-only claude-3-opus should pass")
+	assert.True(t, emitted["claude-sonnet-4.6"], "claude-sonnet-4.6 should pass")
+}
+
+func TestNormalizeModelID(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want string
+	}{
+		{"Claude Sonnet 4.6", "claude-sonnet-4.6"},
+		{"Cohere Rerank v3.5", "cohere-rerank-v3.5"},
+		// " - " separators collapse to a single hyphen instead of "---".
+		{"Cohere Embed 3 Model - English", "cohere-embed-3-model-english"},
+		{"Cohere Generate Model - Command Light", "cohere-generate-model-command-light"},
+		// Parenthesis content is kept (sans parens) so context variants stay distinct.
+		{"Claude (100K)", "claude-100k"},
+		{"Claude Instant (100K)", "claude-instant-100k"},
+		{"Claude", "claude"},
+		{"  Padded Name  ", "padded-name"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeModelID(tt.raw))
+		})
+	}
+}
+
 func TestFamilyFromServiceName(t *testing.T) {
 	tests := []struct {
 		servicename string

--- a/pkg/aws/bedrock/bedrock_test.go
+++ b/pkg/aws/bedrock/bedrock_test.go
@@ -804,6 +804,10 @@ func TestMarketplaceCacheOp(t *testing.T) {
 		{"USE1-MP:USE1_CacheStorage-Units", "", true},     // storage: skipped
 		// A cache shape that is neither read nor write must be skipped, not labeled a 5m write.
 		{"USE1-MP:USE1_CacheValidationCount-Units", "", true},
+		// A write with an unrecognized TTL must be skipped, not defaulted to 5m.
+		{"USE1-MP:USE1_CacheWrite30mInputTokenCount-Units", "", true},
+		// An explicit 5m write is recognized as 5m.
+		{"USE1-MP:USE1_CacheWrite5mInputTokenCount-Units", "cache_write_5m", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.usagetype, func(t *testing.T) {

--- a/pkg/aws/bedrock/bedrock_test.go
+++ b/pkg/aws/bedrock/bedrock_test.go
@@ -94,7 +94,10 @@ func TestCollect_EmitsInputAndOutputTokenMetrics(t *testing.T) {
 	inputMetric := metricByName(results, "cloudcost_aws_bedrock_input_usd_per_1k_tokens")
 	require.NotNil(t, inputMetric)
 	assert.Equal(t, "us-east-1", inputMetric.Labels["region"])
-	assert.Equal(t, "Claude3Sonnet", inputMetric.Labels["model_id"])
+	// These fixtures omit the `model` attribute, so model_id is the normalized usagetype slug
+	// (fallback path). Real Claude SKUs carry `model`, yielding claude-3-sonnet; see
+	// TestCollect_StandardModelIDUsesModelAttribute.
+	assert.Equal(t, "claude3sonnet", inputMetric.Labels["model_id"])
 	assert.Equal(t, "anthropic", inputMetric.Labels["family"])
 	assert.Equal(t, "on_demand", inputMetric.Labels["price_tier"])
 	assert.Equal(t, "123456789012", inputMetric.Labels["account_id"])
@@ -103,7 +106,7 @@ func TestCollect_EmitsInputAndOutputTokenMetrics(t *testing.T) {
 	outputMetric := metricByName(results, "cloudcost_aws_bedrock_output_usd_per_1k_tokens")
 	require.NotNil(t, outputMetric)
 	assert.Equal(t, "us-east-1", outputMetric.Labels["region"])
-	assert.Equal(t, "Claude3Sonnet", outputMetric.Labels["model_id"])
+	assert.Equal(t, "claude3sonnet", outputMetric.Labels["model_id"])
 	assert.Equal(t, "anthropic", outputMetric.Labels["family"])
 	assert.Equal(t, "on_demand", outputMetric.Labels["price_tier"])
 	assert.InDelta(t, 0.015, outputMetric.Value, 1e-9)
@@ -172,7 +175,7 @@ func TestCollect_LabelsCrossRegionPriceTier(t *testing.T) {
 	m := results[0]
 	assert.Equal(t, "cross_region", m.Labels["price_tier"])
 	assert.Equal(t, "amazon", m.Labels["family"])
-	assert.Equal(t, "NovaPremier", m.Labels["model_id"])
+	assert.Equal(t, "novapremier", m.Labels["model_id"])
 }
 
 func TestCollect_LabelsBatchPriceTier(t *testing.T) {
@@ -206,7 +209,7 @@ func TestCollect_LabelsBatchPriceTier(t *testing.T) {
 	m := results[0]
 	assert.Equal(t, "on_demand_batch", m.Labels["price_tier"])
 	assert.Equal(t, "anthropic", m.Labels["family"])
-	assert.Equal(t, "Claude3Sonnet", m.Labels["model_id"])
+	assert.Equal(t, "claude3sonnet", m.Labels["model_id"])
 }
 
 func TestCollect_FamilyFilterRegexFiltersOtherFamilies(t *testing.T) {
@@ -242,7 +245,7 @@ func TestCollect_FamilyFilterRegexFiltersOtherFamilies(t *testing.T) {
 
 	m := results[0]
 	assert.Equal(t, "anthropic", m.Labels["family"])
-	assert.Equal(t, "Claude3Sonnet", m.Labels["model_id"])
+	assert.Equal(t, "claude3sonnet", m.Labels["model_id"])
 }
 
 func TestCollect_FamilyFilterDefaultEmitsAllFamilies(t *testing.T) {
@@ -492,11 +495,22 @@ func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
-// rawPriceJSON builds a minimal Pricing API JSON item with explicit inferenceType and provider.
+// rawPriceJSON builds a minimal Pricing API JSON item with explicit inferenceType and provider,
+// and no `model` attribute. SKUs built with it exercise the usagetype-slug fallback in
+// encodeBedrockPriceJSON (the path for the rare SKU AWS publishes without a `model` attribute).
 func rawPriceJSON(regionCode, usagetype, inferenceType, provider, price string) string {
 	return fmt.Sprintf(
 		`{"product":{"attributes":{"usagetype":%q,"regionCode":%q,"inferenceType":%q,"provider":%q}},"terms":{"OnDemand":{"term1":{"priceDimensions":{"dim1":{"pricePerUnit":{"USD":%q}}}}}}}`,
 		usagetype, regionCode, inferenceType, provider, price,
+	)
+}
+
+// modelPriceJSON builds a standard SKU that includes the human-readable `model` attribute, which
+// is what the live AWS Pricing API returns. model_id is derived from `model`, not the usagetype.
+func modelPriceJSON(regionCode, usagetype, inferenceType, provider, model, price string) string {
+	return fmt.Sprintf(
+		`{"product":{"attributes":{"usagetype":%q,"regionCode":%q,"inferenceType":%q,"provider":%q,"model":%q}},"terms":{"OnDemand":{"term1":{"priceDimensions":{"dim1":{"pricePerUnit":{"USD":%q}}}}}}}`,
+		usagetype, regionCode, inferenceType, provider, model, price,
 	)
 }
 
@@ -622,6 +636,83 @@ func TestNormalizeModelID(t *testing.T) {
 			assert.Equal(t, tt.want, normalizeModelID(tt.raw))
 		})
 	}
+}
+
+func TestCollect_StandardModelIDUsesModelAttribute(t *testing.T) {
+	// The standard source derives model_id from the human-readable `model` attribute, normalized
+	// to the same lowercase-hyphen slug the marketplace source uses, so the two match.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pricingClient := mockclient.NewMockClient(ctrl)
+	pricingClient.EXPECT().
+		ListBedrockPrices(gomock.Any(), "us-east-1").
+		Return([]string{
+			modelPriceJSON("us-east-1", "USE1-Claude3Sonnet-input-tokens", "Input tokens", "Anthropic", "Claude 3 Sonnet", "0.00300"),
+			modelPriceJSON("us-east-1", "USE1-Llama3-1-405B-input-tokens", "Input tokens", "Meta", "Llama 3.1 405B", "0.00240"),
+		}, nil).
+		Times(1)
+	pricingClient.EXPECT().
+		ListBedrockMarketplacePrices(gomock.Any(), "us-east-1").
+		Return([]string{}, nil).
+		Times(1)
+
+	collector, err := New(t.Context(), &Config{
+		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
+		PricingClient: pricingClient,
+		Logger:        testLogger(),
+		AccountID:     "123456789012",
+	})
+	require.NoError(t, err)
+
+	results, err := collectMetricResults(t, collector)
+	require.NoError(t, err)
+
+	ids := map[string]bool{}
+	for _, r := range results {
+		ids[r.Labels["model_id"]] = true
+	}
+	assert.True(t, ids["claude-3-sonnet"], "expected normalized claude-3-sonnet, got %v", ids)
+	assert.True(t, ids["llama-3.1-405b"], "expected normalized llama-3.1-405b, got %v", ids)
+}
+
+func TestCollect_StandardModelIDDisambiguatesNovaSonicModality(t *testing.T) {
+	// Nova Sonic prices text and speech tokens differently while publishing one `model` name.
+	// The modality must fold into model_id so the two prices do not collide on a single key.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	pricingClient := mockclient.NewMockClient(ctrl)
+	pricingClient.EXPECT().
+		ListBedrockPrices(gomock.Any(), "us-east-1").
+		Return([]string{
+			modelPriceJSON("us-east-1", "USE1-NovaSonic-text-input-tokens", "Input tokens", "", "Nova Sonic", "0.00006"),
+			modelPriceJSON("us-east-1", "USE1-NovaSonic-speech-input-tokens", "Input tokens", "", "Nova Sonic", "0.00340"),
+		}, nil).
+		Times(1)
+	pricingClient.EXPECT().
+		ListBedrockMarketplacePrices(gomock.Any(), "us-east-1").
+		Return([]string{}, nil).
+		Times(1)
+
+	collector, err := New(t.Context(), &Config{
+		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
+		PricingClient: pricingClient,
+		Logger:        testLogger(),
+		AccountID:     "123456789012",
+	})
+	require.NoError(t, err)
+
+	results, err := collectMetricResults(t, collector)
+	require.NoError(t, err)
+	require.Len(t, results, 2, "text and speech must not collide into one series")
+
+	byID := map[string]float64{}
+	for _, r := range results {
+		byID[r.Labels["model_id"]] = r.Value
+	}
+	assert.InDelta(t, 0.00006, byID["nova-sonic-text"], 1e-9)
+	assert.InDelta(t, 0.00340, byID["nova-sonic-speech"], 1e-9)
 }
 
 func TestFamilyFromServiceName(t *testing.T) {
@@ -838,5 +929,5 @@ func TestNew_DegradesToStandardPricingWhenMarketplaceAPIUnavailable(t *testing.T
 	// Standard pricing still flows through despite the marketplace failure.
 	inputMetric := metricByName(results, "cloudcost_aws_bedrock_input_usd_per_1k_tokens")
 	require.NotNil(t, inputMetric)
-	assert.Equal(t, "Claude3Sonnet", inputMetric.Labels["model_id"])
+	assert.Equal(t, "claude3sonnet", inputMetric.Labels["model_id"])
 }

--- a/pkg/aws/bedrock/bedrock_test.go
+++ b/pkg/aws/bedrock/bedrock_test.go
@@ -791,23 +791,25 @@ func TestExtractMarketplacePriceTier(t *testing.T) {
 
 func TestMarketplaceCacheOp(t *testing.T) {
 	tests := []struct {
-		usagetype   string
-		wantOp      string
-		wantStorage bool
+		usagetype string
+		wantOp    string
+		wantSkip  bool
 	}{
 		{"USE1-MP:USE1_CacheReadInputTokenCount-Units", "cache_read", false},
 		{"USE1-MP:USE1_CacheReadInputTokenCount_Global-Units", "cache_read", false},
 		{"USE1-MP:USE1_CacheWriteInputTokenCount-Units", "cache_write_5m", false},
 		{"USE1-MP:USE1_CacheWrite1hInputTokenCount-Units", "cache_write_1h", false},
 		{"USE1-MP:USE1_cache_write_tokens_1h_standard-Units", "cache_write_1h", false},
-		{"USE1-MP:USE1_InputTokenCount-Units", "", false}, // not cache
-		{"USE1-MP:USE1_CacheStorage-Units", "", true},     // storage skipped
+		{"USE1-MP:USE1_InputTokenCount-Units", "", false}, // not cache, classified normally
+		{"USE1-MP:USE1_CacheStorage-Units", "", true},     // storage: skipped
+		// A cache shape that is neither read nor write must be skipped, not labeled a 5m write.
+		{"USE1-MP:USE1_CacheValidationCount-Units", "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.usagetype, func(t *testing.T) {
-			op, storage := marketplaceCacheOp(tt.usagetype)
+			op, skip := marketplaceCacheOp(tt.usagetype)
 			assert.Equal(t, tt.wantOp, op)
-			assert.Equal(t, tt.wantStorage, storage)
+			assert.Equal(t, tt.wantSkip, skip)
 		})
 	}
 }

--- a/pkg/aws/bedrock/bedrock_test.go
+++ b/pkg/aws/bedrock/bedrock_test.go
@@ -571,25 +571,26 @@ func marketplacePriceJSON(servicename, usagetype, regionCode, price string) stri
 	)
 }
 
-func TestCollect_SkipsLegacyClaudeCoveredByStandardSource(t *testing.T) {
+func TestCollect_MergesLegacyClaudeAcrossSources(t *testing.T) {
+	// The standard source prices legacy Claude with input tokens only; the marketplace source
+	// adds the output price under the same model_id. Both must be emitted: the overlapping input
+	// key dedups in the pricing store (equal prices), and the marketplace output fills the gap.
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	pricingClient := mockclient.NewMockClient(ctrl)
 	pricingClient.EXPECT().
 		ListBedrockPrices(gomock.Any(), "us-east-1").
-		Return([]string{}, nil).
+		Return([]string{
+			modelPriceJSON("us-east-1", "USE1-Claude3Sonnet-input-tokens", "Input tokens", "Anthropic", "Claude 3 Sonnet", "0.00300"),
+		}, nil).
 		Times(1)
 	pricingClient.EXPECT().
 		ListBedrockMarketplacePrices(gomock.Any(), "us-east-1").
 		Return([]string{
-			// Legacy generation the standard source already prices: must be skipped.
+			// Same model_id (claude-3-sonnet) as standard: input matches, output is new.
 			marketplacePriceJSON("Claude 3 Sonnet (Amazon Bedrock Edition)", "USE1-MP:USE1_InputTokenCount-Units", "us-east-1", "3.0"),
-			marketplacePriceJSON("Claude 3 Haiku (Amazon Bedrock Edition)", "USE1-MP:USE1_InputTokenCount-Units", "us-east-1", "0.25"),
-			marketplacePriceJSON("Claude Instant (Amazon Bedrock Edition)", "USE1-MP:USE1_InputTokenCount-Units", "us-east-1", "0.8"),
-			// Marketplace-only: must pass through.
-			marketplacePriceJSON("Claude 3 Opus (Amazon Bedrock Edition)", "USE1-MP:USE1_InputTokenCount-Units", "us-east-1", "15.0"),
-			marketplacePriceJSON("Claude Sonnet 4.6 (Amazon Bedrock Edition)", "USE1-MP:USE1_InputTokenCount-Units", "us-east-1", "3.0"),
+			marketplacePriceJSON("Claude 3 Sonnet (Amazon Bedrock Edition)", "USE1-MP:USE1_OutputTokenCount-Units", "us-east-1", "15.0"),
 		}, nil).
 		Times(1)
 
@@ -604,15 +605,23 @@ func TestCollect_SkipsLegacyClaudeCoveredByStandardSource(t *testing.T) {
 	results, err := collectMetricResults(t, collector)
 	require.NoError(t, err)
 
-	emitted := map[string]bool{}
+	var input, output *utils.MetricResult
 	for _, r := range results {
-		emitted[r.Labels["model_id"]] = true
+		if r.Labels["model_id"] != "claude-3-sonnet" {
+			continue
+		}
+		switch r.FqName {
+		case "cloudcost_aws_bedrock_input_usd_per_1k_tokens":
+			input = r
+		case "cloudcost_aws_bedrock_output_usd_per_1k_tokens":
+			output = r
+		}
 	}
-	assert.False(t, emitted["claude-3-sonnet"], "legacy claude-3-sonnet should be skipped")
-	assert.False(t, emitted["claude-3-haiku"], "legacy claude-3-haiku should be skipped")
-	assert.False(t, emitted["claude-instant"], "legacy claude-instant should be skipped")
-	assert.True(t, emitted["claude-3-opus"], "marketplace-only claude-3-opus should pass")
-	assert.True(t, emitted["claude-sonnet-4.6"], "claude-sonnet-4.6 should pass")
+	// Input appears once (deduped across sources), output comes from the marketplace source.
+	require.NotNil(t, input, "claude-3-sonnet input should be emitted")
+	require.NotNil(t, output, "claude-3-sonnet output should be recovered from marketplace")
+	assert.InDelta(t, 0.003, input.Value, 1e-9)
+	assert.InDelta(t, 0.015, output.Value, 1e-9)
 }
 
 func TestNormalizeModelID(t *testing.T) {

--- a/pkg/aws/bedrock/bedrock_test.go
+++ b/pkg/aws/bedrock/bedrock_test.go
@@ -34,9 +34,8 @@ func TestNew_Succeeds(t *testing.T) {
 	collector, err := New(t.Context(), &Config{
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		PricingClient: pricingClient,
-		Logger:        testLogger(),
 		AccountID:     "123456789012",
-	})
+	}, testLogger())
 
 	require.NoError(t, err)
 	assert.NotNil(t, collector)
@@ -55,8 +54,7 @@ func TestNew_ReturnsErrorWhenPricingAPIUnavailable(t *testing.T) {
 	collector, err := New(t.Context(), &Config{
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		PricingClient: pricingClient,
-		Logger:        testLogger(),
-	})
+	}, testLogger())
 
 	assert.Nil(t, collector)
 	require.Error(t, err)
@@ -82,9 +80,8 @@ func TestCollect_EmitsInputAndOutputTokenMetrics(t *testing.T) {
 	collector, err := New(t.Context(), &Config{
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		PricingClient: pricingClient,
-		Logger:        testLogger(),
 		AccountID:     "123456789012",
-	})
+	}, testLogger())
 	require.NoError(t, err)
 
 	results, err := collectMetricResults(t, collector)
@@ -134,9 +131,8 @@ func TestCollect_EmitsMetricsForMultipleModels(t *testing.T) {
 	collector, err := New(t.Context(), &Config{
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		PricingClient: pricingClient,
-		Logger:        testLogger(),
 		AccountID:     "123456789012",
-	})
+	}, testLogger())
 	require.NoError(t, err)
 
 	results, err := collectMetricResults(t, collector)
@@ -163,9 +159,8 @@ func TestCollect_LabelsCrossRegionPriceTier(t *testing.T) {
 	collector, err := New(t.Context(), &Config{
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		PricingClient: pricingClient,
-		Logger:        testLogger(),
 		AccountID:     "123456789012",
-	})
+	}, testLogger())
 	require.NoError(t, err)
 
 	results, err := collectMetricResults(t, collector)
@@ -197,9 +192,8 @@ func TestCollect_LabelsBatchPriceTier(t *testing.T) {
 	collector, err := New(t.Context(), &Config{
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		PricingClient: pricingClient,
-		Logger:        testLogger(),
 		AccountID:     "123456789012",
-	})
+	}, testLogger())
 	require.NoError(t, err)
 
 	results, err := collectMetricResults(t, collector)
@@ -234,9 +228,8 @@ func TestCollect_FamilyFilterRegexFiltersOtherFamilies(t *testing.T) {
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		PricingClient: pricingClient,
 		FamilyFilter:  "anthropic|amazon",
-		Logger:        testLogger(),
 		AccountID:     "123456789012",
-	})
+	}, testLogger())
 	require.NoError(t, err)
 
 	results, err := collectMetricResults(t, collector)
@@ -269,9 +262,8 @@ func TestCollect_FamilyFilterDefaultEmitsAllFamilies(t *testing.T) {
 	collector, err := New(t.Context(), &Config{
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		PricingClient: pricingClient,
-		Logger:        testLogger(),
 		AccountID:     "123456789012",
-	})
+	}, testLogger())
 	require.NoError(t, err)
 
 	results, err := collectMetricResults(t, collector)
@@ -289,8 +281,7 @@ func TestNew_ReturnsErrorForInvalidFamilyFilterRegex(t *testing.T) {
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		PricingClient: pricingClient,
 		FamilyFilter:  "[invalid",
-		Logger:        testLogger(),
-	})
+	}, testLogger())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid bedrock family filter")
 }
@@ -320,9 +311,8 @@ func TestCollect_SkipsNonTextTokenSKUs(t *testing.T) {
 	collector, err := New(t.Context(), &Config{
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		PricingClient: pricingClient,
-		Logger:        testLogger(),
 		AccountID:     "123456789012",
-	})
+	}, testLogger())
 	require.NoError(t, err)
 
 	results, err := collectMetricResults(t, collector)
@@ -347,9 +337,8 @@ func TestCollect_ReturnsContextErrWhenContextCancelled(t *testing.T) {
 	collector, err := New(t.Context(), &Config{
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		PricingClient: pricingClient,
-		Logger:        testLogger(),
 		AccountID:     "123456789012",
-	})
+	}, testLogger())
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -597,9 +586,8 @@ func TestCollect_MergesLegacyClaudeAcrossSources(t *testing.T) {
 	collector, err := New(t.Context(), &Config{
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		PricingClient: pricingClient,
-		Logger:        testLogger(),
 		AccountID:     "123456789012",
-	})
+	}, testLogger())
 	require.NoError(t, err)
 
 	results, err := collectMetricResults(t, collector)
@@ -669,9 +657,8 @@ func TestCollect_StandardModelIDUsesModelAttribute(t *testing.T) {
 	collector, err := New(t.Context(), &Config{
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		PricingClient: pricingClient,
-		Logger:        testLogger(),
 		AccountID:     "123456789012",
-	})
+	}, testLogger())
 	require.NoError(t, err)
 
 	results, err := collectMetricResults(t, collector)
@@ -707,9 +694,8 @@ func TestCollect_StandardModelIDDisambiguatesNovaSonicModality(t *testing.T) {
 	collector, err := New(t.Context(), &Config{
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		PricingClient: pricingClient,
-		Logger:        testLogger(),
 		AccountID:     "123456789012",
-	})
+	}, testLogger())
 	require.NoError(t, err)
 
 	results, err := collectMetricResults(t, collector)
@@ -851,9 +837,8 @@ func TestCollect_EmitsMarketplaceCacheMetrics(t *testing.T) {
 	collector, err := New(t.Context(), &Config{
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		PricingClient: pricingClient,
-		Logger:        testLogger(),
 		AccountID:     "123456789012",
-	})
+	}, testLogger())
 	require.NoError(t, err)
 
 	results, err := collectMetricResults(t, collector)
@@ -892,9 +877,8 @@ func TestCollect_EmitsMarketplaceTokenMetrics(t *testing.T) {
 	collector, err := New(t.Context(), &Config{
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		PricingClient: pricingClient,
-		Logger:        testLogger(),
 		AccountID:     "123456789012",
-	})
+	}, testLogger())
 	require.NoError(t, err)
 
 	results, err := collectMetricResults(t, collector)
@@ -933,9 +917,8 @@ func TestCollect_EmitsMarketplaceSearchUnitMetrics(t *testing.T) {
 	collector, err := New(t.Context(), &Config{
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		PricingClient: pricingClient,
-		Logger:        testLogger(),
 		AccountID:     "123456789012",
-	})
+	}, testLogger())
 	require.NoError(t, err)
 
 	results, err := collectMetricResults(t, collector)
@@ -970,9 +953,8 @@ func TestCollect_MarketplaceFamilyFilterApplied(t *testing.T) {
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		PricingClient: pricingClient,
 		FamilyFilter:  "anthropic",
-		Logger:        testLogger(),
 		AccountID:     "123456789012",
-	})
+	}, testLogger())
 	require.NoError(t, err)
 
 	results, err := collectMetricResults(t, collector)
@@ -1000,9 +982,8 @@ func TestNew_DegradesToStandardPricingWhenMarketplaceAPIUnavailable(t *testing.T
 	collector, err := New(t.Context(), &Config{
 		Regions:       []ec2types.Region{{RegionName: aws.String("us-east-1")}},
 		PricingClient: pricingClient,
-		Logger:        testLogger(),
 		AccountID:     "123456789012",
-	})
+	}, testLogger())
 	require.NoError(t, err)
 	require.NotNil(t, collector)
 

--- a/pkg/aws/bedrock/bedrock_test.go
+++ b/pkg/aws/bedrock/bedrock_test.go
@@ -660,14 +660,14 @@ func TestCollect_EmitsMarketplaceTokenMetrics(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 
-	inputMetric := metricByName(results, "cloudcost_aws_bedrock_token_input_usd_per_1k_tokens")
+	inputMetric := metricByName(results, "cloudcost_aws_bedrock_input_usd_per_1k_tokens")
 	require.NotNil(t, inputMetric)
 	assert.Equal(t, "claude-sonnet-4.6", inputMetric.Labels["model_id"])
 	assert.Equal(t, "anthropic", inputMetric.Labels["family"])
 	assert.Equal(t, "on_demand", inputMetric.Labels["price_tier"])
 	assert.InDelta(t, 0.003, inputMetric.Value, 1e-9)
 
-	outputMetric := metricByName(results, "cloudcost_aws_bedrock_token_output_usd_per_1k_tokens")
+	outputMetric := metricByName(results, "cloudcost_aws_bedrock_output_usd_per_1k_tokens")
 	require.NotNil(t, outputMetric)
 	assert.InDelta(t, 0.015, outputMetric.Value, 1e-9)
 }
@@ -769,7 +769,7 @@ func TestNew_DegradesToStandardPricingWhenMarketplaceAPIUnavailable(t *testing.T
 	require.NoError(t, err)
 
 	// Standard pricing still flows through despite the marketplace failure.
-	inputMetric := metricByName(results, "cloudcost_aws_bedrock_token_input_usd_per_1k_tokens")
+	inputMetric := metricByName(results, "cloudcost_aws_bedrock_input_usd_per_1k_tokens")
 	require.NotNil(t, inputMetric)
 	assert.Equal(t, "Claude3Sonnet", inputMetric.Labels["model_id"])
 }

--- a/pkg/aws/client/aws_client.go
+++ b/pkg/aws/client/aws_client.go
@@ -117,3 +117,7 @@ func (c *AWSClient) ListMSKServicePrices(ctx context.Context, region string, fil
 func (c *AWSClient) ListBedrockPrices(ctx context.Context, region string) ([]string, error) {
 	return c.priceService.listBedrockPrices(ctx, region)
 }
+
+func (c *AWSClient) ListBedrockMarketplacePrices(ctx context.Context, region string) ([]string, error) {
+	return c.priceService.listBedrockMarketplacePrices(ctx, region)
+}

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -31,6 +31,7 @@ type Client interface {
 	ListMSKClusters(ctx context.Context) ([]msktypes.Cluster, error)
 	ListMSKServicePrices(ctx context.Context, region string, filters []pricingTypes.Filter) ([]string, error)
 	ListBedrockPrices(ctx context.Context, region string) ([]string, error)
+	ListBedrockMarketplacePrices(ctx context.Context, region string) ([]string, error)
 
 	// TODO: Break out Metrics into an independent interface
 	Metrics() []prometheus.Collector

--- a/pkg/aws/client/mocks/client.go
+++ b/pkg/aws/client/mocks/client.go
@@ -108,6 +108,21 @@ func (mr *MockClientMockRecorder) GetRDSUnitData(ctx, instType, region, deployme
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRDSUnitData", reflect.TypeOf((*MockClient)(nil).GetRDSUnitData), ctx, instType, region, deploymentOption, engineCode, isOutpost)
 }
 
+// ListBedrockMarketplacePrices mocks base method.
+func (m *MockClient) ListBedrockMarketplacePrices(ctx context.Context, region string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBedrockMarketplacePrices", ctx, region)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBedrockMarketplacePrices indicates an expected call of ListBedrockMarketplacePrices.
+func (mr *MockClientMockRecorder) ListBedrockMarketplacePrices(ctx, region any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBedrockMarketplacePrices", reflect.TypeOf((*MockClient)(nil).ListBedrockMarketplacePrices), ctx, region)
+}
+
 // ListBedrockPrices mocks base method.
 func (m *MockClient) ListBedrockPrices(ctx context.Context, region string) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/aws/client/pricing.go
+++ b/pkg/aws/client/pricing.go
@@ -163,6 +163,10 @@ func (p *pricing) listBedrockPrices(ctx context.Context, region string) ([]strin
 	return p.listServicePrices(ctx, "AmazonBedrock", region, nil)
 }
 
+func (p *pricing) listBedrockMarketplacePrices(ctx context.Context, region string) ([]string, error) {
+	return p.listServicePrices(ctx, "AmazonBedrockFoundationModels", region, nil)
+}
+
 func (p *pricing) listELBPrices(ctx context.Context, region string) ([]string, error) {
 	// Fetch ELB pricing from AWS Pricing API
 	input := &awsPricing.GetProductsInput{

--- a/pkg/aws/ec2/mock_client_test.go
+++ b/pkg/aws/ec2/mock_client_test.go
@@ -89,6 +89,10 @@ func (m *mockClient) ListBedrockPrices(ctx context.Context, region string) ([]st
 	panic("not implemented")
 }
 
+func (m *mockClient) ListBedrockMarketplacePrices(ctx context.Context, region string) ([]string, error) {
+	panic("not implemented")
+}
+
 func (m *mockClient) Metrics() []prometheus.Collector {
 	panic("not implemented")
 }

--- a/pkg/aws/pricingstore/pricing_store.go
+++ b/pkg/aws/pricingstore/pricing_store.go
@@ -242,6 +242,10 @@ func (p *PricingStore) buildSnapshot(priceList []string) (*priceSnapshot, error)
 					p.logger.Error(fmt.Sprintf("error parsing price: %s, skipping", err))
 					continue
 				}
+				if existing, ok := regionPrices[unit]; ok && existing != price {
+					p.logger.Warn("overwriting price for usage type with a different value",
+						"region", region, "unit", unit, "old", existing, "new", price)
+				}
 				regionPrices[unit] = price
 			}
 		}

--- a/pkg/aws/vpc/vpc_test.go
+++ b/pkg/aws/vpc/vpc_test.go
@@ -108,6 +108,11 @@ func (m *MockClient) ListBedrockPrices(ctx context.Context, region string) ([]st
 	return args.Get(0).([]string), args.Error(1)
 }
 
+func (m *MockClient) ListBedrockMarketplacePrices(ctx context.Context, region string) ([]string, error) {
+	args := m.Called(ctx, region)
+	return args.Get(0).([]string), args.Error(1)
+}
+
 func (m *MockClient) Metrics() []prometheus.Collector {
 	args := m.Called()
 	return args.Get(0).([]prometheus.Collector)


### PR DESCRIPTION
Part of https://github.com/grafana/cloudcost-exporter/issues/933.

Adds a second pricing source to the Bedrock collector and reconciles it with the existing one. The collector queried only `AmazonBedrock` in the AWS Pricing API, which covers Claude 2/3 and Amazon-native models. The models most used in production (Claude 4.x, Cohere Rerank/Embed) are priced under a separate service code, `AmazonBedrockFoundationModels`, and were missing entirely.

## Metrics emitted

Three gauges, all list-price rates (not measured spend):

| Metric | Unit |
|---|---|
| `cloudcost_aws_bedrock_input_usd_per_1k_tokens` | USD per 1,000 input tokens |
| `cloudcost_aws_bedrock_output_usd_per_1k_tokens` | USD per 1,000 output tokens |
| `cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units` | USD per 1,000 search units (e.g. Cohere Rerank) |

Labels on every series: `account_id`, `region`, `model_id`, `family`, `price_tier`.

```
cloudcost_aws_bedrock_input_usd_per_1k_tokens{account_id="123456789012",region="us-east-1",model_id="claude-sonnet-4.6",family="anthropic",price_tier="on_demand"} 0.0033
cloudcost_aws_bedrock_output_usd_per_1k_tokens{account_id="123456789012",region="us-east-1",model_id="claude-sonnet-4.6",family="anthropic",price_tier="on_demand"} 0.0165
cloudcost_aws_bedrock_input_usd_per_1k_tokens{account_id="123456789012",region="us-east-1",model_id="claude-sonnet-4.6",family="anthropic",price_tier="cache_read"} 0.00033
cloudcost_aws_bedrock_input_usd_per_1k_tokens{account_id="123456789012",region="us-east-1",model_id="claude-sonnet-4.6",family="anthropic",price_tier="cross_region_batch"} 0.0015
cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units{account_id="123456789012",region="us-east-1",model_id="cohere-rerank-v3.5",family="cohere",price_tier="on_demand"} 2
```

## Marketplace pricing source

- `pkg/aws/client/`: add `ListBedrockMarketplacePrices` and implement it against `AmazonBedrockFoundationModels`.
- `pkg/aws/bedrock/bedrock.go`: `newPriceFetcher` queries both APIs per region and merges them. The marketplace fetch is best-effort: a failure logs and continues with standard pricing rather than failing the collector.
- `encodeBedrockMarketplacePriceJSON` parses the marketplace SKU format, where direction comes from the `usagetype` and family from `servicename` (marketplace SKUs have no `inferenceType`/`provider`).
- Adds a third metric, `cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units` (e.g. Cohere Rerank). Token prices convert from `$/1M` to `$/1k`; search-unit prices from `$/unit` to `$/1k`.

## Uniform `model_id`

`model_id` is derived from the human-readable `model` attribute (`AmazonBedrock`, with a normalized usagetype-slug fallback) or `servicename` (`AmazonBedrockFoundationModels`), normalized to one lowercase-hyphen convention so both sources agree (`Claude3Sonnet` and `Claude Sonnet 4.6` become `claude-3-sonnet` and `claude-sonnet-4.6`). Models AWS prices per modality under one name keep the modality (`nova-sonic-text`, `nova-sonic-speech`).

## Legacy Claude cross-source merge

The Claude 2.x / Instant / 3 Haiku / 3 Sonnet generation is priced under both service codes, and since both normalize to the same `model_id` they merge into one set of series: overlapping `(model_id, direction, tier)` entries dedupe (the prices are identical), and a price one source lacks is filled in by the other. This matters because the standard source prices those legacy models for input tokens only, while the marketplace source carries the output price.

## Prompt-cache pricing

Marketplace prompt-cache read/write are emitted on the input metric as `price_tier` values: `cache_read`, `cache_write_5m`, `cache_write_1h` (reads are a single rate; writes split by 5-minute default vs 1-hour TTL). They stack with the cross-region and quota dimensions through a shared `composeTier` helper (`cross_region_cache_read`, `cache_write_1h`, etc.), so each variant stays distinct. Cache storage (priced per token-hour, a different unit) is skipped; standard-source caching (Amazon-native models only) is out of scope.

## Labels and tiers

- `family`: normalized from pricing metadata, open-ended (the `AmazonBedrock` source publishes `anthropic`, `amazon`, `cohere`, `meta`, `mistral`, `deepseek`, `qwen`, and more).
- `price_tier`: composed of an optional `cross_region` prefix, a base operation (`on_demand` or a `cache_*` op), and an optional quota suffix (`batch`, `flex`, `priority`, `latency_optimized`).

## Tests and docs

- `bedrock_test.go`: both client methods mocked; tests cover family classification, usagetype direction, price-tier composition, unit conversions, the family filter, graceful degradation when the marketplace API is unavailable, `model`-attribute keying with slug fallback, the Nova Sonic modality split, the legacy Claude merge, and cache read/write/storage handling.
- `docs/metrics/aws/bedrock.md`: documents both sources, the open-ended `family` set, the composed `price_tier` value set (including cache), the unified `model_id` derivation, and the cross-source merge. Styled to match the sibling collector docs and linked from the docs and metrics indexes. Folds in the change previously proposed as #1010.

Verified live against the AWS Pricing API (all regions): 8,067 series, no duplicate/colliding series, cache rates match Claude's caching ratios (read 0.1x, write_5m 1.25x, write_1h 2x of input).
