### PR TITLE
ci(helm): sign commits in update-helm-chart action

### DIFF
--- a/.github/actions/update-helm-chart/action.yml
+++ b/.github/actions/update-helm-chart/action.yml
@@ -45,6 +45,7 @@ runs:
       uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
       with:
         token: ${{ steps.get-github-app-token.outputs.token }}
+        sign-commits: true
         add-paths: charts/cloudcost-exporter/Chart.yaml
         branch: helm-chart/update-to-${{ steps.update-versions.outputs.app_version }}
         delete-branch: true


### PR DESCRIPTION
## Summary

- The `update-helm-chart` release job was failing with `GH013: Commits must have verified signatures` when pushing the helm chart bump branch.
- The `peter-evans/create-pull-request` action was creating unsigned commits, which violates the repo's branch protection rule.
- Adding `sign-commits: true` tells the action to sign the commit using the GitHub App token already provided.

## Test plan

- [ ] Merge this PR, then trigger a release and confirm the `update-helm-chart` job passes and opens the helm chart bump PR without the GH013 error.