### PR TITLE
feat(bedrock): label token prices by type, region, and quota tier

### DIFF
--- a/docs/metrics/aws/bedrock.md
+++ b/docs/metrics/aws/bedrock.md
@@ -2,9 +2,8 @@
 
 | Metric name                                              | Metric type | Description                                                                      | Labels                                                                                                                                                              |
 |----------------------------------------------------------|-------------|---------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| cloudcost_aws_bedrock_input_usd_per_1k_tokens            | Gauge       | Input token price for an AWS Bedrock model. Cost represented in USD/1000 tokens  | `account_id`=&lt;AWS account ID&gt; <br/> `region`=&lt;AWS region&gt; <br/> `model_id`=&lt;model slug&gt; <br/> `family`=&lt;model provider&gt; <br/> `price_tier`=&lt;see Labels&gt; |
-| cloudcost_aws_bedrock_output_usd_per_1k_tokens           | Gauge       | Output token price for an AWS Bedrock model. Cost represented in USD/1000 tokens | `account_id`=&lt;AWS account ID&gt; <br/> `region`=&lt;AWS region&gt; <br/> `model_id`=&lt;model slug&gt; <br/> `family`=&lt;model provider&gt; <br/> `price_tier`=&lt;see Labels&gt; |
-| cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units | Gauge      | Search unit price for an AWS Bedrock model (e.g. Cohere Rerank). Cost represented in USD/1000 search units | `account_id`=&lt;AWS account ID&gt; <br/> `region`=&lt;AWS region&gt; <br/> `model_id`=&lt;model slug&gt; <br/> `family`=&lt;model provider&gt; <br/> `price_tier`=&lt;see Labels&gt; |
+| cloudcost_aws_bedrock_usd_per_1k_tokens                  | Gauge       | Token price for an AWS Bedrock model. Cost represented in USD/1000 tokens. `token_type` distinguishes input, output, and prompt-cache read/write | `account_id`=&lt;AWS account ID&gt; <br/> `region`=&lt;AWS region&gt; <br/> `model_id`=&lt;model slug&gt; <br/> `family`=&lt;model provider&gt; <br/> `token_type`=&lt;input\|output\|cache_read\|cache_write&gt; <br/> `region_tier`=&lt;in\|cross&gt; <br/> `quota_tier`=&lt;see Labels&gt; <br/> `cache_ttl`=&lt;""\|5m\|1h&gt; |
+| cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units | Gauge      | Search unit price for an AWS Bedrock model (e.g. Cohere Rerank). Cost represented in USD/1000 search units | `account_id`=&lt;AWS account ID&gt; <br/> `region`=&lt;AWS region&gt; <br/> `model_id`=&lt;model slug&gt; <br/> `family`=&lt;model provider&gt; <br/> `region_tier`=&lt;in\|cross&gt; <br/> `quota_tier`=&lt;see Labels&gt; |
 
 ## Overview
 
@@ -45,21 +44,24 @@ Restrict which model families are emitted with `--aws.bedrock.families` (a regex
 
   `model_id` is a normalized label derived from pricing metadata, not a canonical Bedrock model ID or ARN. Because both sources normalize to the same `model_id`, a model priced under both (e.g. the legacy Claude generation) merges into one set of series: identical prices dedupe, and a price one source lacks (the standard source prices some legacy Claude models for input only) is filled in by the other.
 - **family**: Model provider, normalized to lowercase (spaces become underscores) from the `AmazonBedrock` `provider` attribute, or derived from the `AmazonBedrockFoundationModels` `servicename`. The set tracks whatever AWS publishes, so it is open-ended; examples include `anthropic`, `amazon`, `cohere`, `meta`, `ai21`, `mistral`, `deepseek`, `google`, `qwen`, `nvidia`, `openai`, `writer`, and `twelvelabs` (not exhaustive, and the list grows as AWS adds providers). Amazon-developed models with no provider attribute (Nova, Titan) use `amazon`. A marketplace `servicename` with no recognized provider falls back to `unknown`. Filter with `--aws.bedrock.families`.
-- **price_tier**: Inference tier, composed of an optional `cross_region` prefix, a base operation, and an optional quota suffix, joined by `_`. The parts stack, so values like `on_demand`, `on_demand_batch`, `cross_region`, `cross_region_batch`, `cross_region_cache_read` all occur.
-  - Base operation (token metrics): `on_demand`, or a prompt-cache operation `cache_read`, `cache_write_5m`, `cache_write_1h`. Cache reads are a single rate; writes split by TTL (5-minute default vs 1-hour).
-  - Quota suffix: `batch`, `flex`, `priority`, or `latency_optimized` (e.g. `on_demand_batch`, `on_demand_latency_optimized`, `cache_write_1h`).
-  - Cross-region: any of the above prefixed with `cross_region` (e.g. `cross_region`, `cross_region_batch`, `cross_region_cache_write_1h`).
-  - Search-unit metrics use only `on_demand` and `cross_region`.
-  - Prompt caching is emitted only from the marketplace source. Cache storage (priced per token-hour) and caching for Amazon-native models (Nova/Titan) in the `AmazonBedrock` source are not emitted.
+The inference tier is split into orthogonal labels so consumers can filter or join on each
+dimension independently, rather than parsing a composed string:
+
+- **token_type** (token metric only): `input`, `output`, or a prompt-cache operation `cache_read` or `cache_write`. Prompt caching is emitted only from the marketplace source; cache storage (priced per token-hour) and caching for Amazon-native models (Nova/Titan) in the `AmazonBedrock` source are not emitted.
+- **region_tier**: `in` (in-region) or `cross` (cross-region inference).
+- **quota_tier**: `standard` (on-demand), `batch`, `flex`, `priority`, or `latency_optimized`.
+- **cache_ttl** (token metric only): the prompt-cache write TTL, `5m` or `1h`. Empty for non-cache token types and for cache reads (a single rate, no TTL).
+
+Search-unit metrics carry `region_tier` and `quota_tier` only (no `token_type`/`cache_ttl`).
 
 ## Pricing Sources
 
-The collector fetches `AmazonBedrock` and `AmazonBedrockFoundationModels` per region and merges them into one metric set. Each SKU's direction, family, model, and price tier are parsed from its `usagetype` and `servicename`; image, video, audio, cache-storage, provisioned-throughput, and guardrail SKUs are skipped. Prompt-cache read/write SKUs from the marketplace source are emitted on the input metric as `cache_*` price tiers.
+The collector fetches `AmazonBedrock` and `AmazonBedrockFoundationModels` per region and merges them into one metric set. Each SKU's token type, family, model, region tier, and quota tier are parsed from its `usagetype` and `servicename`; image, video, audio, cache-storage, provisioned-throughput, and guardrail SKUs are skipped. Prompt-cache read/write SKUs from the marketplace source are emitted on the token metric with `token_type=cache_read`/`cache_write`.
 
 - `AmazonBedrock` publishes token prices per 1000 tokens directly.
 - `AmazonBedrockFoundationModels` publishes token prices per 1,000,000 tokens (converted to per-1000) and search-unit prices per single unit (converted to per-1000).
 
-When both service codes price the same model (the legacy Claude generation), they share a `model_id`, so per-region/direction/tier entries dedupe and any price only one source carries is retained. Overlapping prices are identical across the two sources.
+When both service codes price the same model (the legacy Claude generation), they share a `model_id`, so entries with the same `(token_type, region_tier, quota_tier, cache_ttl)` dedupe and any price only one source carries is retained. Overlapping prices are identical across the two sources.
 
 `AmazonBedrockFoundationModels` pricing is best-effort: if that service code is unavailable, the collector logs a warning and continues to emit `AmazonBedrock` pricing rather than failing.
 

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -49,14 +49,10 @@ const (
 	cacheTTL5m = "5m"
 	cacheTTL1h = "1h"
 
-	// metricKind selects the output metric when a pricing key is decoded at collection time.
-	kindToken  = "token"
-	kindSearch = "search"
-
 	// compositeKeySep separates the fields encoded in the pricingstore usagetype key:
-	// kind|family|model_id|token_type|region_tier|quota_tier|cache_ttl
+	// family|model_id|token_type|region_tier|quota_tier|cache_ttl
 	compositeKeySep    = "|"
-	compositeKeyFields = 7
+	compositeKeyFields = 6
 
 	// searchUnitsPerKilo converts from per-unit pricing (as published by the AWS Pricing API)
 	// to per-1000-units pricing (as emitted by SearchUnitCostDesc).
@@ -94,17 +90,20 @@ var (
 // pricingstore usagetype key (the store's per-region map key, which must stay unique per price)
 // and expanded back into metric labels at collection time.
 type pricePoint struct {
-	kind       string // kindToken or kindSearch
 	family     string
 	modelID    string
-	tokenType  string // input|output|cache_read|cache_write; empty for search
+	tokenType  string // input|output|cache_read|cache_write; empty marks a search price
 	regionTier string // in|cross
 	quotaTier  string // standard|batch|flex|priority|latency_optimized
 	cacheTTL   string // 5m|1h; empty for non-cache
 }
 
+// isSearch reports whether this is a search-unit price. Search SKUs carry no token_type, so an
+// empty token_type is the marker; token prices always set one (input/output/cache_read/cache_write).
+func (p pricePoint) isSearch() bool { return p.tokenType == "" }
+
 func (p pricePoint) encode() string {
-	return strings.Join([]string{p.kind, p.family, p.modelID, p.tokenType, p.regionTier, p.quotaTier, p.cacheTTL}, compositeKeySep)
+	return strings.Join([]string{p.family, p.modelID, p.tokenType, p.regionTier, p.quotaTier, p.cacheTTL}, compositeKeySep)
 }
 
 func decodePricePoint(key string) (pricePoint, bool) {
@@ -113,13 +112,12 @@ func decodePricePoint(key string) (pricePoint, bool) {
 		return pricePoint{}, false
 	}
 	return pricePoint{
-		kind:       parts[0],
-		family:     parts[1],
-		modelID:    parts[2],
-		tokenType:  parts[3],
-		regionTier: parts[4],
-		quotaTier:  parts[5],
-		cacheTTL:   parts[6],
+		family:     parts[0],
+		modelID:    parts[1],
+		tokenType:  parts[2],
+		regionTier: parts[3],
+		quotaTier:  parts[4],
+		cacheTTL:   parts[5],
 	}, true
 }
 
@@ -236,17 +234,12 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 				continue
 			}
 
-			switch point.kind {
-			case kindToken:
-				ch <- prometheus.MustNewConstMetric(TokenCostDesc, prometheus.GaugeValue, price,
-					c.accountID, region, point.modelID, point.family, point.tokenType, point.regionTier, point.quotaTier, point.cacheTTL)
-			case kindSearch:
+			if point.isSearch() {
 				ch <- prometheus.MustNewConstMetric(SearchUnitCostDesc, prometheus.GaugeValue, price,
 					c.accountID, region, point.modelID, point.family, point.regionTier, point.quotaTier)
-			default:
-				c.logger.LogAttrs(ctx, slog.LevelWarn, "unknown kind in Bedrock pricing key, skipping",
-					slog.String("region", region),
-					slog.String("kind", point.kind))
+			} else {
+				ch <- prometheus.MustNewConstMetric(TokenCostDesc, prometheus.GaugeValue, price,
+					c.accountID, region, point.modelID, point.family, point.tokenType, point.regionTier, point.quotaTier, point.cacheTTL)
 			}
 		}
 	}
@@ -373,11 +366,9 @@ func encodeBedrockPriceJSON(raw string, familyFilter *regexp.Regexp) (string, bo
 		quotaTier:  quotaTier,
 	}
 	// Standard SKUs carry no prompt-cache prices (classifyInferenceType skips "prompt cache"),
-	// so token_type is just the inference direction.
-	if direction == directionSearch {
-		point.kind = kindSearch
-	} else {
-		point.kind = kindToken
+	// so token_type is just the inference direction. Search SKUs leave token_type empty, which
+	// marks them as search at collection time.
+	if direction != directionSearch {
 		point.tokenType = direction
 	}
 
@@ -551,7 +542,6 @@ func encodeBedrockMarketplacePriceJSON(raw string, familyFilter *regexp.Regexp) 
 		quotaTier:  quotaTier,
 	}
 	if cacheTokenType != "" {
-		point.kind = kindToken
 		point.tokenType = cacheTokenType
 		point.cacheTTL = cacheTTL
 	} else {
@@ -559,15 +549,13 @@ func encodeBedrockMarketplacePriceJSON(raw string, familyFilter *regexp.Regexp) 
 		if !ok {
 			return "", false, nil
 		}
-		if direction == directionSearch {
-			point.kind = kindSearch
-		} else {
-			point.kind = kindToken
+		// Search SKUs leave token_type empty (that marks them as search); token SKUs set it.
+		if direction != directionSearch {
 			point.tokenType = direction
 		}
 	}
 
-	isSearch := point.kind == kindSearch
+	isSearch := point.isSearch()
 	for _, term := range info.Terms.OnDemand {
 		for _, pd := range term.PriceDimensions {
 			usd, ok := pd.PricePerUnit["USD"]

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -475,6 +475,8 @@ func standardTier(suffix string) (regionTier, quotaTier string) {
 		quotaTier = quotaTierFlex
 	case strings.Contains(lower, "priority"):
 		quotaTier = quotaTierPriority
+	case strings.Contains(lower, "latency"):
+		quotaTier = quotaTierLatencyOptimized
 	}
 	return regionTier, quotaTier
 }

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -24,21 +24,39 @@ const (
 	subsystem   = "aws_bedrock"
 	serviceName = "bedrock"
 
-	priceTierOnDemand         = "on_demand"
-	priceTierOnDemandBatch    = "on_demand_batch"
-	priceTierOnDemandFlex     = "on_demand_flex"
-	priceTierOnDemandPriority = "on_demand_priority"
-	priceTierCrossRegion      = "cross_region"
+	// token_type label values. Prompt-cache read/write are input-side operations and so are
+	// emitted on the token metric alongside input/output.
+	tokenTypeInput      = "input"
+	tokenTypeOutput     = "output"
+	tokenTypeCacheRead  = "cache_read"
+	tokenTypeCacheWrite = "cache_write"
 
-	// Prompt-caching operations, emitted as price_tier values on the input metric. Reads are a
-	// single rate; writes split by cache TTL (5-minute default vs 1-hour).
-	priceTierCacheRead    = "cache_read"
-	priceTierCacheWrite5m = "cache_write_5m"
-	priceTierCacheWrite1h = "cache_write_1h"
+	// directionSearch routes a SKU to the search-unit metric. It is not a token_type value.
+	directionSearch = "search"
 
-	// compositeKeySep separates the four fields encoded in the pricingstore usagetype key:
-	// family|direction|model_id|price_tier
-	compositeKeySep = "|"
+	// region_tier label values: in-region vs cross-region inference.
+	regionTierIn    = "in"
+	regionTierCross = "cross"
+
+	// quota_tier label values: the on-demand quota a price applies to.
+	quotaTierStandard         = "standard"
+	quotaTierBatch            = "batch"
+	quotaTierFlex             = "flex"
+	quotaTierPriority         = "priority"
+	quotaTierLatencyOptimized = "latency_optimized"
+
+	// cache_ttl label values, set only for cache_write (empty otherwise).
+	cacheTTL5m = "5m"
+	cacheTTL1h = "1h"
+
+	// metricKind selects the output metric when a pricing key is decoded at collection time.
+	kindToken  = "token"
+	kindSearch = "search"
+
+	// compositeKeySep separates the fields encoded in the pricingstore usagetype key:
+	// kind|family|model_id|token_type|region_tier|quota_tier|cache_ttl
+	compositeKeySep    = "|"
+	compositeKeyFields = 7
 
 	// searchUnitsPerKilo converts from per-unit pricing (as published by the AWS Pricing API)
 	// to per-1000-units pricing (as emitted by SearchUnitCostDesc).
@@ -53,28 +71,57 @@ const (
 )
 
 var (
-	InputTokenCostDesc = utils.GenerateDesc(
+	// TokenCostDesc carries every per-token price (input, output, and prompt-cache read/write),
+	// distinguished by orthogonal labels rather than separate metric names or a composed price
+	// tier, so downstream joins key on (model_id, token_type, region_tier) directly.
+	TokenCostDesc = utils.GenerateDesc(
 		cloudcostexporter.MetricPrefix,
 		subsystem,
-		utils.InputTokenCostSuffix,
-		"The cost of AWS Bedrock input tokens in USD per 1000 tokens",
-		[]string{"account_id", "region", "model_id", "family", "price_tier"},
-	)
-	OutputTokenCostDesc = utils.GenerateDesc(
-		cloudcostexporter.MetricPrefix,
-		subsystem,
-		utils.OutputTokenCostSuffix,
-		"The cost of AWS Bedrock output tokens in USD per 1000 tokens",
-		[]string{"account_id", "region", "model_id", "family", "price_tier"},
+		utils.TokenCostSuffix,
+		"The cost of AWS Bedrock tokens in USD per 1000 tokens, by token_type",
+		[]string{"account_id", "region", "model_id", "family", "token_type", "region_tier", "quota_tier", "cache_ttl"},
 	)
 	SearchUnitCostDesc = utils.GenerateDesc(
 		cloudcostexporter.MetricPrefix,
 		subsystem,
 		utils.SearchUnitCostSuffix,
 		"The cost of AWS Bedrock search units in USD per 1000 search units (e.g. Cohere Rerank)",
-		[]string{"account_id", "region", "model_id", "family", "price_tier"},
+		[]string{"account_id", "region", "model_id", "family", "region_tier", "quota_tier"},
 	)
 )
+
+// pricePoint is the decomposed identity of a single Bedrock price. It is encoded into the
+// pricingstore usagetype key (the store's per-region map key, which must stay unique per price)
+// and expanded back into metric labels at collection time.
+type pricePoint struct {
+	kind       string // kindToken or kindSearch
+	family     string
+	modelID    string
+	tokenType  string // input|output|cache_read|cache_write; empty for search
+	regionTier string // in|cross
+	quotaTier  string // standard|batch|flex|priority|latency_optimized
+	cacheTTL   string // 5m|1h; empty for non-cache
+}
+
+func (p pricePoint) encode() string {
+	return strings.Join([]string{p.kind, p.family, p.modelID, p.tokenType, p.regionTier, p.quotaTier, p.cacheTTL}, compositeKeySep)
+}
+
+func decodePricePoint(key string) (pricePoint, bool) {
+	parts := strings.SplitN(key, compositeKeySep, compositeKeyFields)
+	if len(parts) != compositeKeyFields {
+		return pricePoint{}, false
+	}
+	return pricePoint{
+		kind:       parts[0],
+		family:     parts[1],
+		modelID:    parts[2],
+		tokenType:  parts[3],
+		regionTier: parts[4],
+		quotaTier:  parts[5],
+		cacheTTL:   parts[6],
+	}, true
+}
 
 type bedrockProductInfo struct {
 	Product struct {
@@ -181,27 +228,25 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 
 	for region, regionSnap := range snapshot.Regions() {
 		for compositeKey, price := range regionSnap.Entries() {
-			parts := strings.SplitN(compositeKey, compositeKeySep, 4)
-			if len(parts) != 4 {
+			pp, ok := decodePricePoint(compositeKey)
+			if !ok {
 				c.logger.LogAttrs(ctx, slog.LevelWarn, "malformed Bedrock pricing key, skipping",
 					slog.String("region", region),
 					slog.String("key", compositeKey))
 				continue
 			}
-			family, direction, modelID, priceTier := parts[0], parts[1], parts[2], parts[3]
-			labelVals := []string{c.accountID, region, modelID, family, priceTier}
 
-			switch direction {
-			case "input":
-				ch <- prometheus.MustNewConstMetric(InputTokenCostDesc, prometheus.GaugeValue, price, labelVals...)
-			case "output":
-				ch <- prometheus.MustNewConstMetric(OutputTokenCostDesc, prometheus.GaugeValue, price, labelVals...)
-			case "search":
-				ch <- prometheus.MustNewConstMetric(SearchUnitCostDesc, prometheus.GaugeValue, price, labelVals...)
+			switch pp.kind {
+			case kindToken:
+				ch <- prometheus.MustNewConstMetric(TokenCostDesc, prometheus.GaugeValue, price,
+					c.accountID, region, pp.modelID, pp.family, pp.tokenType, pp.regionTier, pp.quotaTier, pp.cacheTTL)
+			case kindSearch:
+				ch <- prometheus.MustNewConstMetric(SearchUnitCostDesc, prometheus.GaugeValue, price,
+					c.accountID, region, pp.modelID, pp.family, pp.regionTier, pp.quotaTier)
 			default:
-				c.logger.LogAttrs(ctx, slog.LevelWarn, "unknown direction in Bedrock pricing key, skipping",
+				c.logger.LogAttrs(ctx, slog.LevelWarn, "unknown kind in Bedrock pricing key, skipping",
 					slog.String("region", region),
-					slog.String("direction", direction))
+					slog.String("kind", pp.kind))
 			}
 		}
 	}
@@ -210,8 +255,7 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 }
 
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
-	ch <- InputTokenCostDesc
-	ch <- OutputTokenCostDesc
+	ch <- TokenCostDesc
 	ch <- SearchUnitCostDesc
 	return nil
 }
@@ -292,7 +336,7 @@ func encodeBedrockPriceJSON(raw string, familyFilter *regexp.Regexp) (string, bo
 		}
 	}
 
-	slug, priceTier := parseBedrockModelID(attrs.UsageType)
+	slug, suffix := parseBedrockModelID(attrs.UsageType)
 	if slug == "" {
 		return "", false, nil
 	}
@@ -315,13 +359,29 @@ func encodeBedrockPriceJSON(raw string, familyFilter *regexp.Regexp) (string, bo
 
 	// The Pricing API publishes search unit prices per single unit; scale to per-1k to match
 	// the SearchUnitCostDesc metric name.
-	if direction == "search" {
+	if direction == directionSearch {
 		if err := scaleSearchUnitPrices(&info); err != nil {
 			return "", false, fmt.Errorf("scaling search unit prices for %q: %w", attrs.UsageType, err)
 		}
 	}
 
-	attrs.UsageType = strings.Join([]string{family, direction, modelID, priceTier}, compositeKeySep)
+	regionTier, quotaTier := standardTier(suffix)
+	pp := pricePoint{
+		family:     family,
+		modelID:    modelID,
+		regionTier: regionTier,
+		quotaTier:  quotaTier,
+	}
+	// Standard SKUs carry no prompt-cache prices (classifyInferenceType skips "prompt cache"),
+	// so token_type is just the inference direction.
+	if direction == directionSearch {
+		pp.kind = kindSearch
+	} else {
+		pp.kind = kindToken
+		pp.tokenType = direction
+	}
+
+	attrs.UsageType = pp.encode()
 
 	modified, err := json.Marshal(&info)
 	if err != nil {
@@ -333,7 +393,7 @@ func encodeBedrockPriceJSON(raw string, familyFilter *regexp.Regexp) (string, bo
 // classifyByUsageType is a fallback for SKUs where inferenceType is absent.
 func classifyByUsageType(usagetype string) (direction string, ok bool) {
 	if strings.Contains(strings.ToLower(usagetype), "searchunits") {
-		return "search", true
+		return directionSearch, true
 	}
 	return "", false
 }
@@ -368,13 +428,13 @@ func classifyInferenceType(inferenceType string) (direction string, ok bool) {
 		}
 	}
 	if strings.Contains(lower, "input tokens") || strings.Contains(lower, "text input token") {
-		return "input", true
+		return tokenTypeInput, true
 	}
 	if strings.Contains(lower, "output tokens") {
-		return "output", true
+		return tokenTypeOutput, true
 	}
 	if strings.Contains(lower, "search unit") || strings.Contains(lower, "rerank") {
-		return "search", true
+		return directionSearch, true
 	}
 	return "", false
 }
@@ -389,7 +449,10 @@ var tokenTypeMarkers = []string{
 	"-searchunits", // Rerank usagetype format (e.g. AmazonRerank-v1-searchunits)
 }
 
-func parseBedrockModelID(usagetype string) (modelID, priceTier string) {
+// parseBedrockModelID splits a standard usagetype into the model slug and the trailing
+// qualifier suffix (everything after the token-type marker, e.g. "-batch",
+// "-cross-region-global"). Returns an empty slug if no token-type marker is present.
+func parseBedrockModelID(usagetype string) (modelID, suffix string) {
 	slug := usagetype
 	if i := strings.Index(usagetype, "-"); i >= 0 {
 		slug = usagetype[i+1:]
@@ -397,28 +460,32 @@ func parseBedrockModelID(usagetype string) (modelID, priceTier string) {
 
 	for _, marker := range tokenTypeMarkers {
 		if idx := strings.Index(slug, marker); idx >= 0 {
-			tierSuffix := slug[idx+len(marker):]
-			return slug[:idx], extractPriceTier(tierSuffix)
+			return slug[:idx], slug[idx+len(marker):]
 		}
 	}
-	return "", priceTierOnDemand
+	return "", ""
 }
 
-func extractPriceTier(suffix string) string {
+// standardTier decodes a standard usagetype qualifier suffix into region and quota tiers.
+// Cross-region and a quota qualifier can co-occur, so each is captured independently.
+func standardTier(suffix string) (regionTier, quotaTier string) {
 	lower := strings.ToLower(suffix)
+
+	regionTier = regionTierIn
 	if strings.Contains(lower, "cross-region") {
-		return priceTierCrossRegion
+		regionTier = regionTierCross
 	}
+
+	quotaTier = quotaTierStandard
 	switch {
-	case strings.HasSuffix(lower, "-batch"):
-		return priceTierOnDemandBatch
-	case strings.HasSuffix(lower, "-flex"):
-		return priceTierOnDemandFlex
-	case strings.HasSuffix(lower, "-priority"):
-		return priceTierOnDemandPriority
-	default:
-		return priceTierOnDemand
+	case strings.Contains(lower, "batch"):
+		quotaTier = quotaTierBatch
+	case strings.Contains(lower, "flex"):
+		quotaTier = quotaTierFlex
+	case strings.Contains(lower, "priority"):
+		quotaTier = quotaTierPriority
 	}
+	return regionTier, quotaTier
 }
 
 // Empty provider maps to "amazon" (Nova, Titan, and other Amazon-developed models).
@@ -466,7 +533,7 @@ func encodeBedrockMarketplacePriceJSON(raw string, familyFilter *regexp.Regexp) 
 
 	// Cache read/write are input-token operations; storage is per token-hour (a different unit)
 	// so it is skipped. Non-cache SKUs fall through to the normal direction classifier.
-	cacheOp, skipCache := marketplaceCacheOp(attrs.UsageType)
+	cacheTokenType, cacheTTL, skipCache := marketplaceCacheOp(attrs.UsageType)
 	if skipCache {
 		// Storage (per token-hour, a different unit) is an expected skip; anything else is an
 		// unrecognized cache shape worth surfacing so we add it rather than mislabel it.
@@ -475,17 +542,32 @@ func encodeBedrockMarketplacePriceJSON(raw string, familyFilter *regexp.Regexp) 
 		}
 		return "", false, nil
 	}
-	direction := "input"
-	if cacheOp == "" {
-		var ok bool
-		direction, ok = classifyMarketplaceUsageType(attrs.UsageType)
+
+	regionTier, quotaTier := marketplaceTier(attrs.UsageType)
+	pp := pricePoint{
+		family:     family,
+		modelID:    modelID,
+		regionTier: regionTier,
+		quotaTier:  quotaTier,
+	}
+	if cacheTokenType != "" {
+		pp.kind = kindToken
+		pp.tokenType = cacheTokenType
+		pp.cacheTTL = cacheTTL
+	} else {
+		direction, ok := classifyMarketplaceUsageType(attrs.UsageType)
 		if !ok {
 			return "", false, nil
 		}
+		if direction == directionSearch {
+			pp.kind = kindSearch
+		} else {
+			pp.kind = kindToken
+			pp.tokenType = direction
+		}
 	}
 
-	priceTier := extractMarketplacePriceTier(attrs.UsageType, cacheOp)
-
+	isSearch := pp.kind == kindSearch
 	for _, term := range info.Terms.OnDemand {
 		for _, pd := range term.PriceDimensions {
 			usd, ok := pd.PricePerUnit["USD"]
@@ -497,7 +579,7 @@ func encodeBedrockMarketplacePriceJSON(raw string, familyFilter *regexp.Regexp) 
 				return "", false, fmt.Errorf("parsing price for %q: %w", attrs.UsageType, err)
 			}
 			var converted float64
-			if direction == "search" {
+			if isSearch {
 				// Marketplace publishes $/search unit; metric is $/1K search units.
 				converted = price * searchUnitsPerKilo
 			} else {
@@ -508,7 +590,7 @@ func encodeBedrockMarketplacePriceJSON(raw string, familyFilter *regexp.Regexp) 
 		}
 	}
 
-	attrs.UsageType = strings.Join([]string{family, direction, modelID, priceTier}, compositeKeySep)
+	attrs.UsageType = pp.encode()
 
 	modified, err := json.Marshal(&info)
 	if err != nil {
@@ -596,88 +678,68 @@ func classifyMarketplaceUsageType(usagetype string) (direction string, ok bool) 
 	}
 	switch {
 	case strings.Contains(lower, "inputtokencount"), strings.Contains(lower, "input_tokens"):
-		return "input", true
+		return tokenTypeInput, true
 	case strings.Contains(lower, "outputtokencount"), strings.Contains(lower, "output_tokens"):
-		return "output", true
+		return tokenTypeOutput, true
 	case strings.Contains(lower, "search_units"):
-		return "search", true
+		return directionSearch, true
 	default:
 		return "", false
 	}
 }
 
-// extractMarketplacePriceTier derives price tier from the marketplace usagetype suffix.
-// Cross-region ("global") and quota-tier ("batch", "priority", "flex") can stack —
-// check batch/priority/flex before the global catch-all.
-// composeTier builds a price_tier from its parts: an optional cross-region prefix, the base
-// operation (on_demand or a cache_* op), and an optional quota tier suffix (batch/flex/priority/
-// latency_optimized). Components stack, e.g. cross_region_cache_read, cache_write_1h,
-// on_demand_batch. Each distinct combination gets a distinct value, so SKUs that differ only by a
-// qualifier do not collide on one key.
-func composeTier(crossRegion bool, op, quota string) string {
-	if op == "" {
-		op = priceTierOnDemand
+// marketplaceTier decodes a marketplace usagetype into region and quota tiers. Cross-region
+// ("_global") and a quota qualifier ("_batch", "_priority", "_flex", "latencyoptimized") are
+// captured independently, so a SKU carrying both keeps both.
+func marketplaceTier(usagetype string) (regionTier, quotaTier string) {
+	lower := strings.ToLower(usagetype)
+
+	regionTier = regionTierIn
+	if strings.Contains(lower, "_global") {
+		regionTier = regionTierCross
 	}
-	parts := make([]string, 0, 3)
-	if crossRegion {
-		parts = append(parts, priceTierCrossRegion)
+
+	quotaTier = quotaTierStandard
+	switch {
+	case strings.Contains(lower, "_batch"):
+		quotaTier = quotaTierBatch
+	case strings.Contains(lower, "_priority"):
+		quotaTier = quotaTierPriority
+	case strings.Contains(lower, "_flex"):
+		quotaTier = quotaTierFlex
+	case strings.Contains(lower, "latencyoptimized"):
+		quotaTier = quotaTierLatencyOptimized
 	}
-	// Drop a redundant on_demand when cross-region already carries the base meaning, matching the
-	// established names (cross_region, not cross_region_on_demand).
-	if !crossRegion || op != priceTierOnDemand {
-		parts = append(parts, op)
-	}
-	if quota != "" {
-		parts = append(parts, quota)
-	}
-	return strings.Join(parts, "_")
+	return regionTier, quotaTier
 }
 
-// marketplaceCacheOp returns the cache operation for a marketplace usagetype, and whether it is a
-// cache-storage SKU. Storage is priced per token-hour (a different unit), so the caller skips it.
-// Returns "" for non-cache SKUs. Reads are a single rate; writes split by 5-minute vs 1-hour TTL.
-func marketplaceCacheOp(usagetype string) (op string, skip bool) {
+// marketplaceCacheOp classifies a marketplace cache usagetype into a token_type and cache TTL.
+// Returns ("", "", false) for non-cache SKUs. skip=true marks cache SKUs we do not model
+// (storage, unrecognized shapes, unrecognized TTLs), so the caller drops them rather than
+// mislabel them. Reads are a single rate (no TTL); writes split by 5-minute vs 1-hour TTL.
+func marketplaceCacheOp(usagetype string) (tokenType, cacheTTL string, skip bool) {
 	lower := strings.ToLower(usagetype)
 	if !strings.Contains(lower, "cache") {
-		return "", false
+		return "", "", false
 	}
 	switch {
 	case strings.Contains(lower, "cacheread") || strings.Contains(lower, "cache_read"):
-		return priceTierCacheRead, false
+		return tokenTypeCacheRead, "", false
 	case strings.Contains(lower, "cachewrite") || strings.Contains(lower, "cache_write"):
 		// Recognize the write TTL explicitly. AWS bills the bare write (no TTL token) at the
 		// 5-minute default and tags the 1-hour write with "1h". Any other TTL token is one we do
 		// not model yet, so skip it and surface it rather than silently labeling it a 5m write.
 		switch cacheWriteTTL.FindString(lower) {
-		case "", "5m":
-			return priceTierCacheWrite5m, false
-		case "1h":
-			return priceTierCacheWrite1h, false
+		case "", cacheTTL5m:
+			return tokenTypeCacheWrite, cacheTTL5m, false
+		case cacheTTL1h:
+			return tokenTypeCacheWrite, cacheTTL1h, false
 		default:
-			return "", true
+			return "", "", true
 		}
 	default:
 		// Cache storage (per token-hour, a different unit) and any cache shape that is neither a
 		// read nor a write: drop it rather than mislabel it as a 5-minute write.
-		return "", true
+		return "", "", true
 	}
-}
-
-func extractMarketplacePriceTier(usagetype, cacheOp string) string {
-	lower := strings.ToLower(usagetype)
-	crossRegion := strings.Contains(lower, "_global")
-
-	var quota string
-	switch {
-	case strings.Contains(lower, "_batch"):
-		quota = "batch"
-	case strings.Contains(lower, "_priority"):
-		quota = "priority"
-	case strings.Contains(lower, "_flex"):
-		quota = "flex"
-	case strings.Contains(lower, "latencyoptimized"):
-		quota = "latency_optimized"
-	}
-
-	return composeTier(crossRegion, cacheOp, quota)
 }

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -228,7 +228,7 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 
 	for region, regionSnap := range snapshot.Regions() {
 		for compositeKey, price := range regionSnap.Entries() {
-			pp, ok := decodePricePoint(compositeKey)
+			point, ok := decodePricePoint(compositeKey)
 			if !ok {
 				c.logger.LogAttrs(ctx, slog.LevelWarn, "malformed Bedrock pricing key, skipping",
 					slog.String("region", region),
@@ -236,17 +236,17 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 				continue
 			}
 
-			switch pp.kind {
+			switch point.kind {
 			case kindToken:
 				ch <- prometheus.MustNewConstMetric(TokenCostDesc, prometheus.GaugeValue, price,
-					c.accountID, region, pp.modelID, pp.family, pp.tokenType, pp.regionTier, pp.quotaTier, pp.cacheTTL)
+					c.accountID, region, point.modelID, point.family, point.tokenType, point.regionTier, point.quotaTier, point.cacheTTL)
 			case kindSearch:
 				ch <- prometheus.MustNewConstMetric(SearchUnitCostDesc, prometheus.GaugeValue, price,
-					c.accountID, region, pp.modelID, pp.family, pp.regionTier, pp.quotaTier)
+					c.accountID, region, point.modelID, point.family, point.regionTier, point.quotaTier)
 			default:
 				c.logger.LogAttrs(ctx, slog.LevelWarn, "unknown kind in Bedrock pricing key, skipping",
 					slog.String("region", region),
-					slog.String("kind", pp.kind))
+					slog.String("kind", point.kind))
 			}
 		}
 	}
@@ -366,7 +366,7 @@ func encodeBedrockPriceJSON(raw string, familyFilter *regexp.Regexp) (string, bo
 	}
 
 	regionTier, quotaTier := standardTier(suffix)
-	pp := pricePoint{
+	point := pricePoint{
 		family:     family,
 		modelID:    modelID,
 		regionTier: regionTier,
@@ -375,13 +375,13 @@ func encodeBedrockPriceJSON(raw string, familyFilter *regexp.Regexp) (string, bo
 	// Standard SKUs carry no prompt-cache prices (classifyInferenceType skips "prompt cache"),
 	// so token_type is just the inference direction.
 	if direction == directionSearch {
-		pp.kind = kindSearch
+		point.kind = kindSearch
 	} else {
-		pp.kind = kindToken
-		pp.tokenType = direction
+		point.kind = kindToken
+		point.tokenType = direction
 	}
 
-	attrs.UsageType = pp.encode()
+	attrs.UsageType = point.encode()
 
 	modified, err := json.Marshal(&info)
 	if err != nil {
@@ -544,30 +544,30 @@ func encodeBedrockMarketplacePriceJSON(raw string, familyFilter *regexp.Regexp) 
 	}
 
 	regionTier, quotaTier := marketplaceTier(attrs.UsageType)
-	pp := pricePoint{
+	point := pricePoint{
 		family:     family,
 		modelID:    modelID,
 		regionTier: regionTier,
 		quotaTier:  quotaTier,
 	}
 	if cacheTokenType != "" {
-		pp.kind = kindToken
-		pp.tokenType = cacheTokenType
-		pp.cacheTTL = cacheTTL
+		point.kind = kindToken
+		point.tokenType = cacheTokenType
+		point.cacheTTL = cacheTTL
 	} else {
 		direction, ok := classifyMarketplaceUsageType(attrs.UsageType)
 		if !ok {
 			return "", false, nil
 		}
 		if direction == directionSearch {
-			pp.kind = kindSearch
+			point.kind = kindSearch
 		} else {
-			pp.kind = kindToken
-			pp.tokenType = direction
+			point.kind = kindToken
+			point.tokenType = direction
 		}
 	}
 
-	isSearch := pp.kind == kindSearch
+	isSearch := point.kind == kindSearch
 	for _, term := range info.Terms.OnDemand {
 		for _, pd := range term.PriceDimensions {
 			usd, ok := pd.PricePerUnit["USD"]
@@ -590,7 +590,7 @@ func encodeBedrockMarketplacePriceJSON(raw string, familyFilter *regexp.Regexp) 
 		}
 	}
 
-	attrs.UsageType = pp.encode()
+	attrs.UsageType = point.encode()
 
 	modified, err := json.Marshal(&info)
 	if err != nil {

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -371,6 +371,7 @@ func encodeBedrockPriceJSON(raw string, familyFilter *regexp.Regexp) (string, bo
 	if direction != directionSearch {
 		point.tokenType = direction
 	}
+	point.modelID = stripRedundantLatency(point.modelID, point.quotaTier)
 
 	attrs.UsageType = point.encode()
 
@@ -481,6 +482,17 @@ func standardTier(suffix string) (regionTier, quotaTier string) {
 	return regionTier, quotaTier
 }
 
+// stripRedundantLatency removes a trailing "-latency-optimized" from a model_id when the quota
+// tier already records it. AWS's `model` attribute folds "Latency Optimized" into the model name
+// for some SKUs (e.g. Nova, Llama), which would double-encode the dimension (model_id + quota_tier);
+// keeping it only in quota_tier matches the SKUs whose model name omits it (e.g. claude-3.5-haiku).
+func stripRedundantLatency(modelID, quotaTier string) string {
+	if quotaTier == quotaTierLatencyOptimized {
+		return strings.TrimSuffix(modelID, "-latency-optimized")
+	}
+	return modelID
+}
+
 // Empty provider maps to "amazon" (Nova, Titan, and other Amazon-developed models).
 func normalizeProvider(provider string) string {
 	if provider == "" {
@@ -579,6 +591,7 @@ func encodeBedrockMarketplacePriceJSON(raw string, familyFilter *regexp.Regexp) 
 			pd.PricePerUnit["USD"] = strconv.FormatFloat(converted, 'f', -1, 64)
 		}
 	}
+	point.modelID = stripRedundantLatency(point.modelID, point.quotaTier)
 
 	attrs.UsageType = point.encode()
 

--- a/pkg/aws/bedrock/bedrock_test.go
+++ b/pkg/aws/bedrock/bedrock_test.go
@@ -88,7 +88,7 @@ func TestCollect_EmitsInputAndOutputTokenMetrics(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 
-	inputMetric := metricByName(results, "cloudcost_aws_bedrock_input_usd_per_1k_tokens")
+	inputMetric := tokenMetricByType(results, "input")
 	require.NotNil(t, inputMetric)
 	assert.Equal(t, "us-east-1", inputMetric.Labels["region"])
 	// These fixtures omit the `model` attribute, so model_id is the normalized usagetype slug
@@ -96,16 +96,19 @@ func TestCollect_EmitsInputAndOutputTokenMetrics(t *testing.T) {
 	// TestCollect_StandardModelIDUsesModelAttribute.
 	assert.Equal(t, "claude3sonnet", inputMetric.Labels["model_id"])
 	assert.Equal(t, "anthropic", inputMetric.Labels["family"])
-	assert.Equal(t, "on_demand", inputMetric.Labels["price_tier"])
+	assert.Equal(t, "in", inputMetric.Labels["region_tier"])
+	assert.Equal(t, "standard", inputMetric.Labels["quota_tier"])
+	assert.Equal(t, "", inputMetric.Labels["cache_ttl"])
 	assert.Equal(t, "123456789012", inputMetric.Labels["account_id"])
 	assert.InDelta(t, 0.003, inputMetric.Value, 1e-9)
 
-	outputMetric := metricByName(results, "cloudcost_aws_bedrock_output_usd_per_1k_tokens")
+	outputMetric := tokenMetricByType(results, "output")
 	require.NotNil(t, outputMetric)
 	assert.Equal(t, "us-east-1", outputMetric.Labels["region"])
 	assert.Equal(t, "claude3sonnet", outputMetric.Labels["model_id"])
 	assert.Equal(t, "anthropic", outputMetric.Labels["family"])
-	assert.Equal(t, "on_demand", outputMetric.Labels["price_tier"])
+	assert.Equal(t, "in", outputMetric.Labels["region_tier"])
+	assert.Equal(t, "standard", outputMetric.Labels["quota_tier"])
 	assert.InDelta(t, 0.015, outputMetric.Value, 1e-9)
 }
 
@@ -168,7 +171,9 @@ func TestCollect_LabelsCrossRegionPriceTier(t *testing.T) {
 	require.Len(t, results, 1)
 
 	m := results[0]
-	assert.Equal(t, "cross_region", m.Labels["price_tier"])
+	assert.Equal(t, "cross", m.Labels["region_tier"])
+	assert.Equal(t, "standard", m.Labels["quota_tier"])
+	assert.Equal(t, "input", m.Labels["token_type"])
 	assert.Equal(t, "amazon", m.Labels["family"])
 	assert.Equal(t, "novapremier", m.Labels["model_id"])
 }
@@ -201,7 +206,9 @@ func TestCollect_LabelsBatchPriceTier(t *testing.T) {
 	require.Len(t, results, 1)
 
 	m := results[0]
-	assert.Equal(t, "on_demand_batch", m.Labels["price_tier"])
+	assert.Equal(t, "in", m.Labels["region_tier"])
+	assert.Equal(t, "batch", m.Labels["quota_tier"])
+	assert.Equal(t, "input", m.Labels["token_type"])
 	assert.Equal(t, "anthropic", m.Labels["family"])
 	assert.Equal(t, "claude3sonnet", m.Labels["model_id"])
 }
@@ -391,67 +398,36 @@ func TestClassifyInferenceType(t *testing.T) {
 }
 
 func TestParseBedrockModelID(t *testing.T) {
+	// Asserts the model slug plus the region/quota tiers decoded from the trailing suffix.
+	// Cross-region and a quota qualifier are captured independently (e.g. cross + batch).
 	tests := []struct {
-		usagetype     string
-		wantModelID   string
-		wantPriceTier string
+		usagetype      string
+		wantModelID    string
+		wantRegionTier string
+		wantQuotaTier  string
 	}{
-		{
-			"USE1-Claude3Sonnet-input-tokens",
-			"Claude3Sonnet", "on_demand",
-		},
-		{
-			"USE1-Claude2.0-input-tokens",
-			"Claude2.0", "on_demand",
-		},
-		{
-			"USE1-Llama4-Maverick-17B-input-tokens-batch",
-			"Llama4-Maverick-17B", "on_demand_batch",
-		},
-		{
-			"USE1-GPT-OSS-Safeguard-20B-input-tokens-priority",
-			"GPT-OSS-Safeguard-20B", "on_demand_priority",
-		},
-		{
-			"USE1-Gemma-3-4B-IT-input-tokens-flex",
-			"Gemma-3-4B-IT", "on_demand_flex",
-		},
-		{
-			"USE1-MistralSmall-input-tokens-batch",
-			"MistralSmall", "on_demand_batch",
-		},
-		{
-			"USE1-Nova2.0Lite-input-tokens-cross-region-global-batch",
-			"Nova2.0Lite", "cross_region",
-		},
-		{
-			"USE1-Nova2.0Pro-text-input-tokens-priority-cross-region-global",
-			"Nova2.0Pro", "cross_region",
-		},
-		{
-			"USE1-GPT-OSS-Safeguard-120B-output-tokens-batch",
-			"GPT-OSS-Safeguard-120B", "on_demand_batch",
-		},
-		{
-			"USE1-Llama3-2-1B-output-tokens",
-			"Llama3-2-1B", "on_demand",
-		},
-		{
-			"USE1-cohere.rerank-english-v3-search-units",
-			"cohere.rerank-english-v3", "on_demand",
-		},
+		{"USE1-Claude3Sonnet-input-tokens", "Claude3Sonnet", "in", "standard"},
+		{"USE1-Claude2.0-input-tokens", "Claude2.0", "in", "standard"},
+		{"USE1-Llama4-Maverick-17B-input-tokens-batch", "Llama4-Maverick-17B", "in", "batch"},
+		{"USE1-GPT-OSS-Safeguard-20B-input-tokens-priority", "GPT-OSS-Safeguard-20B", "in", "priority"},
+		{"USE1-Gemma-3-4B-IT-input-tokens-flex", "Gemma-3-4B-IT", "in", "flex"},
+		{"USE1-MistralSmall-input-tokens-batch", "MistralSmall", "in", "batch"},
+		{"USE1-Nova2.0Lite-input-tokens-cross-region-global-batch", "Nova2.0Lite", "cross", "batch"},
+		{"USE1-Nova2.0Pro-text-input-tokens-priority-cross-region-global", "Nova2.0Pro", "cross", "priority"},
+		{"USE1-GPT-OSS-Safeguard-120B-output-tokens-batch", "GPT-OSS-Safeguard-120B", "in", "batch"},
+		{"USE1-Llama3-2-1B-output-tokens", "Llama3-2-1B", "in", "standard"},
+		{"USE1-cohere.rerank-english-v3-search-units", "cohere.rerank-english-v3", "in", "standard"},
 		// Unrecognized format returns empty model ID.
-		{
-			"USE1-Guardrail-AutomatedReasoningPolicyUnitsConsumed",
-			"", "on_demand",
-		},
+		{"USE1-Guardrail-AutomatedReasoningPolicyUnitsConsumed", "", "in", "standard"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.usagetype, func(t *testing.T) {
-			modelID, priceTier := parseBedrockModelID(tt.usagetype)
+			modelID, suffix := parseBedrockModelID(tt.usagetype)
 			assert.Equal(t, tt.wantModelID, modelID)
-			assert.Equal(t, tt.wantPriceTier, priceTier)
+			regionTier, quotaTier := standardTier(suffix)
+			assert.Equal(t, tt.wantRegionTier, regionTier)
+			assert.Equal(t, tt.wantQuotaTier, quotaTier)
 		})
 	}
 }
@@ -543,9 +519,11 @@ func collectMetricResults(t *testing.T, collector *Collector) ([]*utils.MetricRe
 	return results, err
 }
 
-func metricByName(results []*utils.MetricResult, fqName string) *utils.MetricResult {
+// tokenMetricByType returns the token-cost metric for a given token_type (input, output,
+// cache_read, cache_write). Input and output now share one metric name, distinguished by label.
+func tokenMetricByType(results []*utils.MetricResult, tokenType string) *utils.MetricResult {
 	for _, result := range results {
-		if result.FqName == fqName {
+		if result.FqName == "cloudcost_aws_bedrock_usd_per_1k_tokens" && result.Labels["token_type"] == tokenType {
 			return result
 		}
 	}
@@ -595,13 +573,13 @@ func TestCollect_MergesLegacyClaudeAcrossSources(t *testing.T) {
 
 	var input, output *utils.MetricResult
 	for _, r := range results {
-		if r.Labels["model_id"] != "claude-3-sonnet" {
+		if r.FqName != "cloudcost_aws_bedrock_usd_per_1k_tokens" || r.Labels["model_id"] != "claude-3-sonnet" {
 			continue
 		}
-		switch r.FqName {
-		case "cloudcost_aws_bedrock_input_usd_per_1k_tokens":
+		switch r.Labels["token_type"] {
+		case "input":
 			input = r
-		case "cloudcost_aws_bedrock_output_usd_per_1k_tokens":
+		case "output":
 			output = r
 		}
 	}
@@ -761,66 +739,68 @@ func TestClassifyMarketplaceUsageType(t *testing.T) {
 	}
 }
 
-func TestExtractMarketplacePriceTier(t *testing.T) {
+func TestMarketplaceTier(t *testing.T) {
+	// region_tier and quota_tier are orthogonal and captured independently; the cache token_type
+	// is handled separately by marketplaceCacheOp, so it does not appear here.
 	tests := []struct {
-		usagetype string
-		cacheOp   string
-		want      string
+		usagetype      string
+		wantRegionTier string
+		wantQuotaTier  string
 	}{
-		{"USE1-MP:USE1_InputTokenCount-Units", "", "on_demand"},
-		{"USE1-MP:USE1_InputTokenCount_Global-Units", "", "cross_region"},
-		{"USE1-MP:USE1_InputTokenCount_Batch-Units", "", "on_demand_batch"},
-		{"USE1-MP:USE1_InputTokenCount_Global_Batch-Units", "", "cross_region_batch"},
-		{"USE1-MP:USE1_OutputTokenCount_Global-Units", "", "cross_region"},
-		{"USE1-MP:USE1_search_units-Units", "", "on_demand"},
-		// Latency-optimized is its own quota tier (does not collide with on_demand).
-		{"USE1-MP:USE1_InputTokenCount_LatencyOptimized-Units", "", "on_demand_latency_optimized"},
-		// Cache operations fold into the tier and stack with cross-region.
-		{"USE1-MP:USE1_CacheReadInputTokenCount-Units", "cache_read", "cache_read"},
-		{"USE1-MP:USE1_CacheReadInputTokenCount_Global-Units", "cache_read", "cross_region_cache_read"},
-		{"USE1-MP:USE1_CacheWriteInputTokenCount-Units", "cache_write_5m", "cache_write_5m"},
-		{"USE1-MP:USE1_CacheWrite1hInputTokenCount-Units", "cache_write_1h", "cache_write_1h"},
-		{"USE1-MP:USE1_CacheWrite1hInputTokenCount_Global-Units", "cache_write_1h", "cross_region_cache_write_1h"},
+		{"USE1-MP:USE1_InputTokenCount-Units", "in", "standard"},
+		{"USE1-MP:USE1_InputTokenCount_Global-Units", "cross", "standard"},
+		{"USE1-MP:USE1_InputTokenCount_Batch-Units", "in", "batch"},
+		{"USE1-MP:USE1_InputTokenCount_Global_Batch-Units", "cross", "batch"},
+		{"USE1-MP:USE1_OutputTokenCount_Global-Units", "cross", "standard"},
+		{"USE1-MP:USE1_search_units-Units", "in", "standard"},
+		{"USE1-MP:USE1_InputTokenCount_LatencyOptimized-Units", "in", "latency_optimized"},
+		// Cross-region is captured independently of the cache operation.
+		{"USE1-MP:USE1_CacheReadInputTokenCount_Global-Units", "cross", "standard"},
+		{"USE1-MP:USE1_CacheWrite1hInputTokenCount_Global-Units", "cross", "standard"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.usagetype, func(t *testing.T) {
-			assert.Equal(t, tt.want, extractMarketplacePriceTier(tt.usagetype, tt.cacheOp))
+			regionTier, quotaTier := marketplaceTier(tt.usagetype)
+			assert.Equal(t, tt.wantRegionTier, regionTier)
+			assert.Equal(t, tt.wantQuotaTier, quotaTier)
 		})
 	}
 }
 
 func TestMarketplaceCacheOp(t *testing.T) {
 	tests := []struct {
-		usagetype string
-		wantOp    string
-		wantSkip  bool
+		usagetype     string
+		wantTokenType string
+		wantCacheTTL  string
+		wantSkip      bool
 	}{
-		{"USE1-MP:USE1_CacheReadInputTokenCount-Units", "cache_read", false},
-		{"USE1-MP:USE1_CacheReadInputTokenCount_Global-Units", "cache_read", false},
-		{"USE1-MP:USE1_CacheWriteInputTokenCount-Units", "cache_write_5m", false},
-		{"USE1-MP:USE1_CacheWrite1hInputTokenCount-Units", "cache_write_1h", false},
-		{"USE1-MP:USE1_cache_write_tokens_1h_standard-Units", "cache_write_1h", false},
-		{"USE1-MP:USE1_InputTokenCount-Units", "", false}, // not cache, classified normally
-		{"USE1-MP:USE1_CacheStorage-Units", "", true},     // storage: skipped
+		{"USE1-MP:USE1_CacheReadInputTokenCount-Units", "cache_read", "", false},
+		{"USE1-MP:USE1_CacheReadInputTokenCount_Global-Units", "cache_read", "", false},
+		{"USE1-MP:USE1_CacheWriteInputTokenCount-Units", "cache_write", "5m", false},
+		{"USE1-MP:USE1_CacheWrite1hInputTokenCount-Units", "cache_write", "1h", false},
+		{"USE1-MP:USE1_cache_write_tokens_1h_standard-Units", "cache_write", "1h", false},
+		{"USE1-MP:USE1_InputTokenCount-Units", "", "", false}, // not cache, classified normally
+		{"USE1-MP:USE1_CacheStorage-Units", "", "", true},     // storage: skipped
 		// A cache shape that is neither read nor write must be skipped, not labeled a 5m write.
-		{"USE1-MP:USE1_CacheValidationCount-Units", "", true},
+		{"USE1-MP:USE1_CacheValidationCount-Units", "", "", true},
 		// A write with an unrecognized TTL must be skipped, not defaulted to 5m.
-		{"USE1-MP:USE1_CacheWrite30mInputTokenCount-Units", "", true},
+		{"USE1-MP:USE1_CacheWrite30mInputTokenCount-Units", "", "", true},
 		// An explicit 5m write is recognized as 5m.
-		{"USE1-MP:USE1_CacheWrite5mInputTokenCount-Units", "cache_write_5m", false},
+		{"USE1-MP:USE1_CacheWrite5mInputTokenCount-Units", "cache_write", "5m", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.usagetype, func(t *testing.T) {
-			op, skip := marketplaceCacheOp(tt.usagetype)
-			assert.Equal(t, tt.wantOp, op)
+			tokenType, cacheTTL, skip := marketplaceCacheOp(tt.usagetype)
+			assert.Equal(t, tt.wantTokenType, tokenType)
+			assert.Equal(t, tt.wantCacheTTL, cacheTTL)
 			assert.Equal(t, tt.wantSkip, skip)
 		})
 	}
 }
 
 func TestCollect_EmitsMarketplaceCacheMetrics(t *testing.T) {
-	// Cache read/write are emitted on the input metric with cache_* price_tier values; storage
-	// (per token-hour) is skipped.
+	// Cache read/write are emitted on the token metric with token_type=cache_read/cache_write and
+	// a cache_ttl label; storage (per token-hour) is skipped.
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -851,15 +831,18 @@ func TestCollect_EmitsMarketplaceCacheMetrics(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 3, "read + write_5m + write_1h emitted; storage skipped")
 
-	byTier := map[string]float64{}
+	// Key each cache price by (region_tier, token_type, cache_ttl) so the orthogonal labels are
+	// asserted directly instead of a composed string.
+	byKey := map[string]float64{}
 	for _, r := range results {
-		require.Equal(t, "cloudcost_aws_bedrock_input_usd_per_1k_tokens", r.FqName)
+		require.Equal(t, "cloudcost_aws_bedrock_usd_per_1k_tokens", r.FqName)
 		require.Equal(t, "claude-sonnet-4.6", r.Labels["model_id"])
-		byTier[r.Labels["price_tier"]] = r.Value
+		key := r.Labels["region_tier"] + "/" + r.Labels["token_type"] + "/" + r.Labels["cache_ttl"]
+		byKey[key] = r.Value
 	}
-	assert.InDelta(t, 0.0003, byTier["cache_read"], 1e-9)      // 0.3/1M
-	assert.InDelta(t, 0.00375, byTier["cache_write_5m"], 1e-9) // 3.75/1M
-	assert.InDelta(t, 0.006, byTier["cross_region_cache_write_1h"], 1e-9)
+	assert.InDelta(t, 0.0003, byKey["in/cache_read/"], 1e-9)      // 0.3/1M, reads carry no TTL
+	assert.InDelta(t, 0.00375, byKey["in/cache_write/5m"], 1e-9)  // 3.75/1M
+	assert.InDelta(t, 0.006, byKey["cross/cache_write/1h"], 1e-9) // 6.0/1M, cross-region 1h write
 }
 
 func TestCollect_EmitsMarketplaceTokenMetrics(t *testing.T) {
@@ -891,14 +874,15 @@ func TestCollect_EmitsMarketplaceTokenMetrics(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 
-	inputMetric := metricByName(results, "cloudcost_aws_bedrock_input_usd_per_1k_tokens")
+	inputMetric := tokenMetricByType(results, "input")
 	require.NotNil(t, inputMetric)
 	assert.Equal(t, "claude-sonnet-4.6", inputMetric.Labels["model_id"])
 	assert.Equal(t, "anthropic", inputMetric.Labels["family"])
-	assert.Equal(t, "on_demand", inputMetric.Labels["price_tier"])
+	assert.Equal(t, "in", inputMetric.Labels["region_tier"])
+	assert.Equal(t, "standard", inputMetric.Labels["quota_tier"])
 	assert.InDelta(t, 0.003, inputMetric.Value, 1e-9)
 
-	outputMetric := metricByName(results, "cloudcost_aws_bedrock_output_usd_per_1k_tokens")
+	outputMetric := tokenMetricByType(results, "output")
 	require.NotNil(t, outputMetric)
 	assert.InDelta(t, 0.015, outputMetric.Value, 1e-9)
 }
@@ -935,6 +919,8 @@ func TestCollect_EmitsMarketplaceSearchUnitMetrics(t *testing.T) {
 	assert.Equal(t, "cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units", m.FqName)
 	assert.Equal(t, "cohere-rerank-v3.5", m.Labels["model_id"])
 	assert.Equal(t, "cohere", m.Labels["family"])
+	assert.Equal(t, "in", m.Labels["region_tier"])
+	assert.Equal(t, "standard", m.Labels["quota_tier"])
 	assert.InDelta(t, 2.0, m.Value, 1e-9)
 }
 
@@ -997,7 +983,7 @@ func TestNew_DegradesToStandardPricingWhenMarketplaceAPIUnavailable(t *testing.T
 	require.NoError(t, err)
 
 	// Standard pricing still flows through despite the marketplace failure.
-	inputMetric := metricByName(results, "cloudcost_aws_bedrock_input_usd_per_1k_tokens")
+	inputMetric := tokenMetricByType(results, "input")
 	require.NotNil(t, inputMetric)
 	assert.Equal(t, "claude3sonnet", inputMetric.Labels["model_id"])
 }

--- a/pkg/aws/bedrock/bedrock_test.go
+++ b/pkg/aws/bedrock/bedrock_test.go
@@ -433,6 +433,28 @@ func TestParseBedrockModelID(t *testing.T) {
 	}
 }
 
+func TestStripRedundantLatency(t *testing.T) {
+	tests := []struct {
+		modelID   string
+		quotaTier string
+		want      string
+	}{
+		// Stripped only when quota_tier already records latency-optimized.
+		{"nova-pro-latency-optimized", "latency_optimized", "nova-pro"},
+		{"llama-3.1-405b-latency-optimized", "latency_optimized", "llama-3.1-405b"},
+		// Already clean: no-op.
+		{"claude-3.5-haiku", "latency_optimized", "claude-3.5-haiku"},
+		// Not latency-optimized: left untouched even if the name somehow contains the token.
+		{"nova-pro-latency-optimized", "standard", "nova-pro-latency-optimized"},
+		{"nova-pro", "standard", "nova-pro"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.modelID+"/"+tt.quotaTier, func(t *testing.T) {
+			assert.Equal(t, tt.want, stripRedundantLatency(tt.modelID, tt.quotaTier))
+		})
+	}
+}
+
 func TestNormalizeProvider(t *testing.T) {
 	tests := []struct {
 		provider string

--- a/pkg/aws/bedrock/bedrock_test.go
+++ b/pkg/aws/bedrock/bedrock_test.go
@@ -411,6 +411,7 @@ func TestParseBedrockModelID(t *testing.T) {
 		{"USE1-Llama4-Maverick-17B-input-tokens-batch", "Llama4-Maverick-17B", "in", "batch"},
 		{"USE1-GPT-OSS-Safeguard-20B-input-tokens-priority", "GPT-OSS-Safeguard-20B", "in", "priority"},
 		{"USE1-Gemma-3-4B-IT-input-tokens-flex", "Gemma-3-4B-IT", "in", "flex"},
+		{"USE1-Claude3-5Haiku-input-tokens-latency-optimized", "Claude3-5Haiku", "in", "latency_optimized"},
 		{"USE1-MistralSmall-input-tokens-batch", "MistralSmall", "in", "batch"},
 		{"USE1-Nova2.0Lite-input-tokens-cross-region-global-batch", "Nova2.0Lite", "cross", "batch"},
 		{"USE1-Nova2.0Pro-text-input-tokens-priority-cross-region-global", "Nova2.0Pro", "cross", "priority"},

--- a/pkg/utils/consts.go
+++ b/pkg/utils/consts.go
@@ -31,6 +31,9 @@ const (
 	InputTokenCostSuffix = "input_usd_per_1k_tokens"
 	// OutputTokenCostSuffix is the suffix for per-1k-output-token cost metrics.
 	OutputTokenCostSuffix = "output_usd_per_1k_tokens"
+	// TokenCostSuffix is the suffix for per-1k-token cost metrics that carry a token_type label
+	// (input, output, and prompt-cache read/write) instead of encoding direction in the name.
+	TokenCostSuffix = "usd_per_1k_tokens"
 	// CharacterInputCostSuffix is the suffix for per-1k-input-character cost metrics.
 	// Used for models billed per character rather than per token (e.g. translation models).
 	CharacterInputCostSuffix = "input_usd_per_1k_characters"


### PR DESCRIPTION
Replaces the overloaded `price_tier` label and the per-direction metric names on the AWS Bedrock pricing metrics with a separate label per dimension, so downstream joins key on each dimension directly.

## Summary

- Merges `cloudcost_aws_bedrock_input_usd_per_1k_tokens` and `cloudcost_aws_bedrock_output_usd_per_1k_tokens` into one `cloudcost_aws_bedrock_usd_per_1k_tokens`, distinguished by a `token_type` label (`input`, `output`, `cache_read`, `cache_write`).
- Replaces the composed `price_tier` string with a label per dimension: `region_tier` (`in`/`cross`) and `quota_tier` (`standard`/`batch`/`flex`/`priority`/`latency_optimized`) on both the token and search metrics, plus `cache_ttl` (`""`/`5m`/`1h`) on the token metric (set for `cache_write`).
- `cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units` keeps its name and gains `region_tier`/`quota_tier` (no `token_type`/`cache_ttl`, a different unit).
- The pricingstore composite key is widened to carry the decomposed fields; `Collect` expands them back into labels.

## Why

The old `price_tier` packed three independent dimensions into one string (`composeTier(crossRegion, op, quota)`, e.g. `cross_region_cache_read`, `cache_write_5m`, `on_demand_batch`), and token direction lived in the metric name. Any consumer wanting to filter or join by tier or token type had to parse the composed string or union the two metric names. The gen-AI Bedrock cost recording rules in `grafana/deployment_tools` are the first such consumer: their price-side join is an 8-branch `or` with per-branch `label_replace`. With a label per dimension that collapses to a single selector keyed on `(model_id, region_tier, token_type)`.

Decomposing also fixes a latent bug in the standard (`AmazonBedrock`) source: `extractPriceTier` returned `cross_region` early and dropped the quota qualifier, so cross-region prices that differ only by quota (`batch`/`flex`/`priority`) collided into one series and overwrote each other. Verified against live pricing (one account, `amazon|anthropic`): in-region series are identical (1992 to 1992, a 1:1 re-encoding), and cross-region recovers the dropped prices (1782 to 2196, +414), with `flex`/`priority` cross-region buckets that did not exist before.

## After merge

This is a precondition for the gen-AI Bedrock cost recording rules in `grafana/deployment_tools` (grafana/deployment_tools#621203, still in draft). Those rules will switch their price-side join to the new labels once a release carrying this change is scraped; nothing depends on this metric in production yet.

## Metric change

Bedrock is an experimental collector (enabled via `-aws.experimental.services`), so its metrics are outside the backward-compatibility contract and may change without a major release. This renames the token price metrics and replaces `price_tier`: `cloudcost_aws_bedrock_input_usd_per_1k_tokens` and `cloudcost_aws_bedrock_output_usd_per_1k_tokens` become `cloudcost_aws_bedrock_usd_per_1k_tokens{token_type=...}`, and `price_tier` is replaced by `token_type`/`region_tier`/`quota_tier`/`cache_ttl`. Anyone scraping these should move to the new labels. `docs/metrics/aws/bedrock.md` is updated. The Vertex collector is unaffected (it keeps the `input`/`output` token-cost suffixes).
