### PR TITLE
ci: scope helm chart auto-PR commit and use conventional title

### DIFF
--- a/.github/workflows/release-on-pr-merge.yml
+++ b/.github/workflows/release-on-pr-merge.yml
@@ -296,11 +296,12 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.get-github-app-token.outputs.token }}
+          add-paths: charts/cloudcost-exporter/Chart.yaml
           branch: helm-chart/update-to-${{ steps.update-versions.outputs.app_version }}
           delete-branch: true
           base: main
-          commit-message: "Update Helm chart appVersion to ${{ steps.update-versions.outputs.app_version }}"
-          title: "Update Helm chart to appVersion ${{ steps.update-versions.outputs.app_version }}"
+          commit-message: "chore: update Helm chart appVersion to ${{ steps.update-versions.outputs.app_version }}"
+          title: "chore: update Helm chart to appVersion ${{ steps.update-versions.outputs.app_version }}"
           body: |
             Automated update triggered by release `${{ needs.tag-and-goreleaser.outputs.version }}`.
 


### PR DESCRIPTION
## What

Two fixes to the `update-helm-chart` job in `release-on-pr-merge.yml`, the job
that auto-opens a chart-bump PR on each release:

- Add `add-paths: charts/cloudcost-exporter/Chart.yaml` so the auto-commit is
  scoped to the chart file only.
- Prefix the generated `title` and `commit-message` with `chore:` and lowercase
  the subject.

## Why

`peter-evans/create-pull-request` stages all working-tree changes by default.
The preceding `create-github-app-token` step (bumped to v0.3.0 in #996) does a
`sparse-checkout` of `grafana/shared-workflows` into
`_shared-workflows-create-github-app-token/` to register its token cleanup.
That checkout got committed as a submodule gitlink with no `.gitmodules` entry,
so every downstream `actions/checkout` failed during cleanup:

```
fatal: No url found for submodule path '_shared-workflows-create-github-app-token' in .gitmodules
```

That cascade failed Tests, both `build-and-export-digest` jobs, and the zizmor
steps on the generated PR (#1023). `add-paths` keeps the gitlink out of the commit.

Separately, the hardcoded title `Update Helm chart to appVersion X` has no
conventional-commit type and a capitalized subject, failing `Validate PR title`
and `Suggest Release Label`. The `chore:` prefix fixes both.

## Follow-up

#1021 fixed the token output reference that previously blocked PR creation.
This builds on it.