### PR TITLE
feat(rds): make per-region list timeout configurable

### DIFF
--- a/cmd/exporter/config/config.go
+++ b/cmd/exporter/config/config.go
@@ -10,12 +10,13 @@ type Config struct {
 	ProjectID string
 	Providers struct {
 		AWS struct {
-			Profile             string
-			Region              string
-			Services            StringSliceFlag
-			RoleARN             string
-			ExcludeRegions      StringSliceFlag
-			BedrockFamilyFilter string
+			Profile              string
+			Region               string
+			Services             StringSliceFlag
+			RoleARN              string
+			ExcludeRegions       StringSliceFlag
+			BedrockFamilyFilter  string
+			RDSRegionListTimeout time.Duration
 		}
 		GCP struct {
 			DefaultGCSDiscount       int

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafana/cloudcost-exporter/cmd/exporter/config"
 	"github.com/grafana/cloudcost-exporter/cmd/exporter/web"
 	"github.com/grafana/cloudcost-exporter/pkg/aws"
+	"github.com/grafana/cloudcost-exporter/pkg/aws/rds"
 	"github.com/grafana/cloudcost-exporter/pkg/azure"
 	"github.com/grafana/cloudcost-exporter/pkg/google"
 	"github.com/grafana/cloudcost-exporter/pkg/logger"
@@ -80,6 +81,7 @@ func providerFlags(fs *flag.FlagSet, cfg *config.Config) {
 	flag.StringVar(&cfg.Providers.AWS.Region, "aws.region", "", "AWS region")
 	flag.StringVar(&cfg.Providers.AWS.RoleARN, "aws.roleARN", "", "Optional AWS role ARN to assume for cross-account access.")
 	fs.StringVar(&cfg.Providers.AWS.BedrockFamilyFilter, "aws.bedrock.families", ".*", "Regex matched against the Bedrock model family label. Only matching families are emitted.")
+	flag.DurationVar(&cfg.Providers.AWS.RDSRegionListTimeout, "aws.rds.region-timeout", rds.DefaultRegionListTimeout, "Per-region timeout for listing RDS instances. Lower fails slow/unreachable regions fast (protects scrape availability); raise to wait for complete data from slow regions.")
 	// TODO - PUT PROJECT-ID UNDER GCP
 	flag.StringVar(&cfg.ProjectID, "project-id", "", "Project ID to target.")
 	flag.StringVar(&cfg.Providers.Azure.SubscriptionID, "azure.subscription-id", "", "Azure subscription ID to pull data from.")
@@ -249,15 +251,16 @@ func selectProviderWith(
 		})
 	case "aws":
 		return newAWS(ctx, &aws.Config{
-			Logger:              cfg.Logger,
-			Region:              cfg.Providers.AWS.Region,
-			Profile:             cfg.Providers.AWS.Profile,
-			RoleARN:             cfg.Providers.AWS.RoleARN,
-			ScrapeInterval:      cfg.Collector.ScrapeInterval,
-			Services:            strings.Split(cfg.Providers.AWS.Services.String(), ","),
-			ExcludeRegions:      strings.Split(cfg.Providers.AWS.ExcludeRegions.String(), ","),
-			CollectorTimeout:    collectorTimeout,
-			BedrockFamilyFilter: cfg.Providers.AWS.BedrockFamilyFilter,
+			Logger:               cfg.Logger,
+			Region:               cfg.Providers.AWS.Region,
+			Profile:              cfg.Providers.AWS.Profile,
+			RoleARN:              cfg.Providers.AWS.RoleARN,
+			ScrapeInterval:       cfg.Collector.ScrapeInterval,
+			Services:             strings.Split(cfg.Providers.AWS.Services.String(), ","),
+			ExcludeRegions:       strings.Split(cfg.Providers.AWS.ExcludeRegions.String(), ","),
+			CollectorTimeout:     collectorTimeout,
+			BedrockFamilyFilter:  cfg.Providers.AWS.BedrockFamilyFilter,
+			RDSRegionListTimeout: cfg.Providers.AWS.RDSRegionListTimeout,
 		})
 
 	case "gcp":

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -24,7 +24,6 @@ import (
 	"github.com/grafana/cloudcost-exporter/cmd/exporter/config"
 	"github.com/grafana/cloudcost-exporter/cmd/exporter/web"
 	"github.com/grafana/cloudcost-exporter/pkg/aws"
-	"github.com/grafana/cloudcost-exporter/pkg/aws/rds"
 	"github.com/grafana/cloudcost-exporter/pkg/azure"
 	"github.com/grafana/cloudcost-exporter/pkg/google"
 	"github.com/grafana/cloudcost-exporter/pkg/logger"
@@ -81,7 +80,7 @@ func providerFlags(fs *flag.FlagSet, cfg *config.Config) {
 	flag.StringVar(&cfg.Providers.AWS.Region, "aws.region", "", "AWS region")
 	flag.StringVar(&cfg.Providers.AWS.RoleARN, "aws.roleARN", "", "Optional AWS role ARN to assume for cross-account access.")
 	fs.StringVar(&cfg.Providers.AWS.BedrockFamilyFilter, "aws.bedrock.families", ".*", "Regex matched against the Bedrock model family label. Only matching families are emitted.")
-	flag.DurationVar(&cfg.Providers.AWS.RDSRegionListTimeout, "aws.rds.region-timeout", rds.DefaultRegionListTimeout, "Per-region timeout for listing RDS instances. Lower fails slow/unreachable regions fast (protects scrape availability); raise to wait for complete data from slow regions.")
+	flag.DurationVar(&cfg.Providers.AWS.RDSRegionListTimeout, "aws.rds.region-timeout", 0, "Per-region timeout for listing RDS instances. 0 (default) bounds each region only by -collector-interval. Set a positive value (e.g. 15s) to fail slow or unreachable regions fast and protect scrape availability.")
 	// TODO - PUT PROJECT-ID UNDER GCP
 	flag.StringVar(&cfg.ProjectID, "project-id", "", "Project ID to target.")
 	flag.StringVar(&cfg.Providers.Azure.SubscriptionID, "azure.subscription-id", "", "Azure subscription ID to pull data from.")

--- a/docs/metrics/aws/rds.md
+++ b/docs/metrics/aws/rds.md
@@ -23,6 +23,16 @@ Or via command line:
 --aws.services=ec2,s3,rds
 ```
 
+### Per-region list timeout
+
+The collector queries `DescribeDBInstances` in each region concurrently. `--aws.rds.region-timeout` bounds each region's call (default `15s`):
+
+```bash
+--aws.rds.region-timeout=15s
+```
+
+A region that exceeds the timeout is logged and skipped; the other regions still report. Lower the value to fail slow or unreachable regions fast and keep total collection under the Prometheus `scrape_timeout` (protecting scrape availability). Raise it to wait for complete data from slow regions at the cost of longer scrapes.
+
 ## Labels
 
 - **account_id**: The AWS account ID (12-digit), resolved via STS GetCallerIdentity

--- a/docs/metrics/aws/rds.md
+++ b/docs/metrics/aws/rds.md
@@ -25,13 +25,13 @@ Or via command line:
 
 ### Per-region list timeout
 
-The collector queries `DescribeDBInstances` in each region concurrently. `--aws.rds.region-timeout` bounds each region's call (default `15s`):
+The collector queries `DescribeDBInstances` in each region concurrently. `--aws.rds.region-timeout` bounds each region's call:
 
 ```bash
 --aws.rds.region-timeout=15s
 ```
 
-A region that exceeds the timeout is logged and skipped; the other regions still report. Lower the value to fail slow or unreachable regions fast and keep total collection under the Prometheus `scrape_timeout` (protecting scrape availability). Raise it to wait for complete data from slow regions at the cost of longer scrapes.
+The default is `0`, which leaves each region bounded only by the collector context (`--collector-interval`) — a slow or unreachable region can consume the whole budget and overrun the Prometheus `scrape_timeout`, failing the scrape (`up=0`). Set a positive value (e.g. `15s`) to fail such regions fast: the region is logged and skipped while the others still report, keeping total collection under the scrape timeout and protecting scrape availability. Raise it to wait for complete data from slow regions at the cost of longer scrapes.
 
 ## Labels
 

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -37,16 +37,17 @@ import (
 )
 
 type Config struct {
-	Services            []string
-	Region              string
-	Profile             string
-	RoleARN             string
-	ExcludeRegions      []string // AWS region names to skip (e.g. me-central-1)
-	ScrapeInterval      time.Duration
-	CollectorTimeout    time.Duration
-	Logger              *slog.Logger
-	AccountID           string
-	BedrockFamilyFilter string // regex matched against family label; default "anthropic|amazon"
+	Services             []string
+	Region               string
+	Profile              string
+	RoleARN              string
+	ExcludeRegions       []string // AWS region names to skip (e.g. me-central-1)
+	ScrapeInterval       time.Duration
+	CollectorTimeout     time.Duration
+	RDSRegionListTimeout time.Duration // per-region timeout for RDS DescribeDBInstances; 0 uses the collector default
+	Logger               *slog.Logger
+	AccountID            string
+	BedrockFamilyFilter  string // regex matched against family label; default "anthropic|amazon"
 }
 
 type AWS struct {
@@ -190,11 +191,12 @@ func newWithDependencies(ctx context.Context, config *Config, awsClient client.C
 				RDSService:     rds.NewFromConfig(awsConfig),
 			})
 			collector, err := rdsCollector.New(ctx, &rdsCollector.Config{
-				ScrapeInterval: config.ScrapeInterval,
-				Regions:        regions,
-				RegionMap:      regionClients,
-				Client:         awsRDSClient,
-				AccountID:      config.AccountID,
+				ScrapeInterval:    config.ScrapeInterval,
+				Regions:           regions,
+				RegionMap:         regionClients,
+				Client:            awsRDSClient,
+				AccountID:         config.AccountID,
+				RegionListTimeout: config.RDSRegionListTimeout,
 			}, logger)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -53,27 +53,19 @@ type Config struct {
 
 const (
 	serviceName = "RDS"
-
-	// DefaultRegionListTimeout caps a single region's DescribeDBInstances call so
-	// a slow or unreachable region fails fast instead of consuming the whole
-	// collector budget. Without it, one region riding the full ~60s budget
-	// overruns the Prometheus scrape_timeout and fails the scrape (up=0).
-	// Overridable via the -aws.rds.region-timeout flag.
-	DefaultRegionListTimeout = 15 * time.Second
 )
 
-// New creates an rds collector
+// New creates an rds collector. A RegionListTimeout of 0 leaves each region's
+// DescribeDBInstances call bounded only by the shared collector context
+// (-collector-interval); a positive value caps it per region so a slow or
+// unreachable region fails fast instead of overrunning the scrape.
 func New(_ context.Context, config *Config, logger *slog.Logger) (*Collector, error) {
-	regionListTimeout := config.RegionListTimeout
-	if regionListTimeout <= 0 {
-		regionListTimeout = DefaultRegionListTimeout
-	}
 	return &Collector{
 		pricingMap:        newPricingMap(),
 		regions:           config.Regions,
 		regionMap:         config.RegionMap,
 		scrapeInterval:    config.ScrapeInterval,
-		regionListTimeout: regionListTimeout,
+		regionListTimeout: config.RegionListTimeout,
 		Client:            config.Client,
 		accountID:         config.AccountID,
 		logger:            logger.With("collector", serviceName),
@@ -166,10 +158,15 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 // fetchInstancesData lists RDS instances for a single region, sending the
 // result to instanceCh. On failure it logs the error and returns.
 func (c *Collector) fetchInstancesData(ctx context.Context, regionClient client.Client, region string, instanceCh chan []rdsTypes.DBInstance) {
-	regionCtx, cancel := context.WithTimeout(ctx, c.regionListTimeout)
-	defer cancel()
+	// A positive regionListTimeout caps this region's call; 0 leaves it bounded
+	// only by the parent collector context (backwards-compatible default).
+	if c.regionListTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.regionListTimeout)
+		defer cancel()
+	}
 
-	is, err := regionClient.ListRDSInstances(regionCtx)
+	is, err := regionClient.ListRDSInstances(ctx)
 	if err != nil {
 		c.logger.Error("error listing RDS instances", "region", region, "error", err)
 		return

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -43,25 +43,31 @@ type Collector struct {
 }
 
 type Config struct {
-	Regions        []types.Region
-	RegionMap      map[string]client.Client
-	Client         client.Client
-	ScrapeInterval time.Duration
-	AccountID      string
+	Regions           []types.Region
+	RegionMap         map[string]client.Client
+	Client            client.Client
+	ScrapeInterval    time.Duration
+	RegionListTimeout time.Duration
+	AccountID         string
 }
 
 const (
 	serviceName = "RDS"
 
-	// regionListTimeout caps a single region's DescribeDBInstances call so a slow
-	// or unreachable region fails fast instead of consuming the whole collector
-	// budget. Without it, one region riding the full ~60s budget overruns the
-	// Prometheus scrape_timeout and fails the scrape (up=0).
-	regionListTimeout = 15 * time.Second
+	// DefaultRegionListTimeout caps a single region's DescribeDBInstances call so
+	// a slow or unreachable region fails fast instead of consuming the whole
+	// collector budget. Without it, one region riding the full ~60s budget
+	// overruns the Prometheus scrape_timeout and fails the scrape (up=0).
+	// Overridable via the -aws.rds.region-timeout flag.
+	DefaultRegionListTimeout = 15 * time.Second
 )
 
 // New creates an rds collector
 func New(_ context.Context, config *Config, logger *slog.Logger) (*Collector, error) {
+	regionListTimeout := config.RegionListTimeout
+	if regionListTimeout <= 0 {
+		regionListTimeout = DefaultRegionListTimeout
+	}
 	return &Collector{
 		pricingMap:        newPricingMap(),
 		regions:           config.Regions,

--- a/pkg/aws/rds/rds_test.go
+++ b/pkg/aws/rds/rds_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/cloudcost-exporter/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -259,6 +260,53 @@ func TestCollector_Collect_SlowRegionFailsFast(t *testing.T) {
 	}
 	assert.True(t, gotRegions["us-east-1"], "healthy region should still emit a metric")
 	assert.False(t, gotRegions["ap-southeast-7"], "slow region should be skipped, not block")
+}
+
+// TestCollector_Collect_RegionListTimeout verifies the wrap/no-wrap behavior:
+// a zero timeout leaves the region call bounded only by the parent context
+// (backwards-compatible default), while a positive timeout imposes a deadline.
+func TestCollector_Collect_RegionListTimeout(t *testing.T) {
+	tests := []struct {
+		name              string
+		regionListTimeout time.Duration
+		wantDeadline      bool
+	}{
+		{name: "zero disables per-region timeout", regionListTimeout: 0, wantDeadline: false},
+		{name: "positive imposes per-region timeout", regionListTimeout: 30 * time.Second, wantDeadline: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			var gotDeadline bool
+			regionClient := mock.NewMockClient(mockCtrl)
+			regionClient.EXPECT().ListRDSInstances(gomock.Any()).
+				DoAndReturn(func(ctx context.Context) ([]rdsTypes.DBInstance, error) {
+					_, gotDeadline = ctx.Deadline()
+					return nil, nil
+				}).
+				Times(1)
+
+			c := &Collector{
+				pricingMap:        newPricingMap(),
+				regions:           []types.Region{{RegionName: aws.String("us-east-1")}},
+				regionMap:         map[string]client.Client{"us-east-1": regionClient},
+				scrapeInterval:    time.Minute,
+				regionListTimeout: tt.regionListTimeout,
+				Client:            regionClient,
+				accountID:         "123456789012",
+				logger:            slog.Default(),
+			}
+
+			// Parent context carries no deadline, so any deadline observed by the
+			// region call comes from the per-region timeout.
+			ch := make(chan prometheus.Metric, 1)
+			require.NoError(t, c.Collect(context.Background(), ch))
+			assert.Equal(t, tt.wantDeadline, gotDeadline)
+		})
+	}
 }
 
 func TestCollector_Collect(t *testing.T) {


### PR DESCRIPTION
## What

Expose the per-region RDS list timeout as a CLI/config option, `-aws.rds.region-timeout` (default `15s`).

## Why

The per-region `DescribeDBInstances` timeout added in #1018 was hardcoded to 15s. 15s is a safe default for protecting scrape availability, but the right value is an operator tradeoff, not a constant:

- **Lower** → fail slow/unreachable regions fast, keep total collection under the Prometheus `scrape_timeout`, protect the Scrape Availability SLO (`up`). Accepts partial data when a region is degraded.
- **Higher** → wait for complete data from slow/distant regions, at the cost of longer scrapes.

Making it configurable lets users pick complete-but-slow vs. fast-but-partial for their environment instead of baking in one choice.

## How

- New flag `-aws.rds.region-timeout` (default `rds.DefaultRegionListTimeout` = 15s).
- Threaded through the standard path: `config.Config` → `aws.Config.RDSRegionListTimeout` → `rds.Config.RegionListTimeout` → collector.
- The constant is now the exported `rds.DefaultRegionListTimeout`, and the collector falls back to it when the value is unset (`<= 0`) — so the default stays the single source of truth and programmatic callers keep a sane default.
- Documented in `docs/metrics/aws/rds.md` (Configuration), including the tradeoff.

No behavior change at the default: collection is still bounded at 15s per region unless overridden.

## Testing

- `go build ./...`, `go vet ./pkg/aws/... ./cmd/...`, and `go test -race ./pkg/aws/rds/ ./pkg/aws/ ./cmd/exporter/...` all pass.
- Verified the flag appears in `--help` with the 15s default.