### PR TITLE
feat(exporter): add -list-services flag and registry drift CI check

### DIFF
--- a/cmd/exporter/config/config.go
+++ b/cmd/exporter/config/config.go
@@ -6,9 +6,10 @@ import (
 )
 
 type Config struct {
-	Provider  string
-	ProjectID string
-	Providers struct {
+	Provider     string
+	ProjectID    string
+	ListServices bool
+	Providers    struct {
 		AWS struct {
 			Profile              string
 			Region               string

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/pprof"
@@ -12,6 +13,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"text/tabwriter"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -35,6 +37,11 @@ func main() {
 	providerFlags(flag.CommandLine, &cfg)
 	operationalFlags(&cfg)
 	flag.Parse()
+
+	if cfg.ListServices {
+		printAvailableServices(os.Stdout)
+		return
+	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
@@ -73,10 +80,10 @@ func providerFlags(fs *flag.FlagSet, cfg *config.Config) {
 	fs.StringVar(&cfg.Providers.AWS.Profile, "aws.profile", "", "AWS Profile to authenticate with.")
 	fs.Var(&cfg.Providers.GCP.Projects, "gcp.projects", "GCP project(s).")
 	fs.Var(config.NewDeprecatedStringSliceFlag(&cfg.Providers.GCP.Projects, &cfg.Providers.GCP.BucketProjectsDeprecated), "gcp.bucket-projects", "GCP project(s). (deprecated: use --gcp.projects instead)")
-	fs.Var(&cfg.Providers.AWS.Services, "aws.services", "AWS service(s).")
+	fs.Var(&cfg.Providers.AWS.Services, "aws.services", "AWS service(s). Run with -list-services to see available values.")
 	fs.Var(&cfg.Providers.AWS.ExcludeRegions, "aws.exclude-regions", "AWS region(s) to exclude from cost collection.")
-	fs.Var(&cfg.Providers.Azure.Services, "azure.services", "Azure service(s): AKS, blob (comma-separated and/or repeat flag; case-insensitive).")
-	fs.Var(&cfg.Providers.GCP.Services, "gcp.services", "GCP service(s).")
+	fs.Var(&cfg.Providers.Azure.Services, "azure.services", "Azure service(s) (comma-separated and/or repeat flag; case-insensitive). Run with -list-services to see available values.")
+	fs.Var(&cfg.Providers.GCP.Services, "gcp.services", "GCP service(s). Run with -list-services to see available values.")
 	flag.StringVar(&cfg.Providers.AWS.Region, "aws.region", "", "AWS region")
 	flag.StringVar(&cfg.Providers.AWS.RoleARN, "aws.roleARN", "", "Optional AWS role ARN to assume for cross-account access.")
 	fs.StringVar(&cfg.Providers.AWS.BedrockFamilyFilter, "aws.bedrock.families", ".*", "Regex matched against the Bedrock model family label. Only matching families are emitted.")
@@ -91,6 +98,7 @@ func providerFlags(fs *flag.FlagSet, cfg *config.Config) {
 // operationalFlags is a helper method that is responsible for setting up the flags that are used to configure the operational aspects of the application.
 // TODO: This should probably be moved over to the config package.
 func operationalFlags(cfg *config.Config) {
+	flag.BoolVar(&cfg.ListServices, "list-services", false, "Print the services available per provider and exit. Does not require credentials.")
 	flag.DurationVar(&cfg.Collector.ScrapeInterval, "scrape-interval", 1*time.Hour, "Scrape interval")
 	flag.DurationVar(&cfg.Collector.Timeout, "collector-interval", 1*time.Minute, "Context timeout for collectors")
 	flag.DurationVar(&cfg.Server.Timeout, "server-timeout", 30*time.Second, "Server timeout")
@@ -278,5 +286,57 @@ func selectProviderWith(
 
 	default:
 		return nil, fmt.Errorf("unknown provider")
+	}
+}
+
+// printAvailableServices writes a human-readable summary of every collector
+// each provider supports, plus a ready-to-run example command per provider.
+// It does not initialize any provider and does not require credentials.
+func printAvailableServices(w io.Writer) {
+	groups := []struct {
+		label    string
+		flag     string
+		services []provider.ServiceInfo
+		example  string
+	}{
+		{
+			label:    "GCP",
+			flag:     "-gcp.services",
+			services: google.Services(),
+			example:  "cloudcost-exporter -provider gcp -gcp.projects <project> -gcp.services GKE,GCS",
+		},
+		{
+			label:    "AWS",
+			flag:     "-aws.services",
+			services: aws.Services(),
+			example:  "cloudcost-exporter -provider aws -aws.region <region> -aws.services EC2,S3",
+		},
+		{
+			label:    "Azure",
+			flag:     "-azure.services",
+			services: azure.Services(),
+			example:  "cloudcost-exporter -provider azure -azure.subscription-id <id> -azure.services AKS",
+		},
+	}
+
+	for i, g := range groups {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintf(w, "%s services (%s):\n", g.label, g.flag)
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		for _, s := range g.services {
+			name := s.Name
+			if len(s.Aliases) > 0 {
+				name = fmt.Sprintf("%s (alias: %s)", s.Name, strings.Join(s.Aliases, ", "))
+			}
+			desc := s.Description
+			if s.DisplayName != "" && !strings.EqualFold(s.DisplayName, s.Name) {
+				desc = fmt.Sprintf("%s: %s", s.DisplayName, s.Description)
+			}
+			fmt.Fprintf(tw, "  %s\t%s\n", name, desc)
+		}
+		_ = tw.Flush()
+		fmt.Fprintf(w, "\n  Example: %s\n", g.example)
 	}
 }

--- a/cmd/exporter/exporter_test.go
+++ b/cmd/exporter/exporter_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -243,6 +245,44 @@ func Test_createPromRegistryHandler(t *testing.T) {
 
 			if rec.Code != tc.wantHTTPStatus {
 				t.Errorf("expected HTTP status %d, got %d", tc.wantHTTPStatus, rec.Code)
+			}
+		})
+	}
+}
+
+func TestPrintAvailableServices(t *testing.T) {
+	var buf bytes.Buffer
+	printAvailableServices(&buf)
+	out := buf.String()
+
+	cases := []struct {
+		name     string
+		services []provider.ServiceInfo
+		header   string
+		example  string
+	}{
+		{"AWS", aws.Services(), "AWS services (-aws.services):", "-provider aws"},
+		{"GCP", google.Services(), "GCP services (-gcp.services):", "-provider gcp"},
+		{"Azure", azure.Services(), "Azure services (-azure.services):", "-provider azure"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(out, tc.header) {
+				t.Errorf("output missing header %q", tc.header)
+			}
+			if !strings.Contains(out, tc.example) {
+				t.Errorf("output missing example for %s", tc.name)
+			}
+			for _, s := range tc.services {
+				if !strings.Contains(out, s.Name) {
+					t.Errorf("output missing service %s", s.Name)
+				}
+				for _, a := range s.Aliases {
+					if !strings.Contains(out, a) {
+						t.Errorf("output missing alias %s for %s", a, s.Name)
+					}
+				}
 			}
 		})
 	}

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -1,26 +1,28 @@
 # Supported Services
 
+Each bullet shows the human-readable name, the flag value to pass via `-{provider}.services` (in backticks), and a short description. Run `cloudcost-exporter -list-services` to see this list from the CLI.
+
 ## AWS Services
 
-- **[EC2](./aws/ec2.md)** - Elastic Compute Cloud instances (spot and on-demand pricing)
-- **[S3](./aws/s3.md)** - Simple Storage Service buckets
-- **[RDS](./aws/rds.md)** - Relational Database Service instances
-- **[MSK](./aws/msk.md)** - Managed Service for Apache Kafka clusters
-- **[ELB](./aws/elb.md)** - Elastic Load Balancers (ALB, NLB)
-- **[NAT Gateway](./aws/natgateway.md)** - Network Address Translation gateways
-- **[VPC](./aws/vpc.md)** - VPC endpoints and services
+- **[EC2](./aws/ec2.md)** (`EC2`): Elastic Compute Cloud instances (spot and on-demand pricing)
+- **[S3](./aws/s3.md)** (`S3`): Simple Storage Service buckets
+- **[RDS](./aws/rds.md)** (`RDS`): Relational Database Service instances
+- **[MSK](./aws/msk.md)** (`MSK`): Managed Service for Apache Kafka clusters
+- **[ELB](./aws/elb.md)** (`ELB`): Elastic Load Balancers (ALB, NLB)
+- **[NAT Gateway](./aws/natgateway.md)** (`NATGATEWAY`): Network Address Translation gateways
+- **[VPC](./aws/vpc.md)** (`VPC`): VPC endpoints and services
 
 ## GCP Services
 
-- **[GKE](./gcp/gke.md)** - Google Kubernetes Engine clusters
-- **[GCS](./gcp/gcs.md)** - Google Cloud Storage buckets
-- **[Cloud SQL](./gcp/cloudsql.md)** - Managed database instances
-- **[Managed Kafka](./gcp/managedkafka.md)** - Managed Service for Apache Kafka clusters
-- **[CLB](./gcp/clb.md)** - Cloud Load Balancers via forwarding rules
-- **[VPC](./gcp/vpc.md)** - Cloud NAT Gateway, VPN Gateway, Private Service Connect
+- **[GKE](./gcp/gke.md)** (`GKE`): Google Kubernetes Engine clusters
+- **[GCS](./gcp/gcs.md)** (`GCS`): Google Cloud Storage buckets
+- **[Cloud SQL](./gcp/cloudsql.md)** (`SQL`): Managed database instances
+- **[Managed Kafka](./gcp/managedkafka.md)** (`MANAGEDKAFKA`, alias: `KAFKA`): Managed Service for Apache Kafka clusters
+- **[CLB](./gcp/clb.md)** (`CLB`): Cloud Load Balancers via forwarding rules
+- **[VPC](./gcp/vpc.md)** (`VPC`): Cloud NAT Gateway, VPN Gateway, Private Service Connect
 
 ## Azure Services
 
-- **[AKS](./azure/aks.md)** - Azure Kubernetes Service VM instances and managed disks
-- **[Blob](./azure/blob.md)** - Azure Blob Storage (cost metrics registered; no series until Cost Management)
-- **[Event Hubs](./azure/eventhubs.md)** - Kafka-compatible Azure Event Hubs namespaces
+- **[AKS](./azure/aks.md)** (`AKS`): Azure Kubernetes Service VM instances and managed disks
+- **[Blob](./azure/blob.md)** (`blob`): Azure Blob Storage (cost metrics registered; no series until Cost Management)
+- **[Event Hubs](./azure/eventhubs.md)** (`EVENTHUBS`, alias: `EVENTHUB`): Kafka-compatible Azure Event Hubs namespaces

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -11,6 +11,7 @@ Each bullet shows the human-readable name, the flag value to pass via `-{provide
 - **[ELB](./aws/elb.md)** (`ELB`): Elastic Load Balancers (ALB, NLB)
 - **[NAT Gateway](./aws/natgateway.md)** (`NATGATEWAY`): Network Address Translation gateways
 - **[VPC](./aws/vpc.md)** (`VPC`): VPC endpoints and services
+- **[Bedrock](./aws/bedrock.md)** (`BEDROCK`): Amazon Bedrock 
 
 ## GCP Services
 

--- a/internal/servicesdrift/drift_test.go
+++ b/internal/servicesdrift/drift_test.go
@@ -1,0 +1,126 @@
+// Package servicesdrift verifies that docs/metrics/README.md stays in sync with
+// the per-provider Services() registries. Adding a service to a provider but
+// forgetting to document it (or vice versa) makes this test fail.
+package servicesdrift
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/grafana/cloudcost-exporter/pkg/aws"
+	"github.com/grafana/cloudcost-exporter/pkg/azure"
+	"github.com/grafana/cloudcost-exporter/pkg/google"
+	"github.com/grafana/cloudcost-exporter/pkg/provider"
+)
+
+// readmeRelPath is resolved from this test file's directory: internal/servicesdrift
+// up two levels to the repo root, then into docs/metrics.
+const readmeRelPath = "../../docs/metrics/README.md"
+
+// backtickToken extracts every backtick-wrapped token on a line.
+// e.g. "(`MANAGEDKAFKA`, alias: `KAFKA`)" yields ["MANAGEDKAFKA", "KAFKA"].
+var backtickToken = regexp.MustCompile("`([^`]+)`")
+
+// sectionHeader matches "## AWS Services" / "## GCP Services" / "## Azure Services".
+var sectionHeader = regexp.MustCompile(`^## (AWS|GCP|Azure) Services\s*$`)
+
+func TestReadmeMatchesRegistries(t *testing.T) {
+	readmePath, err := filepath.Abs(readmeRelPath)
+	if err != nil {
+		t.Fatalf("resolve README path: %v", err)
+	}
+	raw, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", readmePath, err)
+	}
+
+	docTokens := parseSections(t, string(raw))
+
+	cases := []struct {
+		provider string
+		services []provider.ServiceInfo
+	}{
+		{"AWS", aws.Services()},
+		{"GCP", google.Services()},
+		{"Azure", azure.Services()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.provider, func(t *testing.T) {
+			doc, ok := docTokens[tc.provider]
+			if !ok {
+				t.Fatalf("docs/metrics/README.md missing '## %s Services' section", tc.provider)
+			}
+			registry := registryTokens(tc.services)
+			missingFromDoc := setDiff(registry, doc)
+			extraInDoc := setDiff(doc, registry)
+			if len(missingFromDoc) > 0 {
+				t.Errorf("%s: registry has %v, docs/metrics/README.md is missing them", tc.provider, missingFromDoc)
+			}
+			if len(extraInDoc) > 0 {
+				t.Errorf("%s: docs/metrics/README.md has %v, registry doesn't (remove or add to Services())", tc.provider, extraInDoc)
+			}
+		})
+	}
+}
+
+// parseSections walks the README line by line and returns, per provider header,
+// the set of backtick-wrapped tokens found in bullet lines under that section.
+func parseSections(t *testing.T, body string) map[string]map[string]struct{} {
+	t.Helper()
+	result := map[string]map[string]struct{}{}
+	var current string
+	for line := range strings.SplitSeq(body, "\n") {
+		if m := sectionHeader.FindStringSubmatch(line); m != nil {
+			current = m[1]
+			result[current] = map[string]struct{}{}
+			continue
+		}
+		if current == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "## ") {
+			current = ""
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "- ") {
+			continue
+		}
+		for _, m := range backtickToken.FindAllStringSubmatch(trimmed, -1) {
+			result[current][m[1]] = struct{}{}
+		}
+	}
+	for _, p := range []string{"AWS", "GCP", "Azure"} {
+		if _, ok := result[p]; !ok {
+			t.Fatalf("docs/metrics/README.md is missing '## %s Services' header (parser may be broken)", p)
+		}
+	}
+	return result
+}
+
+func registryTokens(services []provider.ServiceInfo) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, s := range services {
+		out[s.Name] = struct{}{}
+		for _, a := range s.Aliases {
+			out[a] = struct{}{}
+		}
+	}
+	return out
+}
+
+func setDiff(a, b map[string]struct{}) []string {
+	var diff []string
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			diff = append(diff, k)
+		}
+	}
+	sort.Strings(diff)
+	return diff
+}

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -100,6 +100,22 @@ const (
 	serviceBedrock = "BEDROCK"
 )
 
+// Services returns the collectors that can be enabled via -aws.services.
+// The Name field is the canonical flag value; the dispatch switch in
+// newWithDependencies cases on the same constants.
+func Services() []provider.ServiceInfo {
+	return []provider.ServiceInfo{
+		{Name: serviceS3, DisplayName: "S3", Description: "Simple Storage Service buckets"},
+		{Name: serviceEC2, DisplayName: "EC2", Description: "Elastic Compute Cloud instances (spot and on-demand pricing)"},
+		{Name: serviceRDS, DisplayName: "RDS", Description: "Relational Database Service instances"},
+		{Name: serviceMSK, DisplayName: "MSK", Description: "Managed Service for Apache Kafka clusters"},
+		{Name: serviceELB, DisplayName: "ELB", Description: "Elastic Load Balancers (ALB, NLB)"},
+		{Name: serviceNATGW, DisplayName: "NAT Gateway", Description: "Network Address Translation gateways"},
+		{Name: serviceVPC, DisplayName: "VPC", Description: "VPC endpoints and services"},
+		{Name: serviceBedrock, DisplayName: "Bedrock", Description: "Amazon Bedrock foundation model pricing"},
+	}
+}
+
 func New(ctx context.Context, config *Config) (*AWS, error) {
 	// There are two scenarios:
 	// 1. Running locally, the user must pass in a region and profile to use

--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -651,3 +651,18 @@ func Test_AllCostMetricDescsIncludeAccountID(t *testing.T) {
 	assert.GreaterOrEqual(t, costDescs, len(allServices),
 		"expected at least %d cost metric Descs from %d services", len(allServices), len(allServices))
 }
+
+func TestServices(t *testing.T) {
+	got := Services()
+	wantNames := []string{
+		serviceS3, serviceEC2, serviceRDS, serviceMSK,
+		serviceELB, serviceNATGW, serviceVPC, serviceBedrock,
+	}
+	gotNames := make([]string, 0, len(got))
+	for _, s := range got {
+		gotNames = append(gotNames, s.Name)
+		assert.NotEmpty(t, s.DisplayName, "DisplayName empty for %s", s.Name)
+		assert.NotEmpty(t, s.Description, "Description empty for %s", s.Name)
+	}
+	assert.ElementsMatch(t, wantNames, gotNames)
+}

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -23,7 +23,26 @@ import (
 
 const (
 	subsystem = "azure"
+
+	// Azure service names used by -azure.services. Matching is case-insensitive
+	// (see strings.EqualFold below), so these casings are canonical only for
+	// display and registry purposes.
+	serviceAKS            = "AKS"
+	serviceBlob           = "blob"
+	serviceEventHubs      = "EVENTHUBS"
+	serviceEventHubsAlias = "EVENTHUB"
 )
+
+// Services returns the collectors that can be enabled via -azure.services.
+// The Name field is the canonical flag value; the dispatch switch in New
+// matches case-insensitively against the same constants.
+func Services() []provider.ServiceInfo {
+	return []provider.ServiceInfo{
+		{Name: serviceAKS, DisplayName: "AKS", Description: "Azure Kubernetes Service VM instances and managed disks"},
+		{Name: serviceBlob, DisplayName: "Blob", Description: "Azure Blob Storage (cost metrics registered; no series until Cost Management)"},
+		{Name: serviceEventHubs, DisplayName: "Event Hubs", Description: "Kafka-compatible Azure Event Hubs namespaces", Aliases: []string{serviceEventHubsAlias}},
+	}
+}
 
 var errInvalidSubscriptionID = errors.New("subscription id was invalid")
 
@@ -93,7 +112,7 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 			continue
 		}
 		switch {
-		case strings.EqualFold(svc, "AKS"):
+		case strings.EqualFold(svc, serviceAKS):
 			collector, err := aks.New(ctx, &aks.Config{
 				SubscriptionID: config.SubscriptionID,
 			}, logger, azClientWrapper)
@@ -104,7 +123,7 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 				continue
 			}
 			collectors = append(collectors, collector)
-		case strings.EqualFold(svc, "blob"):
+		case strings.EqualFold(svc, serviceBlob):
 			collector, err := blob.New(ctx, &blob.Config{
 				SubscriptionID: config.SubscriptionID,
 				ScrapeInterval: config.ScrapeInterval,
@@ -116,7 +135,7 @@ func New(ctx context.Context, config *Config) (*Azure, error) {
 				continue
 			}
 			collectors = append(collectors, collector)
-		case strings.EqualFold(svc, "EVENTHUBS"), strings.EqualFold(svc, "EVENTHUB"):
+		case strings.EqualFold(svc, serviceEventHubs), strings.EqualFold(svc, serviceEventHubsAlias):
 			collector, err := eventhubs.New(ctx, &eventhubs.Config{
 				Logger: logger,
 			}, azClientWrapper)

--- a/pkg/azure/azure_test.go
+++ b/pkg/azure/azure_test.go
@@ -211,3 +211,24 @@ func Test_CollectMetrics(t *testing.T) {
 		})
 	}
 }
+
+func TestServices(t *testing.T) {
+	got := Services()
+	wantNames := []string{serviceAKS, serviceBlob, serviceEventHubs}
+	gotNames := make([]string, 0, len(got))
+	for _, s := range got {
+		gotNames = append(gotNames, s.Name)
+		assert.NotEmpty(t, s.DisplayName, "DisplayName empty for %s", s.Name)
+		assert.NotEmpty(t, s.Description, "Description empty for %s", s.Name)
+	}
+	assert.ElementsMatch(t, wantNames, gotNames)
+
+	var eh provider.ServiceInfo
+	for _, s := range got {
+		if s.Name == serviceEventHubs {
+			eh = s
+			break
+		}
+	}
+	assert.Contains(t, eh.Aliases, serviceEventHubsAlias, "EVENTHUBS should carry EVENTHUB as alias")
+}

--- a/pkg/google/gcp.go
+++ b/pkg/google/gcp.go
@@ -29,7 +29,30 @@ const (
 	// many collectors are registered and keeps memory and rate-limit usage
 	// predictable. The value matches Azure's ConcurrentGoroutineLimit.
 	collectConcurrencyLimit = 10
+
+	// GCP service names used by -gcp.services.
+	serviceGCS          = "GCS"
+	serviceGKE          = "GKE"
+	serviceCLB          = "CLB"
+	serviceVPC          = "VPC"
+	serviceSQL          = "SQL"
+	serviceManagedKafka = "MANAGEDKAFKA"
+	serviceKafkaAlias   = "KAFKA"
 )
+
+// Services returns the collectors that can be enabled via -gcp.services.
+// The Name field is the canonical flag value; the dispatch switch in New
+// cases on the same constants.
+func Services() []provider.ServiceInfo {
+	return []provider.ServiceInfo{
+		{Name: serviceGKE, DisplayName: "GKE", Description: "Google Kubernetes Engine clusters"},
+		{Name: serviceGCS, DisplayName: "GCS", Description: "Google Cloud Storage buckets"},
+		{Name: serviceSQL, DisplayName: "Cloud SQL", Description: "Managed database instances"},
+		{Name: serviceManagedKafka, DisplayName: "Managed Kafka", Description: "Managed Service for Apache Kafka clusters", Aliases: []string{serviceKafkaAlias}},
+		{Name: serviceCLB, DisplayName: "CLB", Description: "Cloud Load Balancers via forwarding rules"},
+		{Name: serviceVPC, DisplayName: "VPC", Description: "Cloud NAT Gateway, VPN Gateway, Private Service Connect"},
+	}
+}
 
 var (
 	collectorLastScrapeErrorDesc = prometheus.NewDesc(
@@ -92,7 +115,7 @@ func New(ctx context.Context, config *Config) (*GCP, error) {
 
 		var collector provider.Collector
 		switch strings.ToUpper(service) {
-		case "GCS":
+		case serviceGCS:
 			collector, err = gcs.New(ctx, &gcs.Config{
 				ProjectId:      config.ProjectId,
 				Projects:       config.Projects,
@@ -104,7 +127,7 @@ func New(ctx context.Context, config *Config) (*GCP, error) {
 					slog.String("message", err.Error()))
 				continue
 			}
-		case "GKE":
+		case serviceGKE:
 			collector, err = gke.New(ctx, &gke.Config{
 				Projects:        config.Projects,
 				ScrapeInterval:  config.ScrapeInterval,
@@ -116,7 +139,7 @@ func New(ctx context.Context, config *Config) (*GCP, error) {
 					slog.String("message", err.Error()))
 				continue
 			}
-		case "CLB":
+		case serviceCLB:
 			// CLB = Cloud Load Balancer, but we use forwarding rules to calculate price
 			collector, err = networking.New(ctx, &networking.Config{
 				ScrapeInterval: config.ScrapeInterval,
@@ -131,7 +154,7 @@ func New(ctx context.Context, config *Config) (*GCP, error) {
 					slog.String("message", err.Error()))
 				continue
 			}
-		case "VPC":
+		case serviceVPC:
 			collector, err = vpc.New(ctx, &vpc.Config{
 				Projects:       config.Projects,
 				ScrapeInterval: config.ScrapeInterval,
@@ -142,7 +165,7 @@ func New(ctx context.Context, config *Config) (*GCP, error) {
 					slog.String("message", err.Error()))
 				continue
 			}
-		case "SQL":
+		case serviceSQL:
 			collector, err = cloudsql.New(ctx, &cloudsql.Config{
 				Projects:       config.Projects,
 				ScrapeInterval: config.ScrapeInterval,
@@ -153,7 +176,7 @@ func New(ctx context.Context, config *Config) (*GCP, error) {
 					slog.String("message", err.Error()))
 				continue
 			}
-		case "KAFKA", "MANAGEDKAFKA":
+		case serviceKafkaAlias, serviceManagedKafka:
 			collector, err = gcpmanagedkafka.New(ctx, &gcpmanagedkafka.Config{
 				Projects:       config.Projects,
 				ScrapeInterval: config.ScrapeInterval,

--- a/pkg/google/gcp_test.go
+++ b/pkg/google/gcp_test.go
@@ -242,3 +242,27 @@ func TestGCP_CollectMetrics(t *testing.T) {
 		})
 	}
 }
+
+func TestServices(t *testing.T) {
+	got := Services()
+	wantNames := []string{
+		serviceGCS, serviceGKE, serviceCLB, serviceVPC,
+		serviceSQL, serviceManagedKafka,
+	}
+	gotNames := make([]string, 0, len(got))
+	for _, s := range got {
+		gotNames = append(gotNames, s.Name)
+		assert.NotEmpty(t, s.DisplayName, "DisplayName empty for %s", s.Name)
+		assert.NotEmpty(t, s.Description, "Description empty for %s", s.Name)
+	}
+	assert.ElementsMatch(t, wantNames, gotNames)
+
+	var kafka provider.ServiceInfo
+	for _, s := range got {
+		if s.Name == serviceManagedKafka {
+			kafka = s
+			break
+		}
+	}
+	assert.Contains(t, kafka.Aliases, serviceKafkaAlias, "MANAGEDKAFKA should carry KAFKA as alias")
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -29,3 +29,15 @@ type Provider interface {
 	prometheus.Collector
 	RegisterCollectors(r Registry) error
 }
+
+// ServiceInfo describes a collector that a provider can register via its
+// -{provider}.services flag. Each provider exposes a Services() function
+// returning these entries; the same Name is used by the dispatch switch and
+// the -list-services flag, and verified against docs/metrics/README.md by a
+// drift test.
+type ServiceInfo struct {
+	Name        string
+	DisplayName string
+	Description string
+	Aliases     []string
+}


### PR DESCRIPTION
## Summary

Closes #1040.

- Adds a `-list-services` flag that prints every collector each provider supports, with the canonical flag value, any aliases, a short description, and a ready-to-run example command. The handler runs before provider selection so no credentials are required.
- Introduces a per-provider `Services()` registry as the single source of truth. The dispatch switch and the new flag reference the same name constants, so a registry rename breaks the build.
- Reformats `docs/metrics/README.md` so every bullet shows the flag value inline (in backticks) alongside the human-readable name. Fixes the "NAT Gateway" vs `NATGATEWAY` discoverability gap called out in the issue.
- Adds a CI drift test that parses the README and fails if the registry and the docs disagree in either direction. Adding a service without updating the README now fails CI instead of going unnoticed.

## How It Works

```
$ cloudcost-exporter -list-services
GCP services (-gcp.services):
  GKE                          Google Kubernetes Engine clusters
  GCS                          Google Cloud Storage buckets
  SQL                          Cloud SQL: Managed database instances
  MANAGEDKAFKA (alias: KAFKA)  Managed Kafka: Managed Service for Apache Kafka clusters
  CLB                          Cloud Load Balancers via forwarding rules
  VPC                          Cloud NAT Gateway, VPN Gateway, Private Service Connect

  Example: cloudcost-exporter -provider gcp -gcp.projects <project> -gcp.services GKE,GCS

AWS services (-aws.services):
  ...
```

The display name only appears inline when it differs from the flag value, so common cases like `EC2` and `S3` stay terse.

## Commits

The work is split into six commits for review: provider type plus AWS registry, GCP refactor, Azure refactor, docs reformat, the flag itself, and the drift test.

## Test Plan

- [x] `make lint` passes
- [x] `make test` passes
- [ ] `go run cmd/exporter/exporter.go -list-services` produces three provider blocks, each with an example command, and exits cleanly without credentials
- [ ] Confirm an existing scrape still works: `go run cmd/exporter/exporter.go -provider aws -aws.region us-east-1 -aws.services EC2,S3` (or any provider/service combo you have credentials for)
- [ ] Try the drift guardrail: remove a service from a `Services()` registry without touching the README and confirm `go test ./internal/servicesdrift/...` fails with a clear diff message