### PR TITLE
docs: add deprecation policy

### DIFF
--- a/docs/contribute/README.md
+++ b/docs/contribute/README.md
@@ -20,6 +20,7 @@ We have the following development guides available.
 1. [Developer Guide](developer-guide.md) - Setup and development workflow
 2. [Creating a New Module](creating-a-new-module.md) - Add support for a new cloud service
 3. [Release Process](releases.md) - How releases are created
+4. [Deprecation Policy](./deprecation-policy.md) - How to deprecate an existing feature
 
 **Additional**
 - [Logging Guidelines](logging.md) - Best practices for logging

--- a/docs/contribute/deprecation-policy.md
+++ b/docs/contribute/deprecation-policy.md
@@ -6,7 +6,7 @@ Backward compatibility and feature stability matter, especially since cloudcost-
 
 1. Mark a feature as deprecated - example: https://github.com/grafana/cloudcost-exporter/pull/467:
    1. Open a PR so that cloudcost-exporter logs a deprecation warning.
-   2. Update docs with a warning as well.
+   2. Update any docs with a warning as well. For example, update the service's docs if this is a Prometheus metric or label change; if this is a CLI flag change, find any references to it in the docs and add a warning, including in the Helm chart and its docs.
    3. In the warning, recommend the feature that replaces it (if any), and inform the user about the major release (`x.0.0`) that is targeted for the feature's removal.
 2. Track the feature to be deprecated in an issue, including the major release (`x.0.0`) that is targeted for this feature's removal. Example: https://github.com/grafana/cloudcost-exporter/issues/1000.
 3. A deprecated feature must remain available for a minimum of 3 minor releases or months, whichever is longer.

--- a/docs/contribute/deprecation-policy.md
+++ b/docs/contribute/deprecation-policy.md
@@ -1,0 +1,13 @@
+# Deprecation Policy
+
+Backward compatibility and feature stability matter, especially since cloudcost-exporter is used in production systems and reached its first major (`x.0.0`) [semver](https://semver.org/#semantic-versioning-specification-semver) version. The project should follow a deprecation policy for removing existing features to minimize breaking changes. This applies to features like Prometheus metric names and labels and CLI flags.
+
+## Steps
+
+1. Mark a feature as deprecated - example: https://github.com/grafana/cloudcost-exporter/pull/467:
+   1. Open a PR so that cloudcost-exporter logs a deprecation warning.
+   2. Update docs with a warning as well.
+   3. In the warning, recommend the feature that replaces it (if any), and inform the user about the major release (`x.0.0`) that is targeted for the feature's removal.
+2. Track the feature to be deprecated in an issue, including the major release (`x.0.0`) that is targeted for this feature's removal. Example: https://github.com/grafana/cloudcost-exporter/issues/1000.
+3. A deprecated feature must remain available for a minimum of 3 minor releases or months, whichever is longer.
+4. When the team / maintainers decide that cloudcost-exporter is ready for a major release, open a PR to fully remove all features that were marked as deprecated, including any helper funcs, warning logs, docs, etc.


### PR DESCRIPTION
## Why

`cloudcost-exporter` reached `v1.0.0` and is used in production. Removing user-facing features (Prometheus metric names and labels, CLI flags) requires explicit guardrails. Major releases also require a deprecation policy in place so that removing features can be planned as part of the release process.

## What

Adds `docs/contribute/deprecation-policy.md` covering:

- When the deprecation policy applies (Prometheus metrics and labels, CLI flags)
- Steps to mark a feature as deprecated (warning log, docs update, replacement guidance, target removal version)
- Minimum notice window: 3 minor releases or 3 months, whichever is longer
- Removal at a major release

Links the policy from `docs/contribute/README.md`.