### PR TITLE
chore(gcp)!: remove deprecated bucket-projects flag

### DIFF
--- a/cmd/exporter/config/config.go
+++ b/cmd/exporter/config/config.go
@@ -18,11 +18,10 @@ type Config struct {
 			BedrockFamilyFilter string
 		}
 		GCP struct {
-			DefaultGCSDiscount       int
-			Projects                 StringSliceFlag
-			BucketProjectsDeprecated bool
-			Region                   string
-			Services                 StringSliceFlag
+			DefaultGCSDiscount int
+			Projects           StringSliceFlag
+			Region             string
+			Services           StringSliceFlag
 		}
 		Azure struct {
 			Services       StringSliceFlag

--- a/cmd/exporter/config/string_slice_flag.go
+++ b/cmd/exporter/config/string_slice_flag.go
@@ -12,24 +12,3 @@ func (f *StringSliceFlag) Set(value string) error {
 	*f = append(*f, value)
 	return nil
 }
-
-type DeprecatedStringSliceFlag struct {
-	values  *StringSliceFlag
-	wasUsed *bool
-}
-
-func NewDeprecatedStringSliceFlag(values *StringSliceFlag, wasUsed *bool) *DeprecatedStringSliceFlag {
-	return &DeprecatedStringSliceFlag{
-		values:  values,
-		wasUsed: wasUsed,
-	}
-}
-
-func (f *DeprecatedStringSliceFlag) String() string {
-	return f.values.String()
-}
-
-func (f *DeprecatedStringSliceFlag) Set(value string) error {
-	*f.wasUsed = true
-	return f.values.Set(value)
-}

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -46,10 +46,6 @@ func main() {
 	)
 	cfg.Logger = logs
 
-	if cfg.Providers.GCP.BucketProjectsDeprecated {
-		logs.LogAttrs(ctx, slog.LevelWarn, "'gcp.bucket-projects' is deprecated and will be removed in a future version. Use '--gcp.projects' instead.")
-	}
-
 	csp, err := selectProvider(ctx, &cfg)
 	if err != nil {
 		logs.LogAttrs(ctx, slog.LevelError, "Error selecting provider",
@@ -72,7 +68,6 @@ func providerFlags(fs *flag.FlagSet, cfg *config.Config) {
 	flag.StringVar(&cfg.Provider, "provider", "aws", "aws, gcp, or azure")
 	fs.StringVar(&cfg.Providers.AWS.Profile, "aws.profile", "", "AWS Profile to authenticate with.")
 	fs.Var(&cfg.Providers.GCP.Projects, "gcp.projects", "GCP project(s).")
-	fs.Var(config.NewDeprecatedStringSliceFlag(&cfg.Providers.GCP.Projects, &cfg.Providers.GCP.BucketProjectsDeprecated), "gcp.bucket-projects", "GCP project(s). (deprecated: use --gcp.projects instead)")
 	fs.Var(&cfg.Providers.AWS.Services, "aws.services", "AWS service(s).")
 	fs.Var(&cfg.Providers.AWS.ExcludeRegions, "aws.exclude-regions", "AWS region(s) to exclude from cost collection.")
 	fs.Var(&cfg.Providers.Azure.Services, "azure.services", "Azure service(s): AKS, blob (comma-separated and/or repeat flag; case-insensitive).")


### PR DESCRIPTION
Removes the `--gcp.bucket-projects` flag, deprecated for several releases in favor of `--gcp.projects`. This drops the flag registration, the `BucketProjectsDeprecated` config field, the now-unused `DeprecatedStringSliceFlag` helper, and the startup deprecation-warning log.

### Breaking change

`--gcp.bucket-projects` is no longer recognized. Deployments still passing it must switch to `--gcp.projects` (identical semantics — repeatable and/or comma-separated). The flag has emitted a deprecation warning for several releases.

### Validation

- `gofmt -l` reports no changes
- `go vet ./...`, `go build ./...`, `go test ./...` all pass
- `golangci-lint run ./cmd/exporter/...` reports 0 issues

Closes #1000
