### PR TITLE
chore: update Helm chart to appVersion 1.7.0

### DIFF
--- a/charts/cloudcost-exporter/Chart.yaml
+++ b/charts/cloudcost-exporter/Chart.yaml
@@ -4,8 +4,8 @@ description: Cloud Cost Exporter exports cloud provider agnostic cost metrics to
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.7
+version: 1.1.8
 # This is the version of cloudcost-exporter to be deployed, which should be incremented
 # with each release.
-appVersion: "1.5.0"
+appVersion: "1.7.0"
 home: https://github.com/grafana/cloudcost-exporter


### PR DESCRIPTION
Automated update triggered by release `v1.7.0`.

- `appVersion`: updated to `1.7.0`
- `version`: bumped to `1.1.8`

Once merged, the [Release Helm Chart](https://github.com/grafana/cloudcost-exporter/actions/workflows/release-helm-chart.yaml) workflow will publish the updated Helm chart.