### PR TITLE
chore(ci): add PR title lint workflow to enforce Conventional Commits

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,82 @@
+name: PR Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: write
+
+jobs:
+  lint:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            chore
+            ci
+            build
+          scopes: |
+            [a-z][a-z0-9/_-]*
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            should not start with an uppercase character.
+
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        continue-on-error: true
+        with:
+          header: pr-title-lint-error
+          message: |
+            Pull request titles must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format, because this repository uses squash merges and the PR title becomes the commit message.
+
+            **Format:** `<type>(<scope>): <subject>`
+
+            **Valid types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`
+
+            **Scope** is optional but recommended — use the affected component, e.g. `feat(aws/ec2): add spot price support`.
+
+            **Subject** should be lowercase and use imperative mood (e.g. "add" not "added").
+
+            **Breaking changes:** append `!` after the type/scope, e.g. `feat(gcp)!: remove legacy pricing endpoint`. Explain the breaking change in the PR description.
+
+            **Examples:**
+            - `feat(aws/ec2): add spot price support`
+            - `fix(gcp/gke): handle missing node pool on scrape`
+            - `chore(deps): update go dependencies`
+            - `docs: update release process documentation`
+
+            See [CONTRIBUTING.md](https://github.com/grafana/cloudcost-exporter/blob/main/CONTRIBUTING.md) for full details.
+
+            <details><summary>Error details</summary>
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+            </details>
+
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        continue-on-error: true
+        with:
+          header: pr-title-lint-error
+          delete: true


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/pr-title.yml` to validate PR titles on every open, reopen, edit, and sync
- Uses `amannn/action-semantic-pull-request` to enforce [Conventional Commits](https://www.conventionalcommits.org/) format
- Posts a sticky comment with format guidance on failure; auto-deletes it when the title is fixed
- Scope regex allows `/` to support component-style scopes (`aws/ec2`, `gcp/gke`)

Since this repo uses squash merges, the PR title becomes the commit message. Enforcing the format here ensures git-cliff can reliably compute semver bumps and generate structured changelogs (follow-up PRs in this series).

Part of grafana/deployment_tools#570575.

## Test plan

- [x] Open a PR with an invalid title (e.g. `Update something`) and verify the sticky comment appears. See: https://github.com/grafana/cloudcost-exporter/pull/945
- [x] Edit the title to a valid format (e.g. `fix(aws/ec2): correct pricing lookup`) and verify the comment is removed
- [x] Verify breaking change syntax is accepted: `feat(gcp)!: remove legacy endpoint`