### PR TITLE
fix(release): use cloudcost-exporter-helm-publisher app via token broker

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -50,8 +50,8 @@ jobs:
       charts_dir: charts
       cr_configfile: cr.yaml
       ct_configfile: charts/cloudcost-exporter/ct.yaml
-    secrets:
-      vault_repo_secret_name: github-app
+    with:
+      github_app: cloudcost-exporter-helm-publisher
 
   trigger-deployment-tools-update:
     needs: release-chart


### PR DESCRIPTION
Updates `release-helm-chart.yaml` to use the GitHub App Token Broker.
