### PR TITLE
fix(ci): use correct token output from create-github-app-token action

### DIFF
--- a/.github/workflows/release-on-pr-merge.yml
+++ b/.github/workflows/release-on-pr-merge.yml
@@ -295,7 +295,7 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ steps.get-github-app-token.outputs.github_token }}
+          token: ${{ steps.get-github-app-token.outputs.token }}
           branch: helm-chart/update-to-${{ steps.update-versions.outputs.app_version }}
           delete-branch: true
           base: main


### PR DESCRIPTION
Fixes the final gate in the broken `update-helm-chart` release automation.

## Problem
The `update-helm-chart` job failed at the **Create pull request** step with:

```
Input 'token' not supplied. Unable to continue.
```

The step reads `steps.get-github-app-token.outputs.github_token`, but `grafana/shared-workflows/actions/create-github-app-token@v0.3.0` exposes the installation token as `outputs.token` (not `github_token`). The wrong key resolves to empty, so `peter-evans/create-pull-request` gets no token.

```yaml
# action outputs (v0.3.0)
outputs:
  token:
    value: ${{ steps.generate-token.outputs.github_token }}
```

## Fix
Read `outputs.token` instead of `outputs.github_token`.