### PR TITLE
chore(ci): add cliff.toml for git-cliff changelog generation

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,50 @@
+[changelog]
+header = ""
+body = """
+{% macro pr_link(commit) %}{% if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}](https://github.com/grafana/cloudcost-exporter/pull/{{ commit.remote.pr_number }})){% endif %}{% endmacro %}
+{% macro commit_line(commit) %}- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message }}{{ self::pr_link(commit=commit) }}{% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}{% endmacro %}
+
+{% for group, group_commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in group_commits -%}
+{{ self::commit_line(commit=commit) }}
+{% endfor -%}
+{% endfor %}
+{% if previous.version %}
+**Full Changelog**: [{{ previous.version }}...{{ version }}](https://github.com/grafana/cloudcost-exporter/compare/{{ previous.version }}...{{ version }})
+{% endif %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+commit_preprocessors = [
+    { pattern = ' *\(#\d+\)', replace = "" },
+    { pattern = '\n.*', replace = "" },
+]
+filter_unconventional = false
+protect_breaking_commits = true
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^style", group = "Styling" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore", group = "Miscellaneous" },
+    { message = "^ci", group = "CI/CD" },
+    { message = "^build", group = "Build" },
+    { message = ".*", group = "Other Changes" },
+]
+tag_pattern = "v[0-9]+\\.[0-9]+\\.[0-9]+"
+sort_commits = "oldest"
+
+[remote.github]
+owner = "grafana"
+repo = "cloudcost-exporter"
+
+[bump]
+features_always_bump_minor = true
+breaking_always_bump_major = true
+custom_minor_increment_regex = "^(refactor|perf)"


### PR DESCRIPTION
## Summary

- Adds `cliff.toml` to configure [git-cliff](https://git-cliff.org) for structured changelog generation from Conventional Commits
- Changelog groups commits by type (Features, Bug Fixes, Refactoring, etc.) with PR links and author attribution
- Tag pattern scoped to strict semver (`v[0-9]+\.[0-9]+\.[0-9]+`) to exclude Helm chart tags (`vcloudcost-exporter-X.Y.Z`) from bump computation and changelog ranges
- Bump rules: `fix` → patch, `feat`/`refactor`/`perf` → minor, `BREAKING CHANGE` → major

This is the foundation for follow-up PRs that will wire git-cliff into GoReleaser (for release notes) and `release-on-pr-merge.yml` (for semver bump validation against PR labels).

Part of grafana/deployment_tools#570575.

## Test plan

- [x] Verify `git cliff --bumped-version` produces the expected next version against the current tag history
- [x] Verify `git cliff --latest` produces well-formed grouped changelog output

## Changelog comparison

----------------------**New**:
### Bug Fixes
- **deps:** update module cloud.google.com/go/storage to v1.62.1 ([#903](https://github.com/grafana/cloudcost-exporter/pull/903)) by @renovate-sh-app[bot]
- **deps:** update module cloud.google.com/go/billing to v1.24.0 ([#911](https://github.com/grafana/cloudcost-exporter/pull/911)) by @renovate-sh-app[bot]
- **deps:** update module github.com/googleapis/gax-go/v2 to v2.22.0 ([#917](https://github.com/grafana/cloudcost-exporter/pull/917)) by @renovate-sh-app[bot]
- **deps:** update module google.golang.org/api to v0.276.0 ([#916](https://github.com/grafana/cloudcost-exporter/pull/916)) by @renovate-sh-app[bot]
- **deps:** update module cloud.google.com/go/managedkafka to v0.11.0 ([#913](https://github.com/grafana/cloudcost-exporter/pull/913)) by @renovate-sh-app[bot]
- **deps:** update module cloud.google.com/go/compute to v1.60.0 ([#912](https://github.com/grafana/cloudcost-exporter/pull/912)) by @renovate-sh-app[bot]
- **deps:** update azure-sdk-for-go monorepo ([#932](https://github.com/grafana/cloudcost-exporter/pull/932)) by @renovate-sh-app[bot]
- **deps:** update aws-sdk-go-v2 monorepo ([#918](https://github.com/grafana/cloudcost-exporter/pull/918)) by @renovate-sh-app[bot]

### Miscellaneous
- **deps:** update golang docker tag to v1.26.2 ([#902](https://github.com/grafana/cloudcost-exporter/pull/902)) by @renovate-sh-app[bot]
- **deps:** update goreleaser/goreleaser-action action to v7.1.0 ([#925](https://github.com/grafana/cloudcost-exporter/pull/925)) by @renovate-sh-app[bot]

### Other Changes
- Extract pinned aws pricingAPI instantiation to be done just once ([#928](https://github.com/grafana/cloudcost-exporter/pull/928)) by @leonorfmartins
- Escape line breaks in collector error logs ([#927](https://github.com/grafana/cloudcost-exporter/pull/927)) by @Blinkuu

-----------------**Current**:
## Changelog
* d9ba0e85d145712b1c60ef1661a50a00cc55d7fe Escape line breaks in collector error logs (#927)
* 033c0f756e508ab37126567ec5d5462f545d70d2 Extract pinned aws pricingAPI instantiation to be done just once (#928)
* d189c45c56a469281576c110fe4e5688d693cd34 chore(deps): update golang docker tag to v1.26.2 (#902)
* 4261aec84b11884f04f66dfe4d20102376f5c3d1 chore(deps): update goreleaser/goreleaser-action action to v7.1.0 (#925)
* 451f988767a0e19dfc4cd35b51e699156723063f fix(deps): update aws-sdk-go-v2 monorepo (#918)
* c30f542f1777ed6b831fc30acd6e2f38966c3361 fix(deps): update azure-sdk-for-go monorepo (#932)
* d0da923654d58982d270397467fa7215d117ba65 fix(deps): update module cloud.google.com/go/billing to v1.24.0 (#911)
* b151dd9a882becd1bbc4fbc41eacf0ad268353c3 fix(deps): update module cloud.google.com/go/compute to v1.60.0 (#912)
* f83f7a5655badf2c7ffd1fdec1c11685e715c933 fix(deps): update module cloud.google.com/go/managedkafka to v0.11.0 (#913)
* 33cdafaca4d7b06aef30ed730443e19028c5947f fix(deps): update module cloud.google.com/go/storage to v1.62.1 (#903)
* 93fd37e9e17c36e6aedb03e3d079cbf75077b2c9 fix(deps): update module github.com/googleapis/gax-go/v2 to v2.22.0 (#917)
* 62ef7bc8fd4e218864d45b1fef0780d507d3e03d fix(deps): update module google.golang.org/api to v0.276.0 (#916)


