### PR TITLE
ci: bump `create-github-app-token` to v0.3.1

### DIFF
--- a/.github/actions/update-helm-chart/action.yml
+++ b/.github/actions/update-helm-chart/action.yml
@@ -37,7 +37,7 @@ runs:
 
     - name: Get GitHub App token
       id: get-github-app-token
-      uses: grafana/shared-workflows/actions/create-github-app-token@795f748a236f9de024b7514efc9a208456e7e468 # create-github-app-token/v0.3.0
+      uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
       with:
         github_app: cloudcost-exporter-updater
 


### PR DESCRIPTION
Follow up to #1031

Failed run: [27270528674](https://github.com/grafana/cloudcost-exporter/actions/runs/27270528674/job/80593161293)

The `update-helm-chart` action fails on tag releases because `create-github-app-token@v0.3.0` ships a broken post-step. `v0.3.1` removes the `cleanup/` subaction.

Shared workflow's SHA was validated against its release: https://github.com/grafana/shared-workflows/releases/tag/create-github-app-token%2Fv0.3.1