### PR TITLE
fix: add trailing newline to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,4 @@ We welcome contributions. See the [contributing guide](docs/contribute/README.md
 
 Cloud Cost Exporter is licensed under the [Apache License 2.0](LICENSE).
 
+


### PR DESCRIPTION
Trivial fix to test the `sign-commits` change in the `update-helm-chart` action (#1061).