### PR TITLE
fix(ci): merge duplicate 'with:' blocks in release-helm-chart workflow

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -50,7 +50,6 @@ jobs:
       charts_dir: charts
       cr_configfile: cr.yaml
       ct_configfile: charts/cloudcost-exporter/ct.yaml
-    with:
       github_app: cloudcost-exporter-helm-publisher
 
   trigger-deployment-tools-update:


### PR DESCRIPTION
## Summary

Fixes invalid YAML in `.github/workflows/release-helm-chart.yaml`. The `release-chart` job had two `with:` blocks at the same indentation level, which GitHub Actions rejects with:

```
(Line: 53, Col: 5): 'with' is already defined
```
