### PR TITLE
fix(ci): bump update-helm-repo reusable workflow to a sha that supports github_app input

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -41,7 +41,7 @@ jobs:
 
   release-chart:
     needs: validate-chart
-    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@8522a28e16bc2c84c9339c22c6bdf5446b5e431a
+    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@0cb44b98b41df1bc345376ac40897453fa88df93
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
Bumps the pinned sha of the reusable workflow `grafana/helm-charts/.github/workflows/update-helm-repo.yaml` from `8522a28e` to `0cb44b98` so that the `github_app` input introduced in `grafana/helm-charts` commit `d2a5795` is recognized.