### PR TITLE
chore(chart): bump appVersion to 1.0.3 to align with latest release

### DIFF
--- a/charts/cloudcost-exporter/Chart.yaml
+++ b/charts/cloudcost-exporter/Chart.yaml
@@ -5,10 +5,10 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.3
+version: 1.1.4
 
 # This is the version of cloudcost-exporter to be deployed, which should be incremented
 # with each release.
-appVersion: "0.33.0"
+appVersion: "1.0.3"
 
 home: https://github.com/grafana/cloudcost-exporter


### PR DESCRIPTION
## Summary

Manually bumps `charts/cloudcost-exporter/Chart.yaml` to align with the latest released binary:

- `version`: `1.1.3` → `1.1.4`
- `appVersion`: `"0.33.0"` → `"1.0.3"`

## Why

The chart's `appVersion` has been stuck on `0.33.0` since 2026-04-14 because the `update-helm-chart` job in `release-on-pr-merge.yml` failed on every release from v0.34.0 onward (Vault role mismatch, then later `insufficient scopes` after the Docker Hub OAT rotation). Both root causes are now fixed (GitHub App Token Broker via #974 / #975, GAR migration via #981), but those fixes only affect *future* releases. The chart is still pointed at a binary tag almost three minor versions behind reality.

This is a one-time manual bump to catch the chart up to the existing `v1.0.3` binary, without cutting a new versioned binary release.

## After merge

`release-helm-chart.yaml` triggers on `push: main` with path filter `charts/cloudcost-exporter/Chart.yaml`, so merging this PR publishes chart `1.1.4` to `grafana.github.io/helm-charts`, pointing at the already-released `v1.0.3` Docker image.

The `updater-for-argo-workflows[bot]` will then pick up the new chart version in a follow-up PR to `grafana/deployment_tools`, vendoring chart `1.1.4` and bumping `cloudcost-exporter-gh-runners` from `1.1.3`. Once that lands, the gh-runners env will finally deploy `v1.0.3` instead of `0.33.0`, matching the regular `cloudcost-exporter` env.
