### PR TITLE
chore(ci): suggest release label via git-cliff and document release conventions

### DIFF
--- a/.github/workflows/suggest-release-label.yml
+++ b/.github/workflows/suggest-release-label.yml
@@ -1,0 +1,80 @@
+name: Suggest Release Label
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: write
+
+jobs:
+  suggest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Compute bumped version
+        id: cliff_bump
+        uses: orhun/git-cliff-action@c93ef52f3d0ddcdcc9bd5447d98d458a11cd4f72 # v4.7.1
+        with:
+          args: --bumped-version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build comment
+        run: |
+          LATEST=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -1)
+          LATEST="${LATEST:-v0.0.0}"
+          CLIFF="${{ steps.cliff_bump.outputs.content }}"
+
+          IFS='.' read -r cur_major cur_minor _ <<< "${LATEST#v}"
+          IFS='.' read -r cliff_major cliff_minor _ <<< "${CLIFF#v}"
+
+          if [ "$cliff_major" -gt "$cur_major" ]; then
+            LABEL="release:major"
+            REASON="\`feat!\` or breaking change detected"
+          elif [ "$cliff_minor" -gt "$cur_minor" ]; then
+            LABEL="release:minor"
+            REASON="\`feat\`, \`refactor\`, or \`perf\` commit detected"
+          elif [ "$CLIFF" != "$LATEST" ]; then
+            LABEL="release:patch"
+            REASON="\`fix\` commit detected"
+          else
+            LABEL="none"
+            REASON="only non-binary commits detected (\`chore\`, \`ci\`, \`docs\`, etc.)"
+          fi
+
+          if [ "$LABEL" = "none" ]; then
+            cat > /tmp/comment.md << EOF
+          ## Release Label Suggestion
+
+          Based on commits since \`$LATEST\`, git-cliff detects no release-triggering commits ($REASON).
+
+          **No release label needed** unless this PR introduces \`feat\`, \`fix\`, \`refactor\`, \`perf\`, or a breaking change.
+
+          > This is informational only — the label choice is yours.
+          EOF
+          else
+            cat > /tmp/comment.md << EOF
+          ## Release Label Suggestion
+
+          Based on commits since \`$LATEST\`, git-cliff recommends:
+
+          **\`$LABEL\`** — next version would be \`$CLIFF\` ($REASON)
+
+          > This is informational only — the label choice is yours.
+          EOF
+          fi
+
+      - name: Post comment
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: release-label-suggestion
+          path: /tmp/comment.md

--- a/docs/contribute/releases.md
+++ b/docs/contribute/releases.md
@@ -33,6 +33,8 @@ Releases are now automated! When you merge a PR with a release label, the workfl
    - `release:patch` - For bug fixes and dependency updates (e.g., `v1.2.3` → `v1.2.4`)
 3. Merge the PR - The [release-on-pr-merge.yml](../../.github/workflows/release-on-pr-merge.yml) workflow will run automatically
 
+When you open or update a PR, the [suggest-release-label.yml](../../.github/workflows/suggest-release-label.yml) workflow will post a comment with a label recommendation based on all commits since the last release. This is informational — the final label choice is yours.
+
 ### Release Label Guidelines
 
 | Change Type | Label | Example |
@@ -42,6 +44,42 @@ Releases are now automated! When you merge a PR with a release label, the workfl
 | Bug fixes, dependency updates, documentation | `release:patch` | `v1.2.3` → `v1.2.4` |
 
 **Important**: Only use **ONE** release label per PR. If multiple labels are present, the workflow will fail with an error.
+
+### Commit types and release labels
+
+This repo enforces [Conventional Commits](https://www.conventionalcommits.org/) on PR titles (since the repo uses squash merges, the PR title becomes the commit message). Use the following table to choose the right release label based on your commit type:
+
+| Commit type | Affects binary? | Suggested label |
+|-------------|-----------------|-----------------|
+| `feat`      | yes             | `release:minor` |
+| `fix`       | yes             | `release:patch` |
+| `refactor`  | yes             | `release:minor` |
+| `perf`      | yes             | `release:minor` |
+| `docs`      | no              | no label needed |
+| `ci`        | no              | no label needed |
+| `test`      | no              | no label needed |
+| `build`     | no              | no label needed |
+| `style`     | no              | no label needed |
+| `chore`     | no              | no label needed |
+
+For breaking changes, append `!` to the type (e.g. `feat!:`) and use `release:major`.
+
+### Checking the minimum required bump
+
+To see what label the commits since the last release would require, run [git-cliff](https://git-cliff.org) locally:
+
+```sh
+git cliff --bumped-version
+```
+
+This uses `cliff.toml` at the repo root and computes the minimum next version based on Conventional Commit types since the last tag.
+
+### Dependency updates
+
+Renovate manages dependency updates automatically and uses the correct commit type by convention:
+
+- **Go module updates** use `fix(deps)` — these affect the compiled binary and should use `release:patch`
+- **Non-Go updates** (GitHub Actions, linters, etc.) use `chore(deps)` — these don't affect the binary and need no release label
 
 ### What Happens When You Merge a PR
 


### PR DESCRIPTION
## Summary

- Adds `suggest-release-label.yml` workflow that runs on PR open/update and posts a sticky comment recommending a release label based on all commits since the last release
- Uses `git cliff --bumped-version` to compute the minimum required bump and maps it to the corresponding `release:major/minor/patch` label (or "no label needed" for non-binary commits)
- Comment updates on each push rather than accumulating
- Removes the `validate-bump` job that was drafted but not merged — the suggestion comment is a better fit since validation post-merge has no clean recovery path
- Extends `docs/contribute/releases.md` with commit-type-to-label mapping, Renovate labeling conventions, a note on the suggestion comment, and a section on checking the minimum required bump locally via `git cliff --bumped-version`

Part of grafana/deployment_tools#570575.
