### PR TITLE
fix(rds): parallelize per-region instance fan-out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ go.work
 .run
 .idea
 .vscode
+.claude
 
 # Ignore the compiled binary at root, but not charts/cloudcost-exporter
 /cloudcost-exporter

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -48,12 +49,6 @@ type Config struct {
 	AccountID      string
 }
 
-type listError struct {
-	region string
-	error  error
-	reason string
-}
-
 const (
 	serviceName = "RDS"
 )
@@ -75,36 +70,34 @@ func New(_ context.Context, config *Config, logger *slog.Logger) (*Collector, er
 func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
 	logger := c.logger
 	var instances = []rdsTypes.DBInstance{}
-	var regionErrors []listError
+
+	// Fan out the per-region ListRDSInstances calls concurrently
+	numOfRegions := len(c.regions)
+	instanceCh := make(chan []rdsTypes.DBInstance, numOfRegions)
+
+	wg := sync.WaitGroup{}
 	for _, region := range c.regions {
 		regionName := *region.RegionName
 		regionClient, ok := c.regionMap[regionName]
 		if !ok {
-			regionErrors = append(regionErrors, listError{
-				region: regionName,
-				error:  fmt.Errorf("no client found for region"),
-				reason: "no client found",
-			})
+			logger.Error("no client found for region", "region", regionName)
 			continue
 		}
 
-		is, err := regionClient.ListRDSInstances(ctx)
-		if err != nil {
-			regionErrors = append(regionErrors, listError{
-				region: regionName,
-				error:  err,
-				reason: "error listing RDS instances",
-			})
-			continue
-		}
-
-		instances = append(instances, is...)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.fetchInstancesData(ctx, regionClient, regionName, instanceCh)
+		}()
 	}
 
-	if len(regionErrors) > 0 {
-		for _, re := range regionErrors {
-			logger.Error(re.reason, "region", re.region, "error", re.error)
-		}
+	go func() {
+		wg.Wait()
+		close(instanceCh)
+	}()
+
+	for is := range instanceCh {
+		instances = append(instances, is...)
 	}
 
 	for _, instance := range instances {
@@ -154,6 +147,17 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 		)
 	}
 	return nil
+}
+
+// fetchInstancesData lists RDS instances for a single region, sending the
+// result to instanceCh. On failure it logs the error and returns.
+func (c *Collector) fetchInstancesData(ctx context.Context, regionClient client.Client, region string, instanceCh chan []rdsTypes.DBInstance) {
+	is, err := regionClient.ListRDSInstances(ctx)
+	if err != nil {
+		c.logger.Error("error listing RDS instances", "region", region, "error", err)
+		return
+	}
+	instanceCh <- is
 }
 
 func multiOrSingleAZ(multiAZ bool) string {

--- a/pkg/aws/rds/rds_test.go
+++ b/pkg/aws/rds/rds_test.go
@@ -110,6 +110,79 @@ func TestMultiOrSingleAZ(t *testing.T) {
 	}
 }
 
+func TestCollector_Collect_MultiRegion(t *testing.T) {
+	const validPriceJSON = `{
+            "terms": {
+                "OnDemand": {
+                    "term1": {
+                        "priceDimensions": {
+                            "dim1": {
+                                "pricePerUnit": {"USD": "0.456"}
+                            }
+                        }
+                    }
+                }
+            }
+        }`
+
+	instanceFor := func(region, id string) rdsTypes.DBInstance {
+		return rdsTypes.DBInstance{
+			DBSubnetGroup:        &rdsTypes.DBSubnetGroup{},
+			AvailabilityZone:     aws.String(region + "a"),
+			DBInstanceClass:      aws.String("db.t3.medium"),
+			Engine:               aws.String("postgres"),
+			DBInstanceIdentifier: aws.String(id),
+			MultiAZ:              aws.Bool(false),
+			DbiResourceId:        aws.String(id),
+			DBInstanceArn:        aws.String("arn-" + id),
+		}
+	}
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	regionNames := []string{"us-east-1", "eu-west-1", "ap-southeast-7"}
+	regions := make([]types.Region, 0, len(regionNames))
+	regionMap := make(map[string]client.Client, len(regionNames))
+	for _, region := range regionNames {
+		regions = append(regions, types.Region{RegionName: aws.String(region)})
+		regionClient := mock.NewMockClient(mockCtrl)
+		regionClient.EXPECT().ListRDSInstances(gomock.Any()).
+			Return([]rdsTypes.DBInstance{instanceFor(region, "db-"+region)}, nil).
+			Times(1)
+		regionMap[region] = regionClient
+	}
+
+	// Pricing lookups go through the shared client; serve a valid price for any region.
+	pricingClient := mock.NewMockClient(mockCtrl)
+	pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(validPriceJSON, nil).
+		AnyTimes()
+
+	c := &Collector{
+		pricingMap:     newPricingMap(),
+		regions:        regions,
+		regionMap:      regionMap,
+		scrapeInterval: time.Minute,
+		Client:         pricingClient,
+		accountID:      "123456789012",
+		logger:         slog.Default(),
+	}
+
+	ch := make(chan prometheus.Metric, len(regionNames))
+	err := c.Collect(t.Context(), ch)
+	assert.NoError(t, err)
+	close(ch)
+
+	gotRegions := map[string]bool{}
+	for metric := range ch {
+		gotRegions[utils.ReadMetrics(metric).Labels["region"]] = true
+	}
+	for _, region := range regionNames {
+		assert.True(t, gotRegions[region], "expected a metric for region %s", region)
+	}
+}
+
 func TestCollector_Collect(t *testing.T) {
 	const cacheKey = "us-east-1-db.t3.medium-mysql-Single-AZ-AWS Outposts"
 	validPriceJSON := `{


### PR DESCRIPTION
## What

Parallelize the per-region instance fan-out in the RDS collector, mirroring the EC2 collector's pattern.

## Why

The `prod-us-east-0` deployment was erroring on RDS scrapes:

```
level=ERROR msg="error listing RDS instances" provider=aws collector=RDS region=ap-southeast-7 error="operation error RDS: DescribeDBInstances, context deadline exceeded"
```

`RDS Collector.Collect()` queried every region's `DescribeDBInstances` **sequentially** in a single loop, under the shared 1-minute collector timeout. As AWS added more (and more distant) regions, the cumulative per-region latency exhausted the deadline. The error surfaced on whichever region happened to be in flight when the parent context expired — here `ap-southeast-7` (Bangkok). RDS was the only collector still iterating regions serially; EC2 already fans out concurrently.

## How

- Fan the per-region `ListRDSInstances` calls out across goroutines via a `WaitGroup` + buffered channel, matching the EC2 collector. This turns cumulative cross-region latency into max-of-regions latency, so one slow or distant region no longer starves the rest of the scrape.
- Added a `fetchInstancesData` helper that logs errors inline and returns, mirroring EC2's helper (no error channel).
- "no client found for region" is logged inline and skipped, as before.

## Testing

- Added `TestCollector_Collect_MultiRegion` — three regions (incl. `ap-southeast-7`), asserting a metric is emitted per region.
- `go build ./pkg/aws/rds/`, `go vet ./pkg/aws/rds/`, and `go test -race ./pkg/aws/rds/` all pass.