### PR TITLE
ci: migrate image publishing from Docker Hub to GAR via gar-image-mirror

### DIFF
--- a/.github/workflows/release-on-pr-merge.yml
+++ b/.github/workflows/release-on-pr-merge.yml
@@ -1,8 +1,7 @@
 name: PR Merge to Main
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - main
 
@@ -12,7 +11,6 @@ permissions:
 
 jobs:
   check-release-label:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
       should-release: ${{ steps.check.outputs.should-release }}
@@ -27,7 +25,7 @@ jobs:
       - name: Get PR information
         id: check
         run: |
-          PR_NUMBER=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
+          PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq '.[0].number')
           PR_DATA=$(gh pr view "$PR_NUMBER" --json labels)
           LABELS=$(echo "$PR_DATA" | jq -r '.labels[].name' | tr '\n' ' ')
           
@@ -129,7 +127,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           
           TAG="${{ steps.final-outputs.outputs.version }}"
-          PR_NUMBER=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
+          PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq '.[0].number // empty')
           PR_DATA=$(gh pr view "$PR_NUMBER" --json title,url)
           PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
           PR_URL=$(echo "$PR_DATA" | jq -r '.url')
@@ -205,7 +203,9 @@ jobs:
         id: build
         uses: grafana/shared-workflows/actions/docker-build-push-image@34f27887c37cafe70d34af57dfc86b468a31b8c4 # docker-build-push-image/v0.3.3
         with:
-          registries: dockerhub
+          registries: gar
+          gar-environment: prod
+          gar-repository: dockerhub-cloudcost-exporter-prod-mirror
           platforms: ${{ matrix.platform }}
           outputs: "type=image,push-by-digest=true,name-canonical=true,push=true"
           push: true

--- a/.github/workflows/release-on-tag-push.yml
+++ b/.github/workflows/release-on-tag-push.yml
@@ -94,7 +94,9 @@ jobs:
         id: build
         uses: grafana/shared-workflows/actions/docker-build-push-image@34f27887c37cafe70d34af57dfc86b468a31b8c4 # docker-build-push-image/v0.3.3
         with:
-          registries: dockerhub
+          registries: gar
+          gar-environment: prod
+          gar-repository: dockerhub-cloudcost-exporter-prod-mirror
           platforms: ${{ matrix.platform }}
           outputs: "type=image,push-by-digest=true,name-canonical=true,push=true"
           push: true


### PR DESCRIPTION
## Summary

Migrates the release pipeline off the shared Docker Hub OAT (no longer push-capable post-incident) and onto the gar-image-mirror pattern: workflows push to a dedicated GAR repo via OIDC, and the `gar-image-mirror` service in `ops-eu-south-0` copies to `docker.io/grafana/cloudcost-exporter`.

## Changes

### `release-on-pr-merge.yml`
- **Trigger swap**: `pull_request: closed` → `push: branches: [main]`. Required because GitHub OIDC tokens issued for `pull_request` events are blocked by the strict WIF attribute that protects prod GAR (only `push` events on the default branch / tags are allowed to write to prod GAR).
- **PR context lookups** rewritten to resolve the PR from the commit SHA (`gh api /repos/.../commits/<sha>/pulls`), since `github.event.pull_request.*` is not available in push-event runs.
- **Image push** now targets the dedicated GAR mirror repo `us-docker.pkg.dev/grafanalabs-global/dockerhub-cloudcost-exporter-prod-mirror` via `registries: gar` + `gar-repository: dockerhub-cloudcost-exporter-prod-mirror`.

### `release-on-tag-push.yml`
- **Image push** swapped to GAR (same target as above). Trigger stays `push: tags` (already WIF-compatible, no change needed).

### Not changed
- `build-on-feature-branch.yml` already uses `push: false` so it builds for validation without publishing; needs no auth change.
- `release-helm-chart.yaml` and the `update-helm-chart` job in `release-on-pr-merge.yml` already use the GitHub App Token Broker (configured in #974 and #975) for opening chart-bump PRs; no change needed.
- `deploy` job still triggers Argo with `imageName=grafana/cloudcost-exporter` (Docker Hub path) because cluster pods continue to pull from Docker Hub. The mirror service publishes there asynchronously after each GAR push.

## Related

- grafana/deployment_tools#596202 (GAR repo provisioning)
- grafana/deployment_tools#596219 (mirror mapping)