### PR TITLE
feat(gke): surface zone concurrency limit as gcp.gke.zone-concurrency flag

### DIFF
--- a/cmd/exporter/config/config.go
+++ b/cmd/exporter/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 			BucketProjectsDeprecated bool
 			Region                   string
 			Services                 StringSliceFlag
+			GKEZoneConcurrency       int
 		}
 		Azure struct {
 			Services       StringSliceFlag

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -85,6 +85,7 @@ func providerFlags(fs *flag.FlagSet, cfg *config.Config) {
 	flag.StringVar(&cfg.ProjectID, "project-id", "", "Project ID to target.")
 	flag.StringVar(&cfg.Providers.Azure.SubscriptionID, "azure.subscription-id", "", "Azure subscription ID to pull data from.")
 	flag.IntVar(&cfg.Providers.GCP.DefaultGCSDiscount, "gcp.default-discount", 19, "GCP default discount")
+	flag.IntVar(&cfg.Providers.GCP.GKEZoneConcurrency, "gcp.gke.zone-concurrency", 10, "Cap on concurrent API calls during a GKE scrape per project. Two goroutines run per zone (ListInstances + ListDisks), so the parallel-zone count is this value divided by 2.")
 }
 
 // operationalFlags is a helper method that is responsible for setting up the flags that are used to configure the operational aspects of the application.
@@ -264,14 +265,15 @@ func selectProviderWith(
 
 	case "gcp":
 		return newGCP(ctx, &google.Config{
-			Logger:           cfg.Logger,
-			ProjectId:        cfg.ProjectID,
-			Region:           cfg.Providers.GCP.Region,
-			Projects:         cfg.Providers.GCP.Projects.String(),
-			DefaultDiscount:  cfg.Providers.GCP.DefaultGCSDiscount,
-			ScrapeInterval:   cfg.Collector.ScrapeInterval,
-			Services:         strings.Split(cfg.Providers.GCP.Services.String(), ","),
-			CollectorTimeout: collectorTimeout,
+			Logger:             cfg.Logger,
+			ProjectId:          cfg.ProjectID,
+			Region:             cfg.Providers.GCP.Region,
+			Projects:           cfg.Providers.GCP.Projects.String(),
+			DefaultDiscount:    cfg.Providers.GCP.DefaultGCSDiscount,
+			ScrapeInterval:     cfg.Collector.ScrapeInterval,
+			Services:           strings.Split(cfg.Providers.GCP.Services.String(), ","),
+			CollectorTimeout:   collectorTimeout,
+			GKEZoneConcurrency: cfg.Providers.GCP.GKEZoneConcurrency,
 		})
 
 	default:

--- a/pkg/google/gcp.go
+++ b/pkg/google/gcp.go
@@ -68,7 +68,10 @@ type Config struct {
 	ScrapeInterval   time.Duration
 	DefaultDiscount  int
 	CollectorTimeout time.Duration
-	Logger           *slog.Logger
+	// GKEZoneConcurrency caps zone-level goroutines per project during a GKE scrape.
+	// Zero or negative values fall back to gke.DefaultZoneCollectConcurrency.
+	GKEZoneConcurrency int
+	Logger             *slog.Logger
 }
 
 // New is responsible for parsing out a configuration file and setting up the associated services that could be required.
@@ -103,8 +106,9 @@ func New(ctx context.Context, config *Config) (*GCP, error) {
 			}
 		case "GKE":
 			collector, err = gke.New(ctx, &gke.Config{
-				Projects:       config.Projects,
-				ScrapeInterval: config.ScrapeInterval,
+				Projects:        config.Projects,
+				ScrapeInterval:  config.ScrapeInterval,
+				ZoneConcurrency: config.GKEZoneConcurrency,
 			}, logger, gcpClient)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",

--- a/pkg/google/gke/gke.go
+++ b/pkg/google/gke/gke.go
@@ -20,13 +20,13 @@ import (
 const (
 	subsystem = "gcp_gke"
 
-	// zoneCollectConcurrencyLimit caps the total number of zone-level goroutines
+	// DefaultZoneCollectConcurrency caps the total number of zone-level goroutines
 	// (ListInstances + ListDisks) that run simultaneously per project during a
 	// scrape. GCP regions contain ~50 zones; without a limit every scrape would
-	// fire ~100 concurrent API calls per project. The value of 30 allows up to
-	// 15 zones to be queried in parallel, reducing scrape latency at the cost of
-	// a higher API request burst rate.
-	zoneCollectConcurrencyLimit = 30
+	// fire ~100 concurrent API calls per project. The default of 10 means at most
+	// 5 zones are queried in parallel, which stays well within GCP quota defaults.
+	// Override via Config.ZoneConcurrency to trade burst rate for scrape latency.
+	DefaultZoneCollectConcurrency = 10
 )
 
 var (
@@ -58,6 +58,9 @@ var (
 type Config struct {
 	Projects       string
 	ScrapeInterval time.Duration
+	// ZoneConcurrency caps zone-level goroutines per project during a scrape.
+	// Falls back to DefaultZoneCollectConcurrency.
+	ZoneConcurrency int
 }
 
 type Collector struct {
@@ -80,10 +83,14 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 			return err
 		}
 		// Two goroutines are launched per zone (ListInstances + ListDisks).
-		// zoneCollectConcurrencyLimit caps the total across both, so at most
-		// zoneCollectConcurrencyLimit/2 zones are queried in parallel.
+		// zoneConcurrency caps the total across both, so at most
+		// zoneConcurrency/2 zones are queried in parallel.
+		zoneConcurrency := c.config.ZoneConcurrency
+		if zoneConcurrency <= 0 {
+			zoneConcurrency = DefaultZoneCollectConcurrency
+		}
 		eg, egCtx := errgroup.WithContext(ctx)
-		eg.SetLimit(zoneCollectConcurrencyLimit)
+		eg.SetLimit(zoneConcurrency)
 		instances := make(chan []*client.MachineSpec, len(zones))
 		disks := make(chan []*compute.Disk, len(zones))
 		for _, zone := range zones {

--- a/pkg/google/gke/gke_test.go
+++ b/pkg/google/gke/gke_test.go
@@ -556,9 +556,10 @@ func (c *concurrentGCPClient) ListDisks(_ context.Context, _ string, _ string) (
 }
 
 func TestCollector_ZoneConcurrencyLimit(t *testing.T) {
-	// 8 zones → 16 goroutines (2 per zone: ListInstancesInZone + ListDisks),
-	// but zoneCollectConcurrencyLimit=10 caps the total.
-	const numZones = 8
+	// 20 zones → 40 goroutines (2 per zone: ListInstancesInZone + ListDisks),
+	// with ZoneConcurrency=10 capping the total.
+	const numZones = 20
+	const limit = 10
 
 	zones := make([]*computev1.Zone, numZones)
 	for i := range numZones {
@@ -569,6 +570,36 @@ func TestCollector_ZoneConcurrencyLimit(t *testing.T) {
 
 	// Build the Collector directly to bypass the billing/pricing initialisation
 	// that New() performs — it is irrelevant for a concurrency test.
+	collector := &Collector{
+		gcpClient: fakeClient,
+		config:    &Config{ZoneConcurrency: limit},
+		projects:  []string{"proj1"},
+		pricingMap: &PricingMap{
+			compute: map[string]*FamilyPricing{},
+			storage: map[string]*StoragePricing{},
+		},
+		logger: logger,
+	}
+
+	ch := make(chan prometheus.Metric, numZones*10)
+	err := collector.Collect(t.Context(), ch)
+	close(ch)
+	require.NoError(t, err)
+
+	assert.LessOrEqual(t, fakeClient.peakConcurrency, limit,
+		"peak zone goroutine concurrency must not exceed configured ZoneConcurrency")
+}
+
+func TestCollector_ZoneConcurrencyDefault(t *testing.T) {
+	// Empty Config.ZoneConcurrency should fall back to DefaultZoneCollectConcurrency.
+	const numZones = 40
+
+	zones := make([]*computev1.Zone, numZones)
+	for i := range numZones {
+		zones[i] = &computev1.Zone{Name: fmt.Sprintf("us-central1-%d", i)}
+	}
+
+	fakeClient := &concurrentGCPClient{zones: zones}
 	collector := &Collector{
 		gcpClient: fakeClient,
 		config:    &Config{},
@@ -585,6 +616,6 @@ func TestCollector_ZoneConcurrencyLimit(t *testing.T) {
 	close(ch)
 	require.NoError(t, err)
 
-	assert.LessOrEqual(t, fakeClient.peakConcurrency, zoneCollectConcurrencyLimit,
-		"peak zone goroutine concurrency must not exceed zoneCollectConcurrencyLimit")
+	assert.LessOrEqual(t, fakeClient.peakConcurrency, DefaultZoneCollectConcurrency,
+		"peak zone goroutine concurrency must not exceed DefaultZoneCollectConcurrency")
 }


### PR DESCRIPTION
Builds on https://github.com/grafana/cloudcost-exporter/pull/998
Related to https://github.com/grafana/deployment_tools/issues/608719

Adds `-gcp.gke.zone-concurrency` (default 10) to configure the per-project cap on concurrent zone-level API calls during a GKE scrape.

Builds on Stephan's work to make it configurable at the operations level.