### PR TITLE
refactor(aws/bedrock): rename model_id/token_type labels to gen_ai_request_model/gen_ai_token_type

### DIFF
--- a/docs/metrics/aws/bedrock.md
+++ b/docs/metrics/aws/bedrock.md
@@ -2,8 +2,8 @@
 
 | Metric name                                              | Metric type | Description                                                                      | Labels                                                                                                                                                              |
 |----------------------------------------------------------|-------------|---------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| cloudcost_aws_bedrock_usd_per_1k_tokens                  | Gauge       | Token price for an AWS Bedrock model. Cost represented in USD/1000 tokens. `token_type` distinguishes input, output, and prompt-cache read/write | `account_id`=&lt;AWS account ID&gt; <br/> `region`=&lt;AWS region&gt; <br/> `model_id`=&lt;model slug&gt; <br/> `family`=&lt;model provider&gt; <br/> `token_type`=&lt;input\|output\|cache_read\|cache_write&gt; <br/> `region_tier`=&lt;in\|cross&gt; <br/> `quota_tier`=&lt;see Labels&gt; <br/> `cache_ttl`=&lt;""\|5m\|1h&gt; |
-| cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units | Gauge      | Search unit price for an AWS Bedrock model (e.g. Cohere Rerank). Cost represented in USD/1000 search units | `account_id`=&lt;AWS account ID&gt; <br/> `region`=&lt;AWS region&gt; <br/> `model_id`=&lt;model slug&gt; <br/> `family`=&lt;model provider&gt; <br/> `region_tier`=&lt;in\|cross&gt; <br/> `quota_tier`=&lt;see Labels&gt; |
+| cloudcost_aws_bedrock_usd_per_1k_tokens                  | Gauge       | Token price for an AWS Bedrock model. Cost represented in USD/1000 tokens. `gen_ai_token_type` distinguishes input, output, and prompt-cache read/write | `account_id`=&lt;AWS account ID&gt; <br/> `region`=&lt;AWS region&gt; <br/> `gen_ai_request_model`=&lt;model slug&gt; <br/> `family`=&lt;model provider&gt; <br/> `gen_ai_token_type`=&lt;input\|output\|cache_read\|cache_write&gt; <br/> `region_tier`=&lt;in\|cross&gt; <br/> `quota_tier`=&lt;see Labels&gt; <br/> `cache_ttl`=&lt;""\|5m\|1h&gt; |
+| cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units | Gauge      | Search unit price for an AWS Bedrock model (e.g. Cohere Rerank). Cost represented in USD/1000 search units | `account_id`=&lt;AWS account ID&gt; <br/> `region`=&lt;AWS region&gt; <br/> `gen_ai_request_model`=&lt;model slug&gt; <br/> `family`=&lt;model provider&gt; <br/> `region_tier`=&lt;in\|cross&gt; <br/> `quota_tier`=&lt;see Labels&gt; |
 
 ## Overview
 
@@ -37,31 +37,31 @@ Restrict which model families are emitted with `--aws.bedrock.families` (a regex
 
 - **account_id**: The AWS account ID (12-digit), resolved via STS GetCallerIdentity
 - **region**: The AWS region for which the price applies
-- **model_id**: Normalized model identifier, lowercase with spaces replaced by hyphens, uniform across both pricing sources (e.g. `claude-3-sonnet`, `claude-sonnet-4.6`, `nova-pro`, `llama-3.1-405b`, `cohere-rerank-v3.5`).
+- **gen_ai_request_model**: Normalized model identifier, lowercase with spaces replaced by hyphens, uniform across both pricing sources (e.g. `claude-3-sonnet`, `claude-sonnet-4.6`, `nova-pro`, `llama-3.1-405b`, `cohere-rerank-v3.5`).
   - `AmazonBedrock` derives it from the human-readable `model` attribute, falling back to the normalized `usagetype` slug for the few SKUs (some Titan, Rerank) that lack `model`.
   - `AmazonBedrockFoundationModels` derives it from the `servicename`.
   - Models that AWS prices per modality under one name carry the modality (e.g. `nova-sonic-text`, `nova-sonic-speech`).
 
-  `model_id` is a normalized label derived from pricing metadata, not a canonical Bedrock model ID or ARN. Because both sources normalize to the same `model_id`, a model priced under both (e.g. the legacy Claude generation) merges into one set of series: identical prices dedupe, and a price one source lacks (the standard source prices some legacy Claude models for input only) is filled in by the other.
+  `gen_ai_request_model` is a normalized label derived from pricing metadata, not a canonical Bedrock model ID or ARN. Because both sources normalize to the same `gen_ai_request_model`, a model priced under both (e.g. the legacy Claude generation) merges into one set of series: identical prices dedupe, and a price one source lacks (the standard source prices some legacy Claude models for input only) is filled in by the other.
 - **family**: Model provider, normalized to lowercase (spaces become underscores) from the `AmazonBedrock` `provider` attribute, or derived from the `AmazonBedrockFoundationModels` `servicename`. The set tracks whatever AWS publishes, so it is open-ended; examples include `anthropic`, `amazon`, `cohere`, `meta`, `ai21`, `mistral`, `deepseek`, `google`, `qwen`, `nvidia`, `openai`, `writer`, and `twelvelabs` (not exhaustive, and the list grows as AWS adds providers). Amazon-developed models with no provider attribute (Nova, Titan) use `amazon`. A marketplace `servicename` with no recognized provider falls back to `unknown`. Filter with `--aws.bedrock.families`.
 The inference tier is split into orthogonal labels so consumers can filter or join on each
 dimension independently, rather than parsing a composed string:
 
-- **token_type** (token metric only): `input`, `output`, or a prompt-cache operation `cache_read` or `cache_write`. Prompt caching is emitted only from the marketplace source; cache storage (priced per token-hour) and caching for Amazon-native models (Nova/Titan) in the `AmazonBedrock` source are not emitted.
+- **gen_ai_token_type** (token metric only): `input`, `output`, or a prompt-cache operation `cache_read` or `cache_write`. Prompt caching is emitted only from the marketplace source; cache storage (priced per token-hour) and caching for Amazon-native models (Nova/Titan) in the `AmazonBedrock` source are not emitted.
 - **region_tier**: `in` (in-region) or `cross` (cross-region inference).
 - **quota_tier**: `standard` (on-demand), `batch`, `flex`, `priority`, or `latency_optimized`.
 - **cache_ttl** (token metric only): the prompt-cache write TTL, `5m` or `1h`. Empty for non-cache token types and for cache reads (a single rate, no TTL).
 
-Search-unit metrics carry `region_tier` and `quota_tier` only (no `token_type`/`cache_ttl`).
+Search-unit metrics carry `region_tier` and `quota_tier` only (no `gen_ai_token_type`/`cache_ttl`).
 
 ## Pricing Sources
 
-The collector fetches `AmazonBedrock` and `AmazonBedrockFoundationModels` per region and merges them into one metric set. Each SKU's token type, family, model, region tier, and quota tier are parsed from its `usagetype` and `servicename`; image, video, audio, cache-storage, provisioned-throughput, and guardrail SKUs are skipped. Prompt-cache read/write SKUs from the marketplace source are emitted on the token metric with `token_type=cache_read`/`cache_write`.
+The collector fetches `AmazonBedrock` and `AmazonBedrockFoundationModels` per region and merges them into one metric set. Each SKU's token type, family, model, region tier, and quota tier are parsed from its `usagetype` and `servicename`; image, video, audio, cache-storage, provisioned-throughput, and guardrail SKUs are skipped. Prompt-cache read/write SKUs from the marketplace source are emitted on the token metric with `gen_ai_token_type=cache_read`/`cache_write`.
 
 - `AmazonBedrock` publishes token prices per 1000 tokens directly.
 - `AmazonBedrockFoundationModels` publishes token prices per 1,000,000 tokens (converted to per-1000) and search-unit prices per single unit (converted to per-1000).
 
-When both service codes price the same model (the legacy Claude generation), they share a `model_id`, so entries with the same `(token_type, region_tier, quota_tier, cache_ttl)` dedupe and any price only one source carries is retained. Overlapping prices are identical across the two sources.
+When both service codes price the same model (the legacy Claude generation), they share a `gen_ai_request_model`, so entries with the same `(gen_ai_token_type, region_tier, quota_tier, cache_ttl)` dedupe and any price only one source carries is retained. Overlapping prices are identical across the two sources.
 
 `AmazonBedrockFoundationModels` pricing is best-effort: if that service code is unavailable, the collector logs a warning and continues to emit `AmazonBedrock` pricing rather than failing.
 
@@ -69,7 +69,7 @@ When both service codes price the same model (the legacy Claude generation), the
 
 - Pricing data is fetched from the AWS Pricing API (`us-east-1` endpoint) and refreshed every 24 hours
 - Image, video, audio, cache-storage, provisioned-throughput, and guardrail SKUs are skipped; token (including prompt-cache read/write), and search-unit SKUs are emitted
-- `model_id` is a normalized pricing identifier, not the canonical Bedrock model ARN
+- `gen_ai_request_model` is a normalized pricing identifier, not the canonical Bedrock model ARN
 
 ## IAM Permissions
 

--- a/pkg/aws/bedrock/bedrock.go
+++ b/pkg/aws/bedrock/bedrock.go
@@ -24,14 +24,14 @@ const (
 	subsystem   = "aws_bedrock"
 	serviceName = "bedrock"
 
-	// token_type label values. Prompt-cache read/write are input-side operations and so are
+	// gen_ai_token_type label values. Prompt-cache read/write are input-side operations and so are
 	// emitted on the token metric alongside input/output.
 	tokenTypeInput      = "input"
 	tokenTypeOutput     = "output"
 	tokenTypeCacheRead  = "cache_read"
 	tokenTypeCacheWrite = "cache_write"
 
-	// directionSearch routes a SKU to the search-unit metric. It is not a token_type value.
+	// directionSearch routes a SKU to the search-unit metric. It is not a gen_ai_token_type value.
 	directionSearch = "search"
 
 	// region_tier label values: in-region vs cross-region inference.
@@ -69,20 +69,20 @@ const (
 var (
 	// TokenCostDesc carries every per-token price (input, output, and prompt-cache read/write),
 	// distinguished by orthogonal labels rather than separate metric names or a composed price
-	// tier, so downstream joins key on (model_id, token_type, region_tier) directly.
+	// tier, so downstream joins key on (gen_ai_request_model, gen_ai_token_type, region_tier) directly.
 	TokenCostDesc = utils.GenerateDesc(
 		cloudcostexporter.MetricPrefix,
 		subsystem,
 		utils.TokenCostSuffix,
-		"The cost of AWS Bedrock tokens in USD per 1000 tokens, by token_type",
-		[]string{"account_id", "region", "model_id", "family", "token_type", "region_tier", "quota_tier", "cache_ttl"},
+		"The cost of AWS Bedrock tokens in USD per 1000 tokens, by gen_ai_token_type",
+		[]string{"account_id", "region", "gen_ai_request_model", "family", "gen_ai_token_type", "region_tier", "quota_tier", "cache_ttl"},
 	)
 	SearchUnitCostDesc = utils.GenerateDesc(
 		cloudcostexporter.MetricPrefix,
 		subsystem,
 		utils.SearchUnitCostSuffix,
 		"The cost of AWS Bedrock search units in USD per 1000 search units (e.g. Cohere Rerank)",
-		[]string{"account_id", "region", "model_id", "family", "region_tier", "quota_tier"},
+		[]string{"account_id", "region", "gen_ai_request_model", "family", "region_tier", "quota_tier"},
 	)
 )
 

--- a/pkg/aws/bedrock/bedrock_test.go
+++ b/pkg/aws/bedrock/bedrock_test.go
@@ -94,7 +94,7 @@ func TestCollect_EmitsInputAndOutputTokenMetrics(t *testing.T) {
 	// These fixtures omit the `model` attribute, so model_id is the normalized usagetype slug
 	// (fallback path). Real Claude SKUs carry `model`, yielding claude-3-sonnet; see
 	// TestCollect_StandardModelIDUsesModelAttribute.
-	assert.Equal(t, "claude3sonnet", inputMetric.Labels["model_id"])
+	assert.Equal(t, "claude3sonnet", inputMetric.Labels["gen_ai_request_model"])
 	assert.Equal(t, "anthropic", inputMetric.Labels["family"])
 	assert.Equal(t, "in", inputMetric.Labels["region_tier"])
 	assert.Equal(t, "standard", inputMetric.Labels["quota_tier"])
@@ -105,7 +105,7 @@ func TestCollect_EmitsInputAndOutputTokenMetrics(t *testing.T) {
 	outputMetric := tokenMetricByType(results, "output")
 	require.NotNil(t, outputMetric)
 	assert.Equal(t, "us-east-1", outputMetric.Labels["region"])
-	assert.Equal(t, "claude3sonnet", outputMetric.Labels["model_id"])
+	assert.Equal(t, "claude3sonnet", outputMetric.Labels["gen_ai_request_model"])
 	assert.Equal(t, "anthropic", outputMetric.Labels["family"])
 	assert.Equal(t, "in", outputMetric.Labels["region_tier"])
 	assert.Equal(t, "standard", outputMetric.Labels["quota_tier"])
@@ -173,9 +173,9 @@ func TestCollect_LabelsCrossRegionPriceTier(t *testing.T) {
 	m := results[0]
 	assert.Equal(t, "cross", m.Labels["region_tier"])
 	assert.Equal(t, "standard", m.Labels["quota_tier"])
-	assert.Equal(t, "input", m.Labels["token_type"])
+	assert.Equal(t, "input", m.Labels["gen_ai_token_type"])
 	assert.Equal(t, "amazon", m.Labels["family"])
-	assert.Equal(t, "novapremier", m.Labels["model_id"])
+	assert.Equal(t, "novapremier", m.Labels["gen_ai_request_model"])
 }
 
 func TestCollect_LabelsBatchPriceTier(t *testing.T) {
@@ -208,9 +208,9 @@ func TestCollect_LabelsBatchPriceTier(t *testing.T) {
 	m := results[0]
 	assert.Equal(t, "in", m.Labels["region_tier"])
 	assert.Equal(t, "batch", m.Labels["quota_tier"])
-	assert.Equal(t, "input", m.Labels["token_type"])
+	assert.Equal(t, "input", m.Labels["gen_ai_token_type"])
 	assert.Equal(t, "anthropic", m.Labels["family"])
-	assert.Equal(t, "claude3sonnet", m.Labels["model_id"])
+	assert.Equal(t, "claude3sonnet", m.Labels["gen_ai_request_model"])
 }
 
 func TestCollect_FamilyFilterRegexFiltersOtherFamilies(t *testing.T) {
@@ -245,7 +245,7 @@ func TestCollect_FamilyFilterRegexFiltersOtherFamilies(t *testing.T) {
 
 	m := results[0]
 	assert.Equal(t, "anthropic", m.Labels["family"])
-	assert.Equal(t, "claude3sonnet", m.Labels["model_id"])
+	assert.Equal(t, "claude3sonnet", m.Labels["gen_ai_request_model"])
 }
 
 func TestCollect_FamilyFilterDefaultEmitsAllFamilies(t *testing.T) {
@@ -546,7 +546,7 @@ func collectMetricResults(t *testing.T, collector *Collector) ([]*utils.MetricRe
 // cache_read, cache_write). Input and output now share one metric name, distinguished by label.
 func tokenMetricByType(results []*utils.MetricResult, tokenType string) *utils.MetricResult {
 	for _, result := range results {
-		if result.FqName == "cloudcost_aws_bedrock_usd_per_1k_tokens" && result.Labels["token_type"] == tokenType {
+		if result.FqName == "cloudcost_aws_bedrock_usd_per_1k_tokens" && result.Labels["gen_ai_token_type"] == tokenType {
 			return result
 		}
 	}
@@ -596,10 +596,10 @@ func TestCollect_MergesLegacyClaudeAcrossSources(t *testing.T) {
 
 	var input, output *utils.MetricResult
 	for _, r := range results {
-		if r.FqName != "cloudcost_aws_bedrock_usd_per_1k_tokens" || r.Labels["model_id"] != "claude-3-sonnet" {
+		if r.FqName != "cloudcost_aws_bedrock_usd_per_1k_tokens" || r.Labels["gen_ai_request_model"] != "claude-3-sonnet" {
 			continue
 		}
-		switch r.Labels["token_type"] {
+		switch r.Labels["gen_ai_token_type"] {
 		case "input":
 			input = r
 		case "output":
@@ -667,7 +667,7 @@ func TestCollect_StandardModelIDUsesModelAttribute(t *testing.T) {
 
 	ids := map[string]bool{}
 	for _, r := range results {
-		ids[r.Labels["model_id"]] = true
+		ids[r.Labels["gen_ai_request_model"]] = true
 	}
 	assert.True(t, ids["claude-3-sonnet"], "expected normalized claude-3-sonnet, got %v", ids)
 	assert.True(t, ids["llama-3.1-405b"], "expected normalized llama-3.1-405b, got %v", ids)
@@ -705,7 +705,7 @@ func TestCollect_StandardModelIDDisambiguatesNovaSonicModality(t *testing.T) {
 
 	byID := map[string]float64{}
 	for _, r := range results {
-		byID[r.Labels["model_id"]] = r.Value
+		byID[r.Labels["gen_ai_request_model"]] = r.Value
 	}
 	assert.InDelta(t, 0.00006, byID["nova-sonic-text"], 1e-9)
 	assert.InDelta(t, 0.00340, byID["nova-sonic-speech"], 1e-9)
@@ -859,8 +859,8 @@ func TestCollect_EmitsMarketplaceCacheMetrics(t *testing.T) {
 	byKey := map[string]float64{}
 	for _, r := range results {
 		require.Equal(t, "cloudcost_aws_bedrock_usd_per_1k_tokens", r.FqName)
-		require.Equal(t, "claude-sonnet-4.6", r.Labels["model_id"])
-		key := r.Labels["region_tier"] + "/" + r.Labels["token_type"] + "/" + r.Labels["cache_ttl"]
+		require.Equal(t, "claude-sonnet-4.6", r.Labels["gen_ai_request_model"])
+		key := r.Labels["region_tier"] + "/" + r.Labels["gen_ai_token_type"] + "/" + r.Labels["cache_ttl"]
 		byKey[key] = r.Value
 	}
 	assert.InDelta(t, 0.0003, byKey["in/cache_read/"], 1e-9)      // 0.3/1M, reads carry no TTL
@@ -899,7 +899,7 @@ func TestCollect_EmitsMarketplaceTokenMetrics(t *testing.T) {
 
 	inputMetric := tokenMetricByType(results, "input")
 	require.NotNil(t, inputMetric)
-	assert.Equal(t, "claude-sonnet-4.6", inputMetric.Labels["model_id"])
+	assert.Equal(t, "claude-sonnet-4.6", inputMetric.Labels["gen_ai_request_model"])
 	assert.Equal(t, "anthropic", inputMetric.Labels["family"])
 	assert.Equal(t, "in", inputMetric.Labels["region_tier"])
 	assert.Equal(t, "standard", inputMetric.Labels["quota_tier"])
@@ -940,7 +940,7 @@ func TestCollect_EmitsMarketplaceSearchUnitMetrics(t *testing.T) {
 
 	m := results[0]
 	assert.Equal(t, "cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units", m.FqName)
-	assert.Equal(t, "cohere-rerank-v3.5", m.Labels["model_id"])
+	assert.Equal(t, "cohere-rerank-v3.5", m.Labels["gen_ai_request_model"])
 	assert.Equal(t, "cohere", m.Labels["family"])
 	assert.Equal(t, "in", m.Labels["region_tier"])
 	assert.Equal(t, "standard", m.Labels["quota_tier"])
@@ -1008,5 +1008,5 @@ func TestNew_DegradesToStandardPricingWhenMarketplaceAPIUnavailable(t *testing.T
 	// Standard pricing still flows through despite the marketplace failure.
 	inputMetric := tokenMetricByType(results, "input")
 	require.NotNil(t, inputMetric)
-	assert.Equal(t, "claude3sonnet", inputMetric.Labels["model_id"])
+	assert.Equal(t, "claude3sonnet", inputMetric.Labels["gen_ai_request_model"])
 }


### PR DESCRIPTION
Part of https://github.com/grafana/deployment_tools/issues/626989

Renames two labels on `cloudcost_aws_bedrock_usd_per_1k_tokens` and
`cloudcost_aws_bedrock_search_unit_usd_per_1k_search_units` to align with
the `gen_ai` semantic convention used by Sigil:

- `model_id` -> `gen_ai_request_model`
- `token_type` -> `gen_ai_token_type`

## Summary

`TokenCostDesc` and `SearchUnitCostDesc` in `pkg/aws/bedrock/bedrock.go` now
declare `gen_ai_request_model` and `gen_ai_token_type` as label names. No
logic changes; the internal `pricePoint` struct fields (`modelID`, `tokenType`)
are unchanged. All tests updated and passing.

## Why

Simplifies the downstream recording rules that join
`cloudcost_aws_bedrock_usd_per_1k_tokens` against Sigil's
`gen_ai_client_token_usage_sum`. Both sides of the join now use the same label
names natively, removing a bridging rename step.