### PR TITLE
fix(azure/aks): skip VMs with unavailable ComputerName instead of erroring

### DIFF
--- a/pkg/azure/aks/machine_store.go
+++ b/pkg/azure/aks/machine_store.go
@@ -399,19 +399,22 @@ func (m *MachineStore) PopulateMachineStore(ctx context.Context) {
 	)
 }
 
+// getMachineName returns the VM's ComputerName, which Azure populates only
+// once the OS is running. VMs in transitional states (provisioning, failed,
+// deallocating) are skipped and picked up on the next refresh cycle; emitting
+// metrics with a fallback name would cause the instance label to flap when the
+// VM reaches a running state.
 func (m *MachineStore) getMachineName(vm *armcompute.VirtualMachineScaleSetVM) (string, error) {
-	if vm.Properties.InstanceView == nil {
-		m.logger.Error(fmt.Sprintf("unable to determine machine name, instanceView property not set: %+v", vm))
-		return "", fmt.Errorf("unable to determine machine name, instanceView property not set: %+v", vm)
+	var computerName string
+	if vm.Properties != nil && vm.Properties.InstanceView != nil {
+		computerName = to.String(vm.Properties.InstanceView.ComputerName)
+	}
+	if len(computerName) > 0 {
+		return strings.ToLower(computerName), nil
 	}
 
-	computerName := to.String(vm.Properties.InstanceView.ComputerName)
-	if len(computerName) == 0 {
-		m.logger.Error(fmt.Sprintf("unable to determine machine name: %+v", vm))
-		return "", fmt.Errorf("unable to determine machine name: %+v", vm)
-	}
-
-	return strings.ToLower(computerName), nil
+	m.logger.Debug("ComputerName unavailable, skipping VM until next refresh", slog.String("resourceName", to.String(vm.Name)))
+	return "", fmt.Errorf("ComputerName unavailable")
 }
 
 // Based on this logic https://learn.microsoft.com/en-us/azure/virtual-machines/vm-naming-conventions

--- a/pkg/azure/aks/machine_store_test.go
+++ b/pkg/azure/aks/machine_store_test.go
@@ -492,8 +492,9 @@ func TestGetMachineName(t *testing.T) {
 			expectedName: "aks-vmss-machine",
 			expectedErr:  false,
 		},
-		"instanceView not retrieved": {
+		"instanceView nil, skipped": {
 			vmObject: &armcompute.VirtualMachineScaleSetVM{
+				Name: to.StringPtr("aks-nodepool1-xxxxx-vmss_0"),
 				Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 					InstanceView: nil,
 				},
@@ -501,11 +502,19 @@ func TestGetMachineName(t *testing.T) {
 			expectedName: "",
 			expectedErr:  true,
 		},
-		"instanceView partially retrieved": {
+		"ComputerName empty, skipped": {
 			vmObject: &armcompute.VirtualMachineScaleSetVM{
+				Name: to.StringPtr("aks-nodepool1-xxxxx-vmss_0"),
 				Properties: &armcompute.VirtualMachineScaleSetVMProperties{
 					InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{},
 				},
+			},
+			expectedName: "",
+			expectedErr:  true,
+		},
+		"Properties nil, skipped": {
+			vmObject: &armcompute.VirtualMachineScaleSetVM{
+				Name: to.StringPtr("aks-nodepool1-xxxxx-vmss_0"),
 			},
 			expectedName: "",
 			expectedErr:  true,


### PR DESCRIPTION
## Summary

- VMs in transitional states (provisioning, failed, deallocating) have `InstanceView` set but `ComputerName` empty - Azure only populates it once the OS starts. `getMachineName` errored on these, dumping the full VM struct at `ERROR` every 5-minute refresh until the VM reached a running state.
- Skip these VMs quietly (Debug log with the ARM resource name) and pick them up on the next refresh cycle when ComputerName is populated. 
  - Falling back to `vm.Name` would cause the `instance` label to flap when the VM transitions to running, breaking joins against kube-state-metrics and existing dashboards.
- Also guards against nil `vm.Properties`.

Closes #868

## Test plan

- [x] `go test ./pkg/azure/aks/ -run TestGetMachineName -v` passes
- [x] `golangci-lint run ./pkg/azure/aks/...` clean
- [x] Run exporter against a subscription with a scaling AKS nodepool; verify provisioning VMs no longer emit ERROR + struct dumps
- [x] Confirm `cloudcost_azure_aks_instance_*` series stay stable across a VM provision/run transition
