### PR TITLE
fix(config): guard nil receiver in `DeprecatedStringSliceFlag.String`

### DIFF
--- a/cmd/exporter/config/string_slice_flag.go
+++ b/cmd/exporter/config/string_slice_flag.go
@@ -26,6 +26,9 @@ func NewDeprecatedStringSliceFlag(values *StringSliceFlag, wasUsed *bool) *Depre
 }
 
 func (f *DeprecatedStringSliceFlag) String() string {
+	if f == nil || f.values == nil {
+		return ""
+	}
 	return f.values.String()
 }
 

--- a/cmd/exporter/config/string_slice_flag_test.go
+++ b/cmd/exporter/config/string_slice_flag_test.go
@@ -39,6 +39,13 @@ func TestStringSliceFlag_Set(t *testing.T) {
 	}
 }
 
+func TestDeprecatedStringSliceFlag_StringZeroValue(t *testing.T) {
+	var f DeprecatedStringSliceFlag
+	if got := f.String(); got != "" {
+		t.Fatalf("expected empty string, got %q", got)
+	}
+}
+
 func TestStringSliceFlag_String(t *testing.T) {
 	tests := map[string]struct {
 		values []string


### PR DESCRIPTION
## Why
`cloudcost-exporter --help` returns results then panics with `nil pointer dereference`. 

This happens when the `flag` package renders the default for `-gcp.bucket-projects`.

## What
* Return an empty string when `DeprecatedStringSliceFlag` is its zero value.
* Adds a regression test.