### PR TITLE
fix(gke): add mutex to PricingMap to prevent concurrent map read/write panic

### DIFF
--- a/pkg/google/gke/pricing_map.go
+++ b/pkg/google/gke/pricing_map.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"cloud.google.com/go/billing/apiv1/billingpb"
@@ -101,11 +102,18 @@ func NewPriceTiers() *PriceTiers {
 	}
 }
 
-// PricingMap is a map of regions to a map of family to price tiers
+// PricingMap is a map of regions to a map of family to price tiers.
+//
+// mu guards compute and storage: ParseSkus writes them in place when the 24h
+// refresh ticker fires, while Collect reads them on every scrape via
+// GetCostOfInstance and GetCostOfStorage. Without it a scrape racing a refresh
+// trips the runtime's concurrent map read/write detector and crashes the
+// exporter (https://github.com/grafana/cloudcost-exporter/issues/1036).
 type PricingMap struct {
 	compute   map[string]*FamilyPricing
 	storage   map[string]*StoragePricing
 	gcpClient client.Client
+	mu        sync.RWMutex
 }
 
 // NewPricingMap returns a new PricingMap in a way that can be used afterwards.
@@ -161,6 +169,8 @@ func NewStoragePricing() *StoragePricing {
 }
 
 func (pm *PricingMap) GetCostOfInstance(instance *client.MachineSpec) (float64, float64, error) {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
 	if len(pm.compute) == 0 || instance == nil {
 		return 0, 0, ErrRegionNotFound
 	}
@@ -197,6 +207,8 @@ func computeDiskCost(d *Disk, p *StoragePrices) float64 {
 }
 
 func (pm *PricingMap) GetCostOfStorage(region, storageClass string) (*StoragePrices, error) {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
 	if len(pm.storage) == 0 {
 		return nil, ErrRegionNotFound
 	}
@@ -206,7 +218,10 @@ func (pm *PricingMap) GetCostOfStorage(region, storageClass string) (*StoragePri
 	if _, ok := pm.storage[region].Storage[storageClass]; !ok {
 		return nil, fmt.Errorf("%w: %s", ErrFamilyTypeNotFound, storageClass)
 	}
-	return pm.storage[region].Storage[storageClass], nil
+	// Return a copy so the value stays stable after the read lock is released; a
+	// concurrent ParseSkus refresh mutates the stored StoragePrices in place.
+	sp := *pm.storage[region].Storage[storageClass]
+	return &sp, nil
 }
 
 var (
@@ -239,6 +254,8 @@ func (pm *PricingMap) Populate(ctx context.Context) error {
 
 // ParseSkus accepts a list of skus, parses their content, and updates the pricing map with the appropriate costs.
 func (pm *PricingMap) ParseSkus(skus []*billingpb.Sku) error {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
 	for _, sku := range skus {
 		rawData, err := getDataFromSku(sku)
 		if errors.Is(err, ErrSkuNotRelevant) {

--- a/pkg/google/gke/pricing_map_test.go
+++ b/pkg/google/gke/pricing_map_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -20,7 +21,7 @@ import (
 func TestStructuredPricingMap_GetCostOfInstance(t *testing.T) {
 	for _, tc := range []struct {
 		name             string
-		pm               PricingMap
+		pm               *PricingMap
 		ms               *client.MachineSpec
 		expectedCPUPrice float64
 		expectedRAMPRice float64
@@ -28,28 +29,29 @@ func TestStructuredPricingMap_GetCostOfInstance(t *testing.T) {
 	}{
 		{
 			name:          "regions is nil",
+			pm:            &PricingMap{},
 			expectedError: ErrRegionNotFound,
 		},
 		{
 			name:          "nil machine spec",
-			pm:            PricingMap{compute: map[string]*FamilyPricing{"": {}}},
+			pm:            &PricingMap{compute: map[string]*FamilyPricing{"": {}}},
 			expectedError: ErrRegionNotFound,
 		},
 		{
 			name:          "region not found",
-			pm:            PricingMap{compute: map[string]*FamilyPricing{"": {}}},
+			pm:            &PricingMap{compute: map[string]*FamilyPricing{"": {}}},
 			ms:            &client.MachineSpec{Region: "missing region"},
 			expectedError: ErrRegionNotFound,
 		},
 		{
 			name:          "family type not found",
-			pm:            PricingMap{compute: map[string]*FamilyPricing{"region": {}}},
+			pm:            &PricingMap{compute: map[string]*FamilyPricing{"region": {}}},
 			ms:            &client.MachineSpec{Region: "region"},
 			expectedError: ErrFamilyTypeNotFound,
 		},
 		{
 			name: "on-demand",
-			pm: PricingMap{
+			pm: &PricingMap{
 				compute: map[string]*FamilyPricing{
 					"region": {
 						Family: map[string]*PriceTiers{
@@ -72,7 +74,7 @@ func TestStructuredPricingMap_GetCostOfInstance(t *testing.T) {
 		},
 		{
 			name: "spot",
-			pm: PricingMap{
+			pm: &PricingMap{
 				compute: map[string]*FamilyPricing{
 					"region": {
 						Family: map[string]*PriceTiers{
@@ -106,6 +108,85 @@ func TestStructuredPricingMap_GetCostOfInstance(t *testing.T) {
 			require.Equal(t, tc.expectedRAMPRice, r, "ram price mismatch")
 		})
 	}
+}
+
+// TestPricingMap_ConcurrentAccess is a regression test for
+// https://github.com/grafana/cloudcost-exporter/issues/1036. ParseSkus (the
+// writer, driven by the 24h refresh) and the getters (readers, driven by
+// Collect) must not touch pm.compute/pm.storage concurrently. Run with -race to
+// surface the bug: without the mutex it trips the runtime's "concurrent map
+// read and map write" detector.
+func TestPricingMap_ConcurrentAccess(t *testing.T) {
+	pm := &PricingMap{
+		compute: map[string]*FamilyPricing{},
+		storage: map[string]*StoragePricing{},
+	}
+
+	computeSku := func(region string) *billingpb.Sku {
+		return &billingpb.Sku{
+			Description:    "G2 Instance Core running in Sao Paulo",
+			ServiceRegions: []string{region},
+			PricingInfo: []*billingpb.PricingInfo{{
+				PricingExpression: &billingpb.PricingExpression{
+					TieredRates: []*billingpb.PricingExpression_TierRate{{
+						UnitPrice: &money.Money{Nanos: 1e9},
+					}},
+				},
+			}},
+		}
+	}
+	storageSku := func(region string) *billingpb.Sku {
+		return &billingpb.Sku{
+			Description:    "Storage PD Capacity",
+			Category:       &billingpb.Category{ResourceFamily: "Storage"},
+			ServiceRegions: []string{region},
+			PricingInfo: []*billingpb.PricingInfo{{
+				PricingExpression: &billingpb.PricingExpression{
+					TieredRates: []*billingpb.PricingExpression_TierRate{{
+						UnitPrice: &money.Money{Nanos: 1e9},
+					}},
+				},
+			}},
+		}
+	}
+
+	const iterations = 200
+	var wg sync.WaitGroup
+
+	// Writer: mirrors the periodic refresh, inserting a fresh region each
+	// iteration so the maps keep being written.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			region := fmt.Sprintf("us-central%d", i)
+			_ = pm.ParseSkus([]*billingpb.Sku{computeSku(region), storageSku(region)})
+		}
+	}()
+
+	// Readers: hammer both getters while the writer mutates the maps.
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				region := fmt.Sprintf("us-central%d", i)
+				_, _, _ = pm.GetCostOfInstance(&client.MachineSpec{Region: region, Family: "g2"})
+				_, _ = pm.GetCostOfStorage(region, "pd-standard")
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Sanity-check that the writer actually populated the maps.
+	cpu, _, err := pm.GetCostOfInstance(&client.MachineSpec{Region: "us-central0", Family: "g2"})
+	require.NoError(t, err)
+	require.Equal(t, 1.0, cpu)
+
+	prices, err := pm.GetCostOfStorage("us-central0", "pd-standard")
+	require.NoError(t, err)
+	require.Greater(t, prices.ProvisionedSpaceGiB, 0.0)
 }
 
 func TestPricingMapParseSkus(t *testing.T) {


### PR DESCRIPTION
## What

`PricingMap.compute` and `.storage` (pkg/google/gke) are written in place by
`ParseSkus` when the 24h refresh ticker fires, and read by `Collect` on every
scrape via `GetCostOfInstance` and `GetCostOfStorage`. With no synchronization,
a scrape coinciding with a refresh tick trips Go's "concurrent map read and map
write" detector and crashes the exporter (it recovers on restart).

Fixes #1036.

## Change

- Add a `sync.RWMutex` to `PricingMap`: write-lock `ParseSkus`, read-lock
  `GetCostOfInstance` and `GetCostOfStorage`. Network calls in `Populate` stay
  outside the lock (mirrors the `pkg/google/networking` pattern).
- `GetCostOfStorage` returns a copy of `StoragePrices` so the value read after
  the lock is released can't be mutated by a later refresh.
- Pointer-ize the `TestStructuredPricingMap_GetCostOfInstance` table so the new
  mutex field doesn't trip `go vet` copylocks.
- Add `TestPricingMap_ConcurrentAccess`, a regression test that runs `ParseSkus`
  concurrently with the getters.

## Testing

`go test -race ./pkg/google/gke/` — trips the race detector on `main`, clean
with this change.

Suggested release label: `release:patch` (bug fix affecting the binary).
