### PR TITLE
fix(): increasing concurrency limit by 3x

### DIFF
--- a/pkg/google/gke/gke.go
+++ b/pkg/google/gke/gke.go
@@ -23,9 +23,10 @@ const (
 	// zoneCollectConcurrencyLimit caps the total number of zone-level goroutines
 	// (ListInstances + ListDisks) that run simultaneously per project during a
 	// scrape. GCP regions contain ~50 zones; without a limit every scrape would
-	// fire ~100 concurrent API calls per project. The value of 10 means at most
-	// 5 zones are queried in parallel, which stays well within GCP quota defaults.
-	zoneCollectConcurrencyLimit = 10
+	// fire ~100 concurrent API calls per project. The value of 30 allows up to
+	// 15 zones to be queried in parallel, reducing scrape latency at the cost of
+	// a higher API request burst rate.
+	zoneCollectConcurrencyLimit = 30
 )
 
 var (


### PR DESCRIPTION
This is a short term fix for Cloud Cost Exporter: Scrape Availability - Error Budget Burn Rate is Very High: https://raintank-corp.slack.com/archives/C09N2LBDT44/p1780404325035709. We will be implementing a more robust fix soon but in the mean time this will take some pressure off the on-caller

Internal discussion: https://github.com/grafana/deployment_tools/issues/608719