### PR TITLE
fix(rds): cap per-region DescribeDBInstances with a timeout

### DIFF
--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -32,13 +32,14 @@ var (
 
 // Collector is a prometheus collector that collects metrics from AWS RDS clusters.
 type Collector struct {
-	regions        []types.Region
-	regionMap      map[string]client.Client
-	scrapeInterval time.Duration
-	Client         client.Client
-	pricingMap     *pricingMap
-	accountID      string
-	logger         *slog.Logger
+	regions           []types.Region
+	regionMap         map[string]client.Client
+	scrapeInterval    time.Duration
+	regionListTimeout time.Duration
+	Client            client.Client
+	pricingMap        *pricingMap
+	accountID         string
+	logger            *slog.Logger
 }
 
 type Config struct {
@@ -51,18 +52,25 @@ type Config struct {
 
 const (
 	serviceName = "RDS"
+
+	// regionListTimeout caps a single region's DescribeDBInstances call so a slow
+	// or unreachable region fails fast instead of consuming the whole collector
+	// budget. Without it, one region riding the full ~60s budget overruns the
+	// Prometheus scrape_timeout and fails the scrape (up=0).
+	regionListTimeout = 15 * time.Second
 )
 
 // New creates an rds collector
 func New(_ context.Context, config *Config, logger *slog.Logger) (*Collector, error) {
 	return &Collector{
-		pricingMap:     newPricingMap(),
-		regions:        config.Regions,
-		regionMap:      config.RegionMap,
-		scrapeInterval: config.ScrapeInterval,
-		Client:         config.Client,
-		accountID:      config.AccountID,
-		logger:         logger.With("collector", serviceName),
+		pricingMap:        newPricingMap(),
+		regions:           config.Regions,
+		regionMap:         config.RegionMap,
+		scrapeInterval:    config.ScrapeInterval,
+		regionListTimeout: regionListTimeout,
+		Client:            config.Client,
+		accountID:         config.AccountID,
+		logger:            logger.With("collector", serviceName),
 	}, nil
 }
 
@@ -152,7 +160,10 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 // fetchInstancesData lists RDS instances for a single region, sending the
 // result to instanceCh. On failure it logs the error and returns.
 func (c *Collector) fetchInstancesData(ctx context.Context, regionClient client.Client, region string, instanceCh chan []rdsTypes.DBInstance) {
-	is, err := regionClient.ListRDSInstances(ctx)
+	regionCtx, cancel := context.WithTimeout(ctx, c.regionListTimeout)
+	defer cancel()
+
+	is, err := regionClient.ListRDSInstances(regionCtx)
 	if err != nil {
 		c.logger.Error("error listing RDS instances", "region", region, "error", err)
 		return

--- a/pkg/aws/rds/rds_test.go
+++ b/pkg/aws/rds/rds_test.go
@@ -1,6 +1,7 @@
 package rds
 
 import (
+	"context"
 	"log/slog"
 	"testing"
 	"time"
@@ -160,13 +161,14 @@ func TestCollector_Collect_MultiRegion(t *testing.T) {
 		AnyTimes()
 
 	c := &Collector{
-		pricingMap:     newPricingMap(),
-		regions:        regions,
-		regionMap:      regionMap,
-		scrapeInterval: time.Minute,
-		Client:         pricingClient,
-		accountID:      "123456789012",
-		logger:         slog.Default(),
+		pricingMap:        newPricingMap(),
+		regions:           regions,
+		regionMap:         regionMap,
+		scrapeInterval:    time.Minute,
+		regionListTimeout: time.Minute,
+		Client:            pricingClient,
+		accountID:         "123456789012",
+		logger:            slog.Default(),
 	}
 
 	ch := make(chan prometheus.Metric, len(regionNames))
@@ -181,6 +183,82 @@ func TestCollector_Collect_MultiRegion(t *testing.T) {
 	for _, region := range regionNames {
 		assert.True(t, gotRegions[region], "expected a metric for region %s", region)
 	}
+}
+
+// TestCollector_Collect_SlowRegionFailsFast verifies a region whose
+// ListRDSInstances hangs is bounded by regionListTimeout and does not block the
+// healthy regions or the overall Collect.
+func TestCollector_Collect_SlowRegionFailsFast(t *testing.T) {
+	const validPriceJSON = `{"terms":{"OnDemand":{"t":{"priceDimensions":{"d":{"pricePerUnit":{"USD":"0.456"}}}}}}}`
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	healthyInstance := rdsTypes.DBInstance{
+		DBSubnetGroup:        &rdsTypes.DBSubnetGroup{},
+		AvailabilityZone:     aws.String("us-east-1a"),
+		DBInstanceClass:      aws.String("db.t3.medium"),
+		Engine:               aws.String("postgres"),
+		DBInstanceIdentifier: aws.String("healthy-db"),
+		MultiAZ:              aws.Bool(false),
+		DbiResourceId:        aws.String("healthy-db"),
+		DBInstanceArn:        aws.String("arn-healthy"),
+	}
+
+	healthy := mock.NewMockClient(mockCtrl)
+	healthy.EXPECT().ListRDSInstances(gomock.Any()).
+		Return([]rdsTypes.DBInstance{healthyInstance}, nil).
+		Times(1)
+
+	// The slow region blocks until its (timeout-bounded) context is canceled,
+	// then returns the context error — mimicking an unreachable endpoint.
+	slow := mock.NewMockClient(mockCtrl)
+	slow.EXPECT().ListRDSInstances(gomock.Any()).
+		DoAndReturn(func(ctx context.Context) ([]rdsTypes.DBInstance, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}).
+		Times(1)
+
+	pricingClient := mock.NewMockClient(mockCtrl)
+	pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(validPriceJSON, nil).
+		AnyTimes()
+
+	c := &Collector{
+		pricingMap: newPricingMap(),
+		regions: []types.Region{
+			{RegionName: aws.String("us-east-1")},
+			{RegionName: aws.String("ap-southeast-7")},
+		},
+		regionMap: map[string]client.Client{
+			"us-east-1":      healthy,
+			"ap-southeast-7": slow,
+		},
+		scrapeInterval:    time.Minute,
+		regionListTimeout: 50 * time.Millisecond,
+		Client:            pricingClient,
+		accountID:         "123456789012",
+		logger:            slog.Default(),
+	}
+
+	ch := make(chan prometheus.Metric, 2)
+	start := time.Now()
+	err := c.Collect(t.Context(), ch)
+	elapsed := time.Since(start)
+	assert.NoError(t, err)
+	close(ch)
+
+	// Collect returns shortly after the per-region timeout, not after the full
+	// collector budget; allow generous slack for CI scheduling.
+	assert.Less(t, elapsed, 5*time.Second, "slow region should not block Collect")
+
+	gotRegions := map[string]bool{}
+	for metric := range ch {
+		gotRegions[utils.ReadMetrics(metric).Labels["region"]] = true
+	}
+	assert.True(t, gotRegions["us-east-1"], "healthy region should still emit a metric")
+	assert.False(t, gotRegions["ap-southeast-7"], "slow region should be skipped, not block")
 }
 
 func TestCollector_Collect(t *testing.T) {
@@ -287,13 +365,14 @@ func TestCollector_Collect(t *testing.T) {
 			}
 
 			c := &Collector{
-				pricingMap:     &pricingMap{pricingMap: tt.initialCache},
-				regions:        []types.Region{{RegionName: aws.String("us-east-1")}},
-				regionMap:      map[string]client.Client{"us-east-1": mockClient},
-				scrapeInterval: time.Minute,
-				Client:         mockClient,
-				accountID:      "123456789012",
-				logger:         slog.Default(),
+				pricingMap:        &pricingMap{pricingMap: tt.initialCache},
+				regions:           []types.Region{{RegionName: aws.String("us-east-1")}},
+				regionMap:         map[string]client.Client{"us-east-1": mockClient},
+				scrapeInterval:    time.Minute,
+				regionListTimeout: time.Minute,
+				Client:            mockClient,
+				accountID:         "123456789012",
+				logger:            slog.Default(),
 			}
 
 			ch := make(chan prometheus.Metric, 1)


### PR DESCRIPTION
## What

Cap each region's `ListRDSInstances` (`DescribeDBInstances`) call with a per-region context timeout so a slow or unreachable region fails fast instead of consuming the whole collector budget.

## Why

After parallelizing the RDS region fan-out (#1017), the `prod-us-east-0` Scrape Availability SLO was still burning.

`scrape_duration_seconds` was repeatedly hitting ~55s and `up` dropped to 0 at exactly those points: a single slow/unreachable region rode the full ~60s collector budget via the AWS SDK's retries (`maxRetryAttempts = 10`), pushing the `/metrics` scrape past its `scrape_timeout` (~55s) and failing the whole scrape. Because per-region list errors are swallowed (logged, not returned), `cloudcost_exporter_collector_last_scrape_error` stayed clean while `up` went red — so only `up` reflected the problem.

The fan-out stopped one slow region from starving the others, but didn't bound how long that one region could take. This change adds the missing wall-clock ceiling.

## How

- Wrap each region's `ListRDSInstances` call in `context.WithTimeout(ctx, regionListTimeout)` inside `fetchInstancesData`.
- Default `regionListTimeout = 15s`, held as a `Collector` field (set in `New`) so it's injectable in tests.
- Behavior on timeout is unchanged from the existing per-region error path: the slow region is logged and skipped; healthy regions still report.

## Testing

- Added `TestCollector_Collect_SlowRegionFailsFast`: one region blocks until its context is canceled, the other is healthy. Asserts `Collect` returns quickly (runs in ~0.05s under a 50ms test timeout), the healthy region still emits a metric, and the slow region is skipped without blocking.
- `go build ./...`, `go vet ./pkg/aws/rds/`, and `go test -race ./pkg/aws/rds/` all pass.

