### PR TITLE
chore: add trailing newline to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,4 @@ We welcome contributions. See the [contributing guide](docs/contribute/README.md
 ## License
 
 Cloud Cost Exporter is licensed under the [Apache License 2.0](LICENSE).
+


### PR DESCRIPTION
No-op change to exercise the release pipeline end-to-end after #1024.

Carries `release:patch` to cut a new image tag and trigger the fixed
`update-helm-chart` job. The generated chart PR should:

- touch only `charts/cloudcost-exporter/Chart.yaml` (no stray gitlink),
- have a `chore:`-prefixed, conventional title,
- pass all checks.