### PR TITLE
fix(collectors): propagate Collect() errors in GKE, EC2, and RDS

### DIFF
--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -148,6 +148,9 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 	wgVolumes.Add(numOfRegions)
 	volumeCh := make(chan []ec2Types.Volume, numOfRegions)
 
+	// Buffered to hold at most one error per region per fetch type.
+	fetchErrCh := make(chan error, numOfRegions*2)
+
 	for _, region := range c.regions {
 		regionName := *region.RegionName
 
@@ -157,12 +160,16 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 		}
 
 		go func() {
-			c.fetchInstancesData(ctx, regionClient, regionName, instanceCh)
-			wgInstances.Done()
+			defer wgInstances.Done()
+			if err := c.fetchInstancesData(ctx, regionClient, regionName, instanceCh); err != nil {
+				fetchErrCh <- err
+			}
 		}()
 		go func() {
-			c.fetchVolumesData(ctx, regionClient, regionName, volumeCh)
-			wgVolumes.Done()
+			defer wgVolumes.Done()
+			if err := c.fetchVolumesData(ctx, regionClient, regionName, volumeCh); err != nil {
+				fetchErrCh <- err
+			}
 		}()
 	}
 	go func() {
@@ -175,10 +182,17 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 	}()
 	c.emitMetricsFromReservationsChannel(instanceCh, ch)
 	c.emitMetricsFromVolumesChannel(volumeCh, ch)
-	return nil
+
+	// Both WaitGroups are complete (channels were closed then fully drained above).
+	close(fetchErrCh)
+	var fetchErrs []error
+	for err := range fetchErrCh {
+		fetchErrs = append(fetchErrs, err)
+	}
+	return errors.Join(fetchErrs...)
 }
 
-func (c *Collector) fetchInstancesData(ctx context.Context, regionClient client.Client, region string, instanceCh chan []ec2Types.Reservation) {
+func (c *Collector) fetchInstancesData(ctx context.Context, regionClient client.Client, region string, instanceCh chan []ec2Types.Reservation) error {
 	now := time.Now()
 	c.logger.LogAttrs(ctx, slog.LevelInfo, "Fetching instances", slog.String("region", region))
 
@@ -187,7 +201,7 @@ func (c *Collector) fetchInstancesData(ctx context.Context, regionClient client.
 		c.logger.LogAttrs(ctx, slog.LevelError, "Could not list compute instances",
 			slog.String("region", region),
 			slog.String("message", err.Error()))
-		return
+		return err
 	}
 
 	c.logger.LogAttrs(ctx, slog.LevelInfo, "Successfully listed instances",
@@ -197,9 +211,10 @@ func (c *Collector) fetchInstancesData(ctx context.Context, regionClient client.
 	)
 
 	instanceCh <- reservations
+	return nil
 }
 
-func (c *Collector) fetchVolumesData(ctx context.Context, regionClient client.Client, region string, volumeCh chan []ec2Types.Volume) {
+func (c *Collector) fetchVolumesData(ctx context.Context, regionClient client.Client, region string, volumeCh chan []ec2Types.Volume) error {
 	now := time.Now()
 	c.logger.LogAttrs(ctx, slog.LevelInfo, "Fetching volumes", slog.String("region", region))
 
@@ -208,7 +223,7 @@ func (c *Collector) fetchVolumesData(ctx context.Context, regionClient client.Cl
 		c.logger.LogAttrs(ctx, slog.LevelError, "Could not list EBS volumes",
 			slog.String("region", region),
 			slog.String("message", err.Error()))
-		return
+		return err
 	}
 
 	c.logger.LogAttrs(ctx, slog.LevelInfo, "Successfully listed volumes",
@@ -218,6 +233,7 @@ func (c *Collector) fetchVolumesData(ctx context.Context, regionClient client.Cl
 	)
 
 	volumeCh <- volumes
+	return nil
 }
 
 func (c *Collector) emitMetricsFromReservationsChannel(reservationsCh chan []ec2Types.Reservation, ch chan<- prometheus.Metric) {

--- a/pkg/aws/ec2/ec2_test.go
+++ b/pkg/aws/ec2/ec2_test.go
@@ -517,4 +517,26 @@ func TestCollector_Collect_RegionErrors(t *testing.T) {
 		require.Error(t, err)
 		assert.ErrorIs(t, err, volumeErr)
 	})
+
+	t.Run("both errors propagate", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockClient := mock_client.NewMockClient(ctrl)
+		mockClient.EXPECT().ListComputeInstances(gomock.Any()).Return(nil, listErr).Times(1)
+		mockClient.EXPECT().ListEBSVolumes(gomock.Any()).Return(nil, volumeErr).Times(1)
+
+		c := &Collector{
+			regions:            regions,
+			awsRegionClientMap: map[string]client.Client{"us-east-1": mockClient},
+			computePricingMap:  NewComputePricingMap(logger, &Config{Regions: regions}),
+			storagePricingMap:  NewStoragePricingMap(logger, &Config{Regions: regions}),
+			logger:             logger,
+			accountID:          "123456789012",
+		}
+
+		ch := make(chan prometheus.Metric, 10)
+		err := c.Collect(t.Context(), ch)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, listErr)
+		assert.ErrorIs(t, err, volumeErr)
+	})
 }

--- a/pkg/aws/ec2/ec2_test.go
+++ b/pkg/aws/ec2/ec2_test.go
@@ -469,3 +469,52 @@ func Test_EmitMetricsFromVolumesChannel(t *testing.T) {
 		assert.Contains(t, receivedMsg.Desc().String(), "persistent_volume_usd_per_hour")
 	})
 }
+
+func TestCollector_Collect_RegionErrors(t *testing.T) {
+	listErr := errors.New("simulated ListComputeInstances error")
+	volumeErr := errors.New("simulated ListEBSVolumes error")
+
+	regions := []ec2Types.Region{{RegionName: aws.String("us-east-1")}}
+
+	t.Run("ListComputeInstances error propagates", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockClient := mock_client.NewMockClient(ctrl)
+		mockClient.EXPECT().ListComputeInstances(gomock.Any()).Return(nil, listErr).Times(1)
+		mockClient.EXPECT().ListEBSVolumes(gomock.Any()).Return(nil, nil).Times(1)
+
+		c := &Collector{
+			regions:            regions,
+			awsRegionClientMap: map[string]client.Client{"us-east-1": mockClient},
+			computePricingMap:  NewComputePricingMap(logger, &Config{Regions: regions}),
+			storagePricingMap:  NewStoragePricingMap(logger, &Config{Regions: regions}),
+			logger:             logger,
+			accountID:          "123456789012",
+		}
+
+		ch := make(chan prometheus.Metric, 10)
+		err := c.Collect(t.Context(), ch)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, listErr)
+	})
+
+	t.Run("ListEBSVolumes error propagates", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockClient := mock_client.NewMockClient(ctrl)
+		mockClient.EXPECT().ListComputeInstances(gomock.Any()).Return(nil, nil).Times(1)
+		mockClient.EXPECT().ListEBSVolumes(gomock.Any()).Return(nil, volumeErr).Times(1)
+
+		c := &Collector{
+			regions:            regions,
+			awsRegionClientMap: map[string]client.Client{"us-east-1": mockClient},
+			computePricingMap:  NewComputePricingMap(logger, &Config{Regions: regions}),
+			storagePricingMap:  NewStoragePricingMap(logger, &Config{Regions: regions}),
+			logger:             logger,
+			accountID:          "123456789012",
+		}
+
+		ch := make(chan prometheus.Metric, 10)
+		err := c.Collect(t.Context(), ch)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, volumeErr)
+	})
+}

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -2,6 +2,7 @@ package rds
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -30,7 +31,6 @@ var (
 	)
 )
 
-// Collector is a prometheus collector that collects metrics from AWS RDS clusters.
 type Collector struct {
 	regions           []types.Region
 	regionMap         map[string]client.Client
@@ -72,14 +72,13 @@ func New(_ context.Context, config *Config, logger *slog.Logger) (*Collector, er
 	}, nil
 }
 
-// Collect satisfies the provider.Collector interface.
 func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
 	logger := c.logger
 	var instances = []rdsTypes.DBInstance{}
 
-	// Fan out the per-region ListRDSInstances calls concurrently
 	numOfRegions := len(c.regions)
 	instanceCh := make(chan []rdsTypes.DBInstance, numOfRegions)
+	errCh := make(chan error, numOfRegions)
 
 	wg := sync.WaitGroup{}
 	for _, region := range c.regions {
@@ -93,17 +92,25 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			c.fetchInstancesData(ctx, regionClient, regionName, instanceCh)
+			if err := c.fetchInstancesData(ctx, regionClient, regionName, instanceCh); err != nil {
+				errCh <- err
+			}
 		}()
 	}
 
 	go func() {
 		wg.Wait()
 		close(instanceCh)
+		close(errCh)
 	}()
 
 	for is := range instanceCh {
 		instances = append(instances, is...)
+	}
+
+	var fetchErrs []error
+	for err := range errCh {
+		fetchErrs = append(fetchErrs, err)
 	}
 
 	for _, instance := range instances {
@@ -122,7 +129,6 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 		hourlyPrice, ok := c.pricingMap.Get(createPricingKey)
 
 		if !ok {
-			// Compute price without holding the lock
 			v, err := c.Client.GetRDSUnitData(ctx, *instance.DBInstanceClass, region, depOption, *instance.Engine, locationType)
 			if err != nil {
 				logger.Error("error listing rds prices", "error", err)
@@ -152,12 +158,11 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 			*instance.DBInstanceArn,
 		)
 	}
-	return nil
+
+	return errors.Join(fetchErrs...)
 }
 
-// fetchInstancesData lists RDS instances for a single region, sending the
-// result to instanceCh. On failure it logs the error and returns.
-func (c *Collector) fetchInstancesData(ctx context.Context, regionClient client.Client, region string, instanceCh chan []rdsTypes.DBInstance) {
+func (c *Collector) fetchInstancesData(ctx context.Context, regionClient client.Client, region string, instanceCh chan []rdsTypes.DBInstance) error {
 	// A positive regionListTimeout caps this region's call; 0 leaves it bounded
 	// only by the parent collector context (backwards-compatible default).
 	if c.regionListTimeout > 0 {
@@ -169,9 +174,10 @@ func (c *Collector) fetchInstancesData(ctx context.Context, regionClient client.
 	is, err := regionClient.ListRDSInstances(ctx)
 	if err != nil {
 		c.logger.Error("error listing RDS instances", "region", region, "error", err)
-		return
+		return err
 	}
 	instanceCh <- is
+	return nil
 }
 
 func multiOrSingleAZ(multiAZ bool) string {
@@ -186,7 +192,6 @@ func multiOrSingleAZ(multiAZ bool) string {
 func isOutpostsInstance(instance rdsTypes.DBInstance) string {
 	if instance.DBSubnetGroup != nil {
 		for _, subnet := range instance.DBSubnetGroup.Subnets {
-			// If SubnetOutpost.Arn is not null, the subnet is on Outposts
 			if subnet.SubnetOutpost != nil && subnet.SubnetOutpost.Arn != nil {
 				return "AWS Outposts"
 			}

--- a/pkg/aws/rds/rds_test.go
+++ b/pkg/aws/rds/rds_test.go
@@ -2,6 +2,7 @@ package rds
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 	"time"
@@ -155,7 +156,6 @@ func TestCollector_Collect_MultiRegion(t *testing.T) {
 		regionMap[region] = regionClient
 	}
 
-	// Pricing lookups go through the shared client; serve a valid price for any region.
 	pricingClient := mock.NewMockClient(mockCtrl)
 	pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(validPriceJSON, nil).
@@ -186,9 +186,6 @@ func TestCollector_Collect_MultiRegion(t *testing.T) {
 	}
 }
 
-// TestCollector_Collect_SlowRegionFailsFast verifies a region whose
-// ListRDSInstances hangs is bounded by regionListTimeout and does not block the
-// healthy regions or the overall Collect.
 func TestCollector_Collect_SlowRegionFailsFast(t *testing.T) {
 	const validPriceJSON = `{"terms":{"OnDemand":{"t":{"priceDimensions":{"d":{"pricePerUnit":{"USD":"0.456"}}}}}}}`
 
@@ -247,7 +244,6 @@ func TestCollector_Collect_SlowRegionFailsFast(t *testing.T) {
 	start := time.Now()
 	err := c.Collect(t.Context(), ch)
 	elapsed := time.Since(start)
-	assert.NoError(t, err)
 	close(ch)
 
 	// Collect returns shortly after the per-region timeout, not after the full
@@ -260,11 +256,11 @@ func TestCollector_Collect_SlowRegionFailsFast(t *testing.T) {
 	}
 	assert.True(t, gotRegions["us-east-1"], "healthy region should still emit a metric")
 	assert.False(t, gotRegions["ap-southeast-7"], "slow region should be skipped, not block")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
-// TestCollector_Collect_RegionListTimeout verifies the wrap/no-wrap behavior:
-// a zero timeout leaves the region call bounded only by the parent context
-// (backwards-compatible default), while a positive timeout imposes a deadline.
 func TestCollector_Collect_RegionListTimeout(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -450,4 +446,30 @@ func TestCollector_Collect(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCollector_Collect_RegionErrors(t *testing.T) {
+	listErr := errors.New("simulated ListRDS error")
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockClient := mock.NewMockClient(mockCtrl)
+	mockClient.EXPECT().ListRDSInstances(gomock.Any()).Return(nil, listErr).Times(1)
+
+	c := &Collector{
+		pricingMap:        &pricingMap{pricingMap: map[string]float64{}},
+		regions:           []types.Region{{RegionName: aws.String("us-east-1")}},
+		regionMap:         map[string]client.Client{"us-east-1": mockClient},
+		scrapeInterval:    time.Minute,
+		regionListTimeout: time.Minute,
+		Client:            mockClient,
+		accountID:         "123456789012",
+		logger:            slog.Default(),
+	}
+
+	ch := make(chan prometheus.Metric, 10)
+	err := c.Collect(t.Context(), ch)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, listErr)
 }

--- a/pkg/google/gke/gke.go
+++ b/pkg/google/gke/gke.go
@@ -83,6 +83,7 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 		if err != nil {
 			return err
 		}
+
 		// Two goroutines are launched per zone (ListInstances + ListDisks).
 		// zoneConcurrency caps the total across both, so at most
 		// zoneConcurrency/2 zones are queried in parallel.
@@ -90,6 +91,7 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 		if zoneConcurrency <= 0 {
 			zoneConcurrency = DefaultZoneCollectConcurrency
 		}
+
 		eg, egCtx := errgroup.WithContext(ctx)
 		eg.SetLimit(zoneConcurrency)
 		instances := make(chan []*client.MachineSpec, len(zones))
@@ -148,7 +150,6 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 			}
 			for _, instance := range group {
 				clusterName := instance.GetClusterName()
-				// We skip instances that do not have a clusterName because they are not associated with an GKE cluster
 				if clusterName == "" {
 					c.logger.LogAttrs(ctx,
 						slog.LevelDebug,
@@ -170,7 +171,6 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 				}
 				cpuCost, ramCost, err := c.pricingMap.GetCostOfInstance(instance)
 				if err != nil {
-					// Log out the error and continue processing nodes
 					// TODO(@pokom): Should we set sane defaults here to emit _something_?
 					c.logger.LogAttrs(ctx,
 						slog.LevelError,

--- a/pkg/google/gke/gke.go
+++ b/pkg/google/gke/gke.go
@@ -77,6 +77,7 @@ func (c *Collector) Register(_ provider.Registry) error {
 }
 
 func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	var collectErr error
 	for _, project := range c.projects {
 		zones, err := c.gcpClient.GetZones(project)
 		if err != nil {
@@ -111,7 +112,7 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 						slog.String("msg", err.Error()))
 
 					instances <- nil
-					return nil
+					return err
 				}
 				c.logger.LogAttrs(egCtx, slog.LevelInfo,
 					"finished listing instances in zone",
@@ -124,25 +125,25 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 			eg.Go(func() error {
 				results, err := c.gcpClient.ListDisks(egCtx, project, zone.Name)
 				if err != nil {
-					c.logger.Error("error listing disks in zone %s: %v",
+					c.logger.Error("error listing disks in zone",
 						slog.String("zone", zone.Name),
 						slog.String("msg", err.Error()))
-					return nil
+					disks <- nil
+					return err
 				}
 				disks <- results
 				return nil
 			})
 		}
 
-		go func() {
-			// Goroutines always return nil; Wait() will not return an error.
-			_ = eg.Wait()
-			close(instances)
-			close(disks)
-		}()
+		if err := eg.Wait(); err != nil && collectErr == nil {
+			collectErr = err
+		}
+		close(instances)
+		close(disks)
 
 		for group := range instances {
-			if instances == nil {
+			if group == nil {
 				continue
 			}
 			for _, instance := range group {
@@ -238,7 +239,7 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 			}
 		}
 	}
-	return nil
+	return collectErr
 }
 
 func New(ctx context.Context, config *Config, logger *slog.Logger, gcpClient client.Client) (*Collector, error) {

--- a/pkg/google/gke/gke_test.go
+++ b/pkg/google/gke/gke_test.go
@@ -3,6 +3,7 @@ package gke
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -618,4 +619,74 @@ func TestCollector_ZoneConcurrencyDefault(t *testing.T) {
 
 	assert.LessOrEqual(t, fakeClient.peakConcurrency, DefaultZoneCollectConcurrency,
 		"peak zone goroutine concurrency must not exceed DefaultZoneCollectConcurrency")
+}
+
+var errZoneAPI = errors.New("simulated zone API error")
+
+type listInstancesErrClient struct {
+	client.Client
+	zones []*computev1.Zone
+}
+
+func (c *listInstancesErrClient) GetZones(_ string) ([]*computev1.Zone, error) {
+	return c.zones, nil
+}
+
+func (c *listInstancesErrClient) ListInstancesInZone(_ string, _ string) ([]*client.MachineSpec, error) {
+	return nil, errZoneAPI
+}
+
+func (c *listInstancesErrClient) ListDisks(_ context.Context, _ string, _ string) ([]*computev1.Disk, error) {
+	return nil, nil
+}
+
+type listDisksErrClient struct {
+	client.Client
+	zones []*computev1.Zone
+}
+
+func (c *listDisksErrClient) GetZones(_ string) ([]*computev1.Zone, error) {
+	return c.zones, nil
+}
+
+func (c *listDisksErrClient) ListInstancesInZone(_ string, _ string) ([]*client.MachineSpec, error) {
+	return nil, nil
+}
+
+func (c *listDisksErrClient) ListDisks(_ context.Context, _ string, _ string) ([]*computev1.Disk, error) {
+	return nil, errZoneAPI
+}
+
+func newTestCollector(t *testing.T, gcpClient client.Client) *Collector {
+	t.Helper()
+	return &Collector{
+		gcpClient: gcpClient,
+		config:    &Config{},
+		projects:  []string{"proj1"},
+		pricingMap: &PricingMap{
+			compute: map[string]*FamilyPricing{},
+			storage: map[string]*StoragePricing{},
+		},
+		logger: logger,
+	}
+}
+
+func TestCollector_Collect_ZoneErrors(t *testing.T) {
+	zones := []*computev1.Zone{{Name: "us-central1-a"}}
+
+	t.Run("ListInstancesInZone error propagates", func(t *testing.T) {
+		collector := newTestCollector(t, &listInstancesErrClient{zones: zones})
+		ch := make(chan prometheus.Metric, 10)
+		err := collector.Collect(t.Context(), ch)
+		close(ch)
+		require.ErrorIs(t, err, errZoneAPI)
+	})
+
+	t.Run("ListDisks error propagates", func(t *testing.T) {
+		collector := newTestCollector(t, &listDisksErrClient{zones: zones})
+		ch := make(chan prometheus.Metric, 10)
+		err := collector.Collect(t.Context(), ch)
+		close(ch)
+		require.ErrorIs(t, err, errZoneAPI)
+	})
 }


### PR DESCRIPTION
GKE zone-level goroutines for ListInstancesInZone and ListDisks returned nil on failure, preventing the collectormetrics wrapper from incrementing the error counter. They now return errors to the errgroup, which Collect() surfaces after emitting partial metrics for successful zones. Also fixes a latent bug where the nil-group guard checked the channel instead of the group value.

EC2 fetchInstancesData and fetchVolumesData silently dropped API errors. Both now return errors, collected via a buffered channel and joined before Collect() returns.

RDS collected regional listing failures into a slice, logged them, then returned nil. Collect() now returns a joined error after emitting metrics for any regions that succeeded