### PR TITLE
feat(vertex): align with the Bedrock collector and price Claude on Vertex

### DIFF
--- a/cmd/exporter/config/config.go
+++ b/cmd/exporter/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 			Services                 StringSliceFlag
 			ExperimentalServices     StringSliceFlag
 			GKEZoneConcurrency       int
+			VertexFamilyFilter       string
 		}
 		Azure struct {
 			Services             StringSliceFlag

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -87,6 +87,7 @@ func providerFlags(fs *flag.FlagSet, cfg *config.Config) {
 	fs.Var(&cfg.Providers.Azure.ExperimentalServices, "azure.experimental.services", "Experimental Azure service(s); their metrics are not covered by the backward-compatibility contract and may change. Run with -list-services to see available values.")
 	fs.Var(&cfg.Providers.GCP.Services, "gcp.services", "GCP service(s). Run with -list-services to see available values.")
 	fs.Var(&cfg.Providers.GCP.ExperimentalServices, "gcp.experimental.services", "Experimental GCP service(s); their metrics are not covered by the backward-compatibility contract and may change. Run with -list-services to see available values.")
+	fs.StringVar(&cfg.Providers.GCP.VertexFamilyFilter, "gcp.vertex.families", ".*", "Regex matched against the Vertex model family label. Only matching families are emitted.")
 	flag.StringVar(&cfg.Providers.AWS.Region, "aws.region", "", "AWS region")
 	flag.StringVar(&cfg.Providers.AWS.RoleARN, "aws.roleARN", "", "Optional AWS role ARN to assume for cross-account access.")
 	fs.StringVar(&cfg.Providers.AWS.BedrockFamilyFilter, "aws.bedrock.families", ".*", "Regex matched against the Bedrock model family label. Only matching families are emitted.")
@@ -288,6 +289,7 @@ func selectProviderWith(
 			ExperimentalServices: strings.Split(cfg.Providers.GCP.ExperimentalServices.String(), ","),
 			CollectorTimeout:     collectorTimeout,
 			GKEZoneConcurrency:   cfg.Providers.GCP.GKEZoneConcurrency,
+			VertexFamilyFilter:   cfg.Providers.GCP.VertexFamilyFilter,
 		})
 
 	default:

--- a/docs/metrics/gcp/vertex.md
+++ b/docs/metrics/gcp/vertex.md
@@ -32,7 +32,9 @@ Claude on Vertex (`family="anthropic"`) is priced automatically, no extra config
 are account-scoped rather than public catalog SKUs, so the collector resolves the billing account
 from `--project-id` (via `getBillingInfo`) and reads them from the Cloud Billing v1beta pricing API.
 The lookup is best-effort: if the billing account cannot be resolved or has no Claude SKUs, Claude is
-left unpriced and the other Vertex prices are still emitted.
+left unpriced and the other Vertex prices are still emitted. It runs off the startup path (the
+collector starts with catalog prices and adds Claude on the first background refresh), so Claude
+series appear a few seconds after start.
 
 ## Token Pricing
 

--- a/docs/metrics/gcp/vertex.md
+++ b/docs/metrics/gcp/vertex.md
@@ -102,24 +102,6 @@ Tiers are composed from up to three modifiers: a `thinking_` prefix, a `cached_`
 | `gen_ai_token_type` | `input`, `output` | Whether the price is for input or output characters |
 | `price_tier` | `on_demand` | GCP Translation is flat-rate; no batch tier exists in the billing API |
 
-## Compute Pricing
-
-| Metric | Labels | Description |
-|--------|--------|-------------|
-| `cloudcost_gcp_vertex_instance_total_usd_per_hour` | `project_id`, `machine_type`, `use_case`, `region`, `price_tier` | Vertex AI custom training and prediction node cost in USD per hour |
-
-### Labels
-
-| Label | Values | Description |
-|-------|--------|-------------|
-| `project_id` | e.g. `my-gcp-project` | Billing-scope project (see Token Pricing) |
-| `machine_type` | e.g. `n1-standard-4` | Machine type used for the compute node |
-| `use_case` | `training`, `prediction` | Whether the node is used for custom training or online prediction |
-| `region` | e.g. `us-central1` | GCP region |
-| `price_tier` | `on_demand`, `spot` | Pricing tier; spot metrics are only emitted when a spot price exists |
-
-Compute nodes are not models, so this metric carries no `gen_ai_request_model` / `gen_ai_token_type`.
-
 ## Reranking
 
 | Metric | Labels | Description |

--- a/docs/metrics/gcp/vertex.md
+++ b/docs/metrics/gcp/vertex.md
@@ -21,7 +21,7 @@ The tier stays a single composed `price_tier` label rather than splitting into B
 Enable the Vertex collector by adding `vertex` to the experimental GCP services:
 
 ```bash
---gcp.experimental.services=vertex --gcp.projects=<project>[,<project>...]
+--project-id=<project> --gcp.experimental.services=vertex
 ```
 
 Restrict which model families are emitted with `--gcp.vertex.families`, a regex matched against the
@@ -38,7 +38,7 @@ Garden long tail (`deepseek`, `alibaba`, `meta`, and so on). Mirrors Bedrock's `
 
 | Label | Values | Description |
 |-------|--------|-------------|
-| `project_id` | e.g. `my-gcp-project` | Billing-scope project. Prices are project-independent; each series is emitted once per configured project (`--gcp.projects`), defaulting to the auth project |
+| `project_id` | e.g. `my-gcp-project` | Billing-scope project: the single auth project (`--project-id`). Prices are project-independent, so one value is stamped on every series, mirroring the single `account_id` on the Bedrock metrics |
 | `region` | e.g. `us-central1` | GCP region |
 | `gen_ai_request_model` | e.g. `gemini-1.5-flash`, `gemma-4`, `llama-4-maverick` | Model name, normalised to lowercase with spaces replaced by hyphens |
 | `family` | `google`, `meta`, `alibaba`, `deepseek`, `minimax`, `moonshot`, `unknown` | Model provider family; `unknown` for unrecognised model prefixes |

--- a/docs/metrics/gcp/vertex.md
+++ b/docs/metrics/gcp/vertex.md
@@ -16,6 +16,18 @@ The tier stays a single composed `price_tier` label rather than splitting into B
   them into a single `quota_tier` would let SKUs with different prices collide and overwrite each
   other, so the composed label is retained to keep every dimension.
 
+## Configuration
+
+Enable the Vertex collector by adding `vertex` to the experimental GCP services:
+
+```bash
+--gcp.experimental.services=vertex --gcp.projects=<project>[,<project>...]
+```
+
+Restrict which model families are emitted with `--gcp.vertex.families`, a regex matched against the
+`family` label. The default `.*` emits all families; set e.g. `google|anthropic` to drop the Model
+Garden long tail (`deepseek`, `alibaba`, `meta`, and so on). Mirrors Bedrock's `--aws.bedrock.families`.
+
 ## Token Pricing
 
 | Metric | Labels | Description |

--- a/docs/metrics/gcp/vertex.md
+++ b/docs/metrics/gcp/vertex.md
@@ -2,20 +2,35 @@
 
 Metrics exported for the GCP Vertex AI service.
 
+## Alignment with the Bedrock collector
+
+These metrics mirror the AWS Bedrock collector's shape where GCP pricing allows: input and output are
+one metric distinguished by `gen_ai_token_type`, the model label is `gen_ai_request_model`, and every
+metric carries a billing-scope label (`project_id` here, `account_id` on Bedrock).
+
+The tier stays a single composed `price_tier` label rather than splitting into Bedrock's orthogonal
+`region_tier` / `quota_tier` / `cache_ttl`, because Vertex pricing does not decompose the same way:
+
+- Vertex has no cross-region inference pricing, so there is no `region_tier` equivalent.
+- `price_tier` composes four independent dimensions (quota, caching, long context, thinking). Folding
+  them into a single `quota_tier` would let SKUs with different prices collide and overwrite each
+  other, so the composed label is retained to keep every dimension.
+
 ## Token Pricing
 
 | Metric | Labels | Description |
 |--------|--------|-------------|
-| `cloudcost_gcp_vertex_input_usd_per_1k_tokens` | `model_id`, `family`, `region`, `price_tier` | Input cost in USD per 1k tokens, for models billed by token. Character-billed models use the character metric. |
-| `cloudcost_gcp_vertex_output_usd_per_1k_tokens` | `model_id`, `family`, `region`, `price_tier` | Output cost in USD per 1k tokens, for models billed by token. Character-billed models use the character metric. |
+| `cloudcost_gcp_vertex_usd_per_1k_tokens` | `project_id`, `region`, `gen_ai_request_model`, `family`, `gen_ai_token_type`, `price_tier` | Cost in USD per 1k tokens, by `gen_ai_token_type`, for models billed by token. Character-billed models use the character metric. |
 
 ### Labels
 
 | Label | Values | Description |
 |-------|--------|-------------|
-| `model_id` | e.g. `gemini-1.5-flash`, `gemma-4`, `llama-4-maverick` | Model name, normalised to lowercase with spaces replaced by hyphens |
-| `family` | `google`, `meta`, `alibaba`, `deepseek`, `minimax`, `moonshot`, `unknown` | Model provider family; `unknown` for unrecognised model prefixes |
+| `project_id` | e.g. `my-gcp-project` | Billing-scope project. Prices are project-independent; each series is emitted once per configured project (`--gcp.projects`), defaulting to the auth project |
 | `region` | e.g. `us-central1` | GCP region |
+| `gen_ai_request_model` | e.g. `gemini-1.5-flash`, `gemma-4`, `llama-4-maverick` | Model name, normalised to lowercase with spaces replaced by hyphens |
+| `family` | `google`, `meta`, `alibaba`, `deepseek`, `minimax`, `moonshot`, `unknown` | Model provider family; `unknown` for unrecognised model prefixes |
+| `gen_ai_token_type` | `input`, `output` | Whether the price is for input or output tokens |
 | `price_tier` | see below | Running mode or pricing tier derived from the GCP SKU description |
 
 #### `price_tier` Values for Token Metrics
@@ -62,38 +77,42 @@ Tiers are composed from up to three modifiers: a `thinking_` prefix, a `cached_`
 
 | Metric | Labels | Description |
 |--------|--------|-------------|
-| `cloudcost_gcp_vertex_input_usd_per_1k_characters` | `model_id`, `family`, `region`, `price_tier` | Input cost in USD per 1k characters, for models billed by character (e.g. translation models). |
-| `cloudcost_gcp_vertex_output_usd_per_1k_characters` | `model_id`, `family`, `region`, `price_tier` | Output cost in USD per 1k characters, for models billed by character (e.g. translation models). |
+| `cloudcost_gcp_vertex_usd_per_1k_characters` | `project_id`, `region`, `gen_ai_request_model`, `family`, `gen_ai_token_type`, `price_tier` | Cost in USD per 1k characters, by `gen_ai_token_type`, for models billed by character (e.g. translation models). |
 
 ### Labels
 
 | Label | Values | Description |
 |-------|--------|-------------|
-| `model_id` | e.g. `translation-llm` | Model name, normalised to lowercase with spaces replaced by hyphens |
-| `family` | `google`, `unknown` | Model provider family; `unknown` for unrecognised model prefixes |
+| `project_id` | e.g. `my-gcp-project` | Billing-scope project (see Token Pricing) |
 | `region` | e.g. `global` | GCP region |
+| `gen_ai_request_model` | e.g. `translation-llm` | Model name, normalised to lowercase with spaces replaced by hyphens |
+| `family` | `google`, `unknown` | Model provider family; `unknown` for unrecognised model prefixes |
+| `gen_ai_token_type` | `input`, `output` | Whether the price is for input or output characters |
 | `price_tier` | `on_demand` | GCP Translation is flat-rate; no batch tier exists in the billing API |
 
 ## Compute Pricing
 
 | Metric | Labels | Description |
 |--------|--------|-------------|
-| `cloudcost_gcp_vertex_instance_total_usd_per_hour` | `machine_type`, `use_case`, `region`, `price_tier` | Vertex AI custom training and prediction node cost in USD per hour |
+| `cloudcost_gcp_vertex_instance_total_usd_per_hour` | `project_id`, `machine_type`, `use_case`, `region`, `price_tier` | Vertex AI custom training and prediction node cost in USD per hour |
 
 ### Labels
 
 | Label | Values | Description |
 |-------|--------|-------------|
+| `project_id` | e.g. `my-gcp-project` | Billing-scope project (see Token Pricing) |
 | `machine_type` | e.g. `n1-standard-4` | Machine type used for the compute node |
 | `use_case` | `training`, `prediction` | Whether the node is used for custom training or online prediction |
 | `region` | e.g. `us-central1` | GCP region |
 | `price_tier` | `on_demand`, `spot` | Pricing tier; spot metrics are only emitted when a spot price exists |
 
+Compute nodes are not models, so this metric carries no `gen_ai_request_model` / `gen_ai_token_type`.
+
 ## Reranking
 
 | Metric | Labels | Description |
 |--------|--------|-------------|
-| `cloudcost_gcp_vertex_search_unit_usd_per_1k_search_units` | `model_id`, `family`, `region` | Vertex AI reranking cost in USD per 1k ranking requests |
+| `cloudcost_gcp_vertex_search_unit_usd_per_1k_search_units` | `project_id`, `region`, `gen_ai_request_model`, `family`, `price_tier` | Vertex AI reranking cost in USD per 1k ranking requests |
 
 Reranking SKUs are fetched from the Cloud Discovery Engine billing service. If that service is unavailable at startup, reranking metrics are omitted and a warning is logged.
 
@@ -101,9 +120,11 @@ Reranking SKUs are fetched from the Cloud Discovery Engine billing service. If t
 
 | Label | Values | Description |
 |-------|--------|-------------|
-| `model_id` | e.g. `semantic-ranker-api` | Ranker model name, normalised to lowercase with spaces replaced by hyphens |
-| `family` | `google` | Model provider family; Discovery Engine reranking models are Google's |
+| `project_id` | e.g. `my-gcp-project` | Billing-scope project (see Token Pricing) |
 | `region` | e.g. `global` | GCP region |
+| `gen_ai_request_model` | e.g. `semantic-ranker-api` | Ranker model name, normalised to lowercase with spaces replaced by hyphens |
+| `family` | `google` | Model provider family; Discovery Engine reranking models are Google's |
+| `price_tier` | `on_demand` | The Ranking API is a single flat rate; the label is constant and mirrors the other Vertex metrics. Analogous to Bedrock's search-unit metric, this carries no `gen_ai_token_type` |
 
 ## Notes
 

--- a/docs/metrics/gcp/vertex.md
+++ b/docs/metrics/gcp/vertex.md
@@ -28,6 +28,12 @@ Restrict which model families are emitted with `--gcp.vertex.families`, a regex 
 `family` label. The default `.*` emits all families; set e.g. `google|anthropic` to drop the Model
 Garden long tail (`deepseek`, `alibaba`, `meta`, and so on). Mirrors Bedrock's `--aws.bedrock.families`.
 
+Claude on Vertex (`family="anthropic"`) is priced automatically, no extra configuration. Its prices
+are account-scoped rather than public catalog SKUs, so the collector resolves the billing account
+from `--project-id` (via `getBillingInfo`) and reads them from the Cloud Billing v1beta pricing API.
+The lookup is best-effort: if the billing account cannot be resolved or has no Claude SKUs, Claude is
+left unpriced and the other Vertex prices are still emitted.
+
 ## Token Pricing
 
 | Metric | Labels | Description |
@@ -40,9 +46,9 @@ Garden long tail (`deepseek`, `alibaba`, `meta`, and so on). Mirrors Bedrock's `
 |-------|--------|-------------|
 | `project_id` | e.g. `my-gcp-project` | Billing-scope project: the single auth project (`--project-id`). Prices are project-independent, so one value is stamped on every series, mirroring the single `account_id` on the Bedrock metrics |
 | `region` | e.g. `us-central1` | GCP region |
-| `gen_ai_request_model` | e.g. `gemini-1.5-flash`, `gemma-4`, `llama-4-maverick` | Model name, normalised to lowercase with spaces replaced by hyphens |
-| `family` | `google`, `meta`, `alibaba`, `deepseek`, `minimax`, `moonshot`, `unknown` | Model provider family; `unknown` for unrecognised model prefixes |
-| `gen_ai_token_type` | `input`, `output` | Whether the price is for input or output tokens |
+| `gen_ai_request_model` | e.g. `gemini-1.5-flash`, `gemma-4`, `llama-4-maverick`, `claude-sonnet-4-6` | Model name, normalised to lowercase with spaces replaced by hyphens (Claude names match the Sigil `gen_ai_request_model` form) |
+| `family` | `google`, `anthropic`, `meta`, `alibaba`, `deepseek`, `minimax`, `moonshot`, `unknown` | Model provider family; `anthropic` (Claude on Vertex) requires the project's billing account to be resolvable; `unknown` for unrecognised model prefixes |
+| `gen_ai_token_type` | `input`, `output`, `cache_read`, `cache_write` | Token direction / prompt-cache operation. `cache_read`/`cache_write` apply to Claude-on-Vertex only |
 | `price_tier` | see below | Running mode or pricing tier derived from the GCP SKU description |
 
 #### `price_tier` Values for Token Metrics
@@ -84,6 +90,12 @@ Tiers are composed from up to three modifiers: a `thinking_` prefix, a `cached_`
 | `thinking_batch_long_context` | Thinking + batch + long context |
 | `thinking_flex_long_context` | Thinking + flex + long context |
 | `thinking_priority_long_context` | Thinking + priority + long context |
+
+**Claude on Vertex** (`family="anthropic"`, when the account-scoped prices are available) uses a smaller set:
+`on_demand`, `long_context` (context window above 200k tokens), and `on_demand_1h` (the 1-hour
+prompt-cache write; the 5-minute write is `on_demand`). Its `gen_ai_token_type` spans `input`,
+`output`, `cache_read`, and `cache_write`. Regional and multi-region endpoints carry a 10% premium
+over `global`, captured by the per-`region` price (no separate tier), so `region` distinguishes them.
 
 ## Character Pricing
 

--- a/docs/metrics/gcp/vertex.md
+++ b/docs/metrics/gcp/vertex.md
@@ -108,7 +108,7 @@ Tiers are composed from up to three modifiers: a `thinking_` prefix, a `cached_`
 |--------|--------|-------------|
 | `cloudcost_gcp_vertex_search_unit_usd_per_1k_search_units` | `project_id`, `region`, `gen_ai_request_model`, `family`, `price_tier` | Vertex AI reranking cost in USD per 1k ranking requests |
 
-Reranking SKUs are fetched from the Cloud Discovery Engine billing service. If that service is unavailable at startup, reranking metrics are omitted and a warning is logged.
+Reranking is priced from the `Vertex AI Search: Ranking` SKU (the Semantic Ranker the Assistant uses), fetched from the Cloud Discovery Engine billing service. If that service is unavailable at startup, reranking metrics are omitted and a warning is logged. Agent Builder (`AI Dev Tools:`) SKUs share this service but price a different product and are skipped.
 
 ### Labels
 
@@ -116,8 +116,8 @@ Reranking SKUs are fetched from the Cloud Discovery Engine billing service. If t
 |-------|--------|-------------|
 | `project_id` | e.g. `my-gcp-project` | Billing-scope project (see Token Pricing) |
 | `region` | e.g. `global` | GCP region |
-| `gen_ai_request_model` | e.g. `semantic-ranker-api` | Ranker model name, normalised to lowercase with spaces replaced by hyphens |
-| `family` | `google` | Model provider family; Discovery Engine reranking models are Google's |
+| `gen_ai_request_model` | `semantic-ranker` | GCP catalogs ranking as a service SKU with no model name; this recognizable slug stands in |
+| `family` | `google` | Model provider family; the Ranking API is a Google service |
 | `price_tier` | `on_demand` | The Ranking API is a single flat rate; the label is constant and mirrors the other Vertex metrics. Analogous to Bedrock's search-unit metric, this carries no `gen_ai_token_type` |
 
 ## Notes

--- a/pkg/google/client/billing.go
+++ b/pkg/google/client/billing.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 
 	billingv1 "cloud.google.com/go/billing/apiv1"
 	"cloud.google.com/go/billing/apiv1/billingpb"
 	"github.com/grafana/cloudcost-exporter/pkg/google/metrics"
+	cloudbillingv1beta "google.golang.org/api/cloudbilling/v1beta"
 	"google.golang.org/api/iterator"
 )
 
@@ -30,12 +32,116 @@ var (
 
 type Billing struct {
 	billingService *billingv1.CloudCatalogClient
+	// pricing is the v1beta Cloud Billing client, used for account-scoped SKUs (e.g. Anthropic
+	// Claude on Vertex) that are not in the public Cloud Catalog. May be nil (e.g. in the mock).
+	pricing *cloudbillingv1beta.Service
+	// cloudBilling resolves a project's billing account (for account-scoped pricing). May be nil.
+	cloudBilling *billingv1.CloudBillingClient
 }
 
-func newBilling(billingService *billingv1.CloudCatalogClient) *Billing {
+func newBilling(billingService *billingv1.CloudCatalogClient, pricing *cloudbillingv1beta.Service, cloudBilling *billingv1.CloudBillingClient) *Billing {
 	return &Billing{
 		billingService: billingService,
+		pricing:        pricing,
+		cloudBilling:   cloudBilling,
 	}
+}
+
+// getProjectBillingAccount resolves the billing account a project bills to (e.g. "01330B-..."),
+// stripped of the "billingAccounts/" prefix. Read-only. Used to locate account-scoped pricing
+// without extra configuration, the way the AWS collectors derive the account from STS.
+func (b *Billing) getProjectBillingAccount(ctx context.Context, projectID string) (string, error) {
+	if b.cloudBilling == nil {
+		return "", fmt.Errorf("cloud billing client not configured")
+	}
+	info, err := b.cloudBilling.GetProjectBillingInfo(ctx, &billingpb.GetProjectBillingInfoRequest{
+		Name: "projects/" + projectID,
+	})
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimPrefix(info.GetBillingAccountName(), "billingAccounts/"), nil
+}
+
+// BillingAccountPrice is the list price of a single account-scoped SKU. Account-scoped SKUs are not
+// in the public Cloud Catalog; they are only available under a Cloud Billing account via v1beta.
+type BillingAccountPrice struct {
+	Description  string  // SKU display name (e.g. "Claude Sonnet 4.6 — Input Tokens — global — ...")
+	USDPerUnit   float64 // list price for one UnitQuantity of usage
+	UnitQuantity float64 // units the price applies to (e.g. 1000000 for per-1M-token SKUs)
+}
+
+// listBillingAccountPrices returns the list price of every account-scoped SKU belonging to a service
+// whose display name starts with displayNamePrefix (e.g. the per-model "Claude ..." services).
+//
+// It resolves matching services first, then lists only those services' SKUs (server-side filtered by
+// billing_account_service). This avoids scanning the account's full SKU catalog (tens of thousands of
+// entries). The SKU list carries only metadata, so each SKU's price is fetched from its per-SKU price
+// sub-resource.
+func (b *Billing) listBillingAccountPrices(ctx context.Context, billingAccount, displayNamePrefix string) ([]BillingAccountPrice, error) {
+	if b.pricing == nil {
+		return nil, fmt.Errorf("v1beta pricing client not configured")
+	}
+	parent := fmt.Sprintf("billingAccounts/%s", billingAccount)
+
+	var serviceNames []string
+	err := b.pricing.BillingAccounts.Services.List(parent).PageSize(5000).Pages(ctx,
+		func(resp *cloudbillingv1beta.GoogleCloudBillingBillingaccountservicesV1betaListBillingAccountServicesResponse) error {
+			for _, svc := range resp.BillingAccountServices {
+				if strings.HasPrefix(svc.DisplayName, displayNamePrefix) {
+					serviceNames = append(serviceNames, svc.Name)
+				}
+			}
+			return nil
+		})
+	if err != nil {
+		return nil, fmt.Errorf("listing billing account services: %w", err)
+	}
+
+	var prices []BillingAccountPrice
+	for _, serviceName := range serviceNames {
+		// The filter value must be double-quoted per the API.
+		filter := fmt.Sprintf("billing_account_service=%q", serviceName)
+		err := b.pricing.BillingAccounts.Skus.List(parent).Filter(filter).PageSize(5000).Pages(ctx,
+			func(resp *cloudbillingv1beta.GoogleCloudBillingBillingaccountskusV1betaListBillingAccountSkusResponse) error {
+				for _, sku := range resp.BillingAccountSkus {
+					price, err := b.pricing.BillingAccounts.Skus.Price.Get(sku.Name + "/price").Context(ctx).Do()
+					if err != nil {
+						return fmt.Errorf("fetching price for %q: %w", sku.DisplayName, err)
+					}
+					usd, qty, ok := listPriceFromRate(price.Rate)
+					if !ok {
+						continue
+					}
+					prices = append(prices, BillingAccountPrice{Description: sku.DisplayName, USDPerUnit: usd, UnitQuantity: qty})
+				}
+				return nil
+			})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return prices, nil
+}
+
+// listPriceFromRate extracts the steady-state list price and its unit quantity. The last tier is the
+// paid rate (earlier tiers are free allowances), matching getPriceFromSku.
+func listPriceFromRate(rate *cloudbillingv1beta.GoogleCloudBillingBillingaccountpricesV1betaRate) (usdPerUnit, unitQuantity float64, ok bool) {
+	if rate == nil || len(rate.Tiers) == 0 {
+		return 0, 0, false
+	}
+	tier := rate.Tiers[len(rate.Tiers)-1]
+	if tier.ListPrice == nil {
+		return 0, 0, false
+	}
+	usdPerUnit = float64(tier.ListPrice.Units) + float64(tier.ListPrice.Nanos)/1e9
+	unitQuantity = 1
+	if rate.UnitInfo != nil && rate.UnitInfo.UnitQuantity != nil {
+		if v, err := strconv.ParseFloat(rate.UnitInfo.UnitQuantity.Value, 64); err == nil && v > 0 {
+			unitQuantity = v
+		}
+	}
+	return usdPerUnit, unitQuantity, true
 }
 
 // getServiceName will search for a service by the display name and return the full name.

--- a/pkg/google/client/billing.go
+++ b/pkg/google/client/billing.go
@@ -11,9 +11,14 @@ import (
 	billingv1 "cloud.google.com/go/billing/apiv1"
 	"cloud.google.com/go/billing/apiv1/billingpb"
 	"github.com/grafana/cloudcost-exporter/pkg/google/metrics"
+	"golang.org/x/sync/errgroup"
 	cloudbillingv1beta "google.golang.org/api/cloudbilling/v1beta"
 	"google.golang.org/api/iterator"
 )
+
+// billingPriceConcurrency bounds the concurrent per-SKU price fetches for account-scoped pricing.
+// Those calls dominate the fetch latency, so they run in parallel rather than one at a time.
+const billingPriceConcurrency = 16
 
 // ServiceNotFound indicates the requested GCP service was not found in the Cloud Catalog.
 var errServiceNotFound = errors.New("service not found")
@@ -98,27 +103,49 @@ func (b *Billing) listBillingAccountPrices(ctx context.Context, billingAccount, 
 		return nil, fmt.Errorf("listing billing account services: %w", err)
 	}
 
-	var prices []BillingAccountPrice
+	// Collect the SKUs across matching services (metadata only; price is a separate sub-resource).
+	type skuRef struct{ name, description string }
+	var skus []skuRef
 	for _, serviceName := range serviceNames {
 		// The filter value must be double-quoted per the API.
 		filter := fmt.Sprintf("billing_account_service=%q", serviceName)
 		err := b.pricing.BillingAccounts.Skus.List(parent).Filter(filter).PageSize(5000).Pages(ctx,
 			func(resp *cloudbillingv1beta.GoogleCloudBillingBillingaccountskusV1betaListBillingAccountSkusResponse) error {
 				for _, sku := range resp.BillingAccountSkus {
-					price, err := b.pricing.BillingAccounts.Skus.Price.Get(sku.Name + "/price").Context(ctx).Do()
-					if err != nil {
-						return fmt.Errorf("fetching price for %q: %w", sku.DisplayName, err)
-					}
-					usd, qty, ok := listPriceFromRate(price.Rate)
-					if !ok {
-						continue
-					}
-					prices = append(prices, BillingAccountPrice{Description: sku.DisplayName, USDPerUnit: usd, UnitQuantity: qty})
+					skus = append(skus, skuRef{name: sku.Name, description: sku.DisplayName})
 				}
 				return nil
 			})
 		if err != nil {
 			return nil, err
+		}
+	}
+
+	// The per-SKU price calls dominate latency, so fetch them concurrently. Results go to a
+	// pre-sized, index-aligned slice (no lock needed); unpriced entries stay empty and are dropped.
+	out := make([]BillingAccountPrice, len(skus))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(billingPriceConcurrency)
+	for i, s := range skus {
+		g.Go(func() error {
+			price, err := b.pricing.BillingAccounts.Skus.Price.Get(s.name + "/price").Context(gctx).Do()
+			if err != nil {
+				return fmt.Errorf("fetching price for %q: %w", s.description, err)
+			}
+			if usd, qty, ok := listPriceFromRate(price.Rate); ok {
+				out[i] = BillingAccountPrice{Description: s.description, USDPerUnit: usd, UnitQuantity: qty}
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	prices := make([]BillingAccountPrice, 0, len(out))
+	for _, p := range out {
+		if p.Description != "" {
+			prices = append(prices, p)
 		}
 	}
 	return prices, nil

--- a/pkg/google/client/billing.go
+++ b/pkg/google/client/billing.go
@@ -123,6 +123,8 @@ func (b *Billing) listBillingAccountPrices(ctx context.Context, billingAccount, 
 
 	// The per-SKU price calls dominate latency, so fetch them concurrently. Results go to a
 	// pre-sized, index-aligned slice (no lock needed); unpriced entries stay empty and are dropped.
+	// A single SKU fetch error aborts the whole batch via errgroup: the caller (applyClaudePrices)
+	// treats any error as best-effort and preserves the already-populated catalog prices.
 	out := make([]BillingAccountPrice, len(skus))
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(billingPriceConcurrency)

--- a/pkg/google/client/client.go
+++ b/pkg/google/client/client.go
@@ -16,6 +16,8 @@ type Client interface {
 	ExportGCPCostData(ctx context.Context, serviceName string, m *metrics.Metrics) float64
 	ExportBucketInfo(ctx context.Context, projects []string, m *metrics.Metrics) error
 	GetPricing(ctx context.Context, serviceName string) []*billingpb.Sku
+	ListBillingAccountPrices(ctx context.Context, billingAccount, displayNamePrefix string) ([]BillingAccountPrice, error)
+	GetProjectBillingAccount(ctx context.Context, projectID string) (string, error)
 	GetZones(project string) ([]*compute.Zone, error)
 	GetRegions(project string) ([]*compute.Region, error)
 	ListInstancesInZone(projectId, zone string) ([]*MachineSpec, error)

--- a/pkg/google/client/client_mock.go
+++ b/pkg/google/client/client_mock.go
@@ -29,7 +29,7 @@ type Mock struct {
 func NewMock(projectId string, discount int, regionsClient RegionsClient, bucketClient StorageClientInterface, billingClient *billingv1.CloudCatalogClient, computeService *compute.Service, sqladminService *sqladmin.Service, managedKafkaClient ManagedKafkaClient) *Mock {
 	return &Mock{
 		region:       newRegion(projectId, discount, regionsClient),
-		billing:      newBilling(billingClient),
+		billing:      newBilling(billingClient, nil, nil),
 		bucket:       newBucket(bucketClient, cache.NewNoopCache[[]*storage.BucketAttrs]()),
 		compute:      newCompute(computeService),
 		sqladmin:     newSQLAdmin(sqladminService, projectId),
@@ -55,6 +55,14 @@ func (c *Mock) ExportBucketInfo(ctx context.Context, projects []string, m *metri
 
 func (c *Mock) GetPricing(ctx context.Context, serviceName string) []*billingpb.Sku {
 	return c.billing.getPricing(ctx, serviceName)
+}
+
+func (c *Mock) ListBillingAccountPrices(ctx context.Context, billingAccount, displayNamePrefix string) ([]BillingAccountPrice, error) {
+	return c.billing.listBillingAccountPrices(ctx, billingAccount, displayNamePrefix)
+}
+
+func (c *Mock) GetProjectBillingAccount(ctx context.Context, projectID string) (string, error) {
+	return c.billing.getProjectBillingAccount(ctx, projectID)
 }
 
 func (c *Mock) GetZones(projectId string) ([]*compute.Zone, error) {

--- a/pkg/google/client/gcp_client.go
+++ b/pkg/google/client/gcp_client.go
@@ -12,7 +12,9 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/grafana/cloudcost-exporter/pkg/google/client/cache"
 	"github.com/grafana/cloudcost-exporter/pkg/google/metrics"
+	cloudbillingv1beta "google.golang.org/api/cloudbilling/v1beta"
 	computev1 "google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
@@ -42,6 +44,22 @@ func NewGCPClient(ctx context.Context, cfg Config) (*GCPClient, error) {
 		return nil, fmt.Errorf("error creating cloudCatalogClient: %w", err)
 	}
 
+	// v1beta Cloud Billing client for account-scoped pricing (e.g. Claude on Vertex). The quota
+	// project is the auth project; account-scoped price calls require it.
+	billingOpts := []option.ClientOption{}
+	if cfg.ProjectId != "" {
+		billingOpts = append(billingOpts, option.WithQuotaProject(cfg.ProjectId))
+	}
+	pricingService, err := cloudbillingv1beta.NewService(ctx, billingOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating billing pricing client: %w", err)
+	}
+
+	cloudBillingClient, err := billingv1.NewCloudBillingClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error creating cloud billing client: %w", err)
+	}
+
 	regionsClient, err := computeapiv1.NewRegionsRESTClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not create regions client: %w", err)
@@ -64,7 +82,7 @@ func NewGCPClient(ctx context.Context, cfg Config) (*GCPClient, error) {
 
 	return &GCPClient{
 		compute:      newCompute(computeService),
-		billing:      newBilling(cloudCatalogClient),
+		billing:      newBilling(cloudCatalogClient, pricingService, cloudBillingClient),
 		regions:      newRegion(cfg.ProjectId, cfg.Discount, regionsClient),
 		bucket:       newBucket(storageClient, cache.NewBucketCache()),
 		sqlAdmin:     newSQLAdmin(sqlAdminClient, cfg.ProjectId),
@@ -86,6 +104,14 @@ func (c *GCPClient) ExportGCPCostData(ctx context.Context, serviceName string, m
 
 func (c *GCPClient) GetPricing(ctx context.Context, serviceName string) []*billingpb.Sku {
 	return c.billing.getPricing(ctx, serviceName)
+}
+
+func (c *GCPClient) ListBillingAccountPrices(ctx context.Context, billingAccount, displayNamePrefix string) ([]BillingAccountPrice, error) {
+	return c.billing.listBillingAccountPrices(ctx, billingAccount, displayNamePrefix)
+}
+
+func (c *GCPClient) GetProjectBillingAccount(ctx context.Context, projectID string) (string, error) {
+	return c.billing.getProjectBillingAccount(ctx, projectID)
 }
 
 func (c *GCPClient) ExportBucketInfo(ctx context.Context, projects []string, m *metrics.Metrics) error {

--- a/pkg/google/client/regions_test.go
+++ b/pkg/google/client/regions_test.go
@@ -52,6 +52,12 @@ func (c *regionsStubClient) ExportBucketInfo(_ context.Context, _ []string, _ *m
 func (c *regionsStubClient) GetPricing(_ context.Context, _ string) []*billingpb.Sku {
 	panic("not implemented")
 }
+func (c *regionsStubClient) ListBillingAccountPrices(_ context.Context, _, _ string) ([]BillingAccountPrice, error) {
+	panic("not implemented")
+}
+func (c *regionsStubClient) GetProjectBillingAccount(_ context.Context, _ string) (string, error) {
+	panic("not implemented")
+}
 func (c *regionsStubClient) ListInstancesInZone(_, _ string) ([]*MachineSpec, error) {
 	panic("not implemented")
 }

--- a/pkg/google/gcp.go
+++ b/pkg/google/gcp.go
@@ -218,7 +218,6 @@ func New(ctx context.Context, config *Config) (*GCP, error) {
 		case serviceVertex:
 			collector, err = vertex.New(ctx, &vertex.Config{
 				ProjectId:    config.ProjectId,
-				Projects:     config.Projects,
 				FamilyFilter: config.VertexFamilyFilter,
 			}, logger, gcpClient)
 			if err != nil {

--- a/pkg/google/gcp.go
+++ b/pkg/google/gcp.go
@@ -99,6 +99,9 @@ type Config struct {
 	// GKEZoneConcurrency caps zone-level goroutines per project during a GKE scrape.
 	// Zero or negative values fall back to gke.DefaultZoneCollectConcurrency.
 	GKEZoneConcurrency int
+	// VertexFamilyFilter is a regex matched against the Vertex model family label; only matching
+	// families are emitted. Mirrors --aws.bedrock.families. Empty or ".*" emits all families.
+	VertexFamilyFilter string
 	Logger             *slog.Logger
 }
 
@@ -214,8 +217,9 @@ func New(ctx context.Context, config *Config) (*GCP, error) {
 			}
 		case serviceVertex:
 			collector, err = vertex.New(ctx, &vertex.Config{
-				ProjectId: config.ProjectId,
-				Projects:  config.Projects,
+				ProjectId:    config.ProjectId,
+				Projects:     config.Projects,
+				FamilyFilter: config.VertexFamilyFilter,
 			}, logger, gcpClient)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",

--- a/pkg/google/gcp.go
+++ b/pkg/google/gcp.go
@@ -213,7 +213,10 @@ func New(ctx context.Context, config *Config) (*GCP, error) {
 				continue
 			}
 		case serviceVertex:
-			collector, err = vertex.New(ctx, logger, gcpClient)
+			collector, err = vertex.New(ctx, &vertex.Config{
+				ProjectId: config.ProjectId,
+				Projects:  config.Projects,
+			}, logger, gcpClient)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
 					slog.String("service", service),

--- a/pkg/google/managedkafka/managedkafka_test.go
+++ b/pkg/google/managedkafka/managedkafka_test.go
@@ -298,6 +298,14 @@ func (s *stubClient) GetPricing(context.Context, string) []*billingpb.Sku {
 	return s.skus
 }
 
+func (s *stubClient) ListBillingAccountPrices(context.Context, string, string) ([]client.BillingAccountPrice, error) {
+	return nil, nil
+}
+
+func (s *stubClient) GetProjectBillingAccount(context.Context, string) (string, error) {
+	return "", nil
+}
+
 func (s *stubClient) GetZones(string) ([]*compute.Zone, error) {
 	return nil, nil
 }

--- a/pkg/google/vertex/pricing_map.go
+++ b/pkg/google/vertex/pricing_map.go
@@ -27,11 +27,6 @@ const (
 )
 
 var (
-	// computeRegex matches custom training/prediction compute SKU descriptions.
-	// Example: "Custom Training n1-standard-4 running in us-central1"
-	// Example: "Spot Custom Prediction n1-highmem-8 running in europe-west1"
-	// NOTE: Exact SKU description strings must be verified against the live GCP Billing API.
-	computeRegex = regexp.MustCompile(`(?i)^(Spot\s+)?Custom\s+(Training|Prediction)\s+(\S+)\s+running\s+in`)
 	// rerankRegex matches Discovery Engine Ranking API SKU descriptions.
 	// Example: "Semantic Ranker API Ranking Requests"
 	// NOTE: Exact SKU description strings must be verified against the live GCP Billing API.
@@ -135,12 +130,6 @@ var skuPatterns = []skuPattern{
 	{regexp.MustCompile(`(?i)^(.+?)\s+Output\s+Characters?$`), "output", "char", "on_demand"},
 }
 
-// ComputePricing holds per-hour prices for a Vertex AI compute node.
-type ComputePricing struct {
-	OnDemandPerHour float64
-	SpotPerHour     float64
-}
-
 // Snapshot is an immutable view of the Vertex AI pricing data.
 type Snapshot struct {
 	// tokenInput[region][model][tier] = price per 1k input tokens (only set if a SKU exists)
@@ -151,8 +140,6 @@ type Snapshot struct {
 	charInput map[string]map[string]map[string]float64
 	// charOutput[region][model][tier] = price per 1k output characters (only set if a SKU exists)
 	charOutput map[string]map[string]map[string]float64
-	// compute[region][machineType][useCase] = ComputePricing
-	compute map[string]map[string]map[string]*ComputePricing
 	// reranking[region][model] = price per 1k ranking requests (USD)
 	reranking map[string]map[string]float64
 }
@@ -222,7 +209,6 @@ func (pm *PricingMap) ParseSkus(skus []*billingpb.Sku) error {
 		tokenOutput: make(map[string]map[string]map[string]float64),
 		charInput:   make(map[string]map[string]map[string]float64),
 		charOutput:  make(map[string]map[string]map[string]float64),
-		compute:     make(map[string]map[string]map[string]*ComputePricing),
 		reranking:   make(map[string]map[string]float64),
 	}
 
@@ -260,34 +246,6 @@ func (pm *PricingMap) ParseSkus(skus []*billingpb.Sku) error {
 			break
 		}
 		if matched {
-			continue
-		}
-
-		if matches := computeRegex.FindStringSubmatch(desc); len(matches) > 0 {
-			isSpot := strings.TrimSpace(matches[1]) != ""
-			useCase := strings.ToLower(matches[2])
-			machineType := strings.ToLower(matches[3])
-			price := priceFromSku(sku)
-			for _, region := range regions {
-				if region == "" {
-					continue
-				}
-				if snap.compute[region] == nil {
-					snap.compute[region] = make(map[string]map[string]*ComputePricing)
-				}
-				if snap.compute[region][machineType] == nil {
-					snap.compute[region][machineType] = make(map[string]*ComputePricing)
-				}
-				if snap.compute[region][machineType][useCase] == nil {
-					snap.compute[region][machineType][useCase] = &ComputePricing{}
-				}
-				cp := snap.compute[region][machineType][useCase]
-				if isSpot {
-					cp.SpotPerHour = price
-				} else {
-					cp.OnDemandPerHour = price
-				}
-			}
 			continue
 		}
 

--- a/pkg/google/vertex/pricing_map.go
+++ b/pkg/google/vertex/pricing_map.go
@@ -174,7 +174,9 @@ type PricingMap struct {
 // NewPricingMap initialises and populates a PricingMap.
 func NewPricingMap(ctx context.Context, logger *slog.Logger, gcpClient client.Client, familyFilter *regexp.Regexp, billingAccount string) (*PricingMap, error) {
 	pm := &PricingMap{gcpClient: gcpClient, logger: logger, familyFilter: familyFilter, billingAccount: billingAccount}
-	if err := pm.Populate(ctx); err != nil {
+	// Catalog only, to keep construction (and thus startup) fast; account-scoped Claude prices are
+	// layered in by the background refresh, off the startup path.
+	if err := pm.PopulateCatalog(ctx); err != nil {
 		return nil, err
 	}
 	return pm, nil
@@ -196,17 +198,41 @@ func (pm *PricingMap) Snapshot() Snapshot {
 	return Snapshot{}
 }
 
-// Populate fetches the latest Vertex AI SKUs and updates the pricing map.
-// Discovery Engine SKUs (reranking) are fetched non-fatally; reranking metrics
-// are omitted if the service is unavailable.
+// PopulateCatalog fetches the public Cloud Catalog SKUs (Gemini and other Model Garden models,
+// translation, reranking) and stores them. It excludes the account-scoped Claude prices, which are
+// slow to fetch, so it stays fast enough to run on the startup path.
+func (pm *PricingMap) PopulateCatalog(ctx context.Context) error {
+	skus, err := pm.fetchCatalogSKUs(ctx)
+	if err != nil {
+		return err
+	}
+	pm.current.Store(pm.buildSnapshot(skus))
+	return nil
+}
+
+// Populate refreshes the full pricing map: the public catalog plus account-scoped Claude prices.
+// Used by the background refresh loop, where the slower Claude fetch is off the startup path.
 func (pm *PricingMap) Populate(ctx context.Context) error {
+	skus, err := pm.fetchCatalogSKUs(ctx)
+	if err != nil {
+		return err
+	}
+	snap := pm.buildSnapshot(skus)
+	pm.applyClaudePrices(ctx, snap)
+	pm.current.Store(snap)
+	return nil
+}
+
+// fetchCatalogSKUs collects the Vertex AI SKUs plus the Discovery Engine SKUs (reranking). Discovery
+// Engine is non-fatal: reranking is omitted if that service is unavailable.
+func (pm *PricingMap) fetchCatalogSKUs(ctx context.Context) ([]*billingpb.Sku, error) {
 	serviceName, err := pm.gcpClient.GetServiceName(ctx, vertexAIServiceName)
 	if err != nil {
-		return fmt.Errorf("failed to get Vertex AI service name: %w", err)
+		return nil, fmt.Errorf("failed to get Vertex AI service name: %w", err)
 	}
 	skus := pm.gcpClient.GetPricing(ctx, serviceName)
 	if len(skus) == 0 {
-		return fmt.Errorf("no SKUs found for Vertex AI service")
+		return nil, fmt.Errorf("no SKUs found for Vertex AI service")
 	}
 
 	if deSvcName, err := pm.gcpClient.GetServiceName(ctx, discoveryEngineServiceName); err != nil {
@@ -214,25 +240,24 @@ func (pm *PricingMap) Populate(ctx context.Context) error {
 	} else {
 		skus = append(skus, pm.gcpClient.GetPricing(ctx, deSvcName)...)
 	}
+	return skus, nil
+}
 
-	snap := pm.buildSnapshot(skus)
-
-	// Claude-on-Vertex prices are account-scoped (not in the public catalog), so they are fetched
-	// from the v1beta pricing API and layered in non-fatally: omitted with a warning if the billing
-	// account is unset or the lookup fails, rather than dropping the catalog pricing already parsed.
-	if pm.billingAccount != "" {
-		prices, err := pm.gcpClient.ListBillingAccountPrices(ctx, pm.billingAccount, claudeDisplayPrefix)
-		if err != nil {
-			pm.logger.Warn("failed to fetch Claude-on-Vertex prices, they will be unavailable", "error", err)
-		} else {
-			for _, p := range prices {
-				pm.applyClaudeAccountPrice(snap, p)
-			}
-		}
+// applyClaudePrices layers account-scoped Claude-on-Vertex prices into snap. Best-effort: skipped
+// when no billing account is configured, and a fetch failure is logged rather than propagated so
+// the catalog prices already in snap are preserved.
+func (pm *PricingMap) applyClaudePrices(ctx context.Context, snap *Snapshot) {
+	if pm.billingAccount == "" {
+		return
 	}
-
-	pm.current.Store(snap)
-	return nil
+	prices, err := pm.gcpClient.ListBillingAccountPrices(ctx, pm.billingAccount, claudeDisplayPrefix)
+	if err != nil {
+		pm.logger.Warn("failed to fetch Claude-on-Vertex prices, they will be unavailable", "error", err)
+		return
+	}
+	for _, p := range prices {
+		pm.applyClaudeAccountPrice(snap, p)
+	}
 }
 
 // ParseSkus parses the provided SKUs and updates the pricing map atomically.

--- a/pkg/google/vertex/pricing_map.go
+++ b/pkg/google/vertex/pricing_map.go
@@ -26,11 +26,22 @@ const (
 	modalityGroup = `(?:text)`
 )
 
+// rerankModel is the gen_ai_request_model label for the reranker. GCP catalogs the price as a
+// service SKU ("Vertex AI Search: Ranking") with no model name, so this recognizable slug (the
+// Semantic Ranker the Assistant uses) stands in; familyFromModelID maps the "semantic" prefix to
+// google.
+const rerankModel = "semantic-ranker"
+
 var (
-	// rerankRegex matches Discovery Engine Ranking API SKU descriptions.
-	// Example: "Semantic Ranker API Ranking Requests"
-	// NOTE: Exact SKU description strings must be verified against the live GCP Billing API.
-	rerankRegex = regexp.MustCompile(`(?i)^(.+?)\s+[Rr]anking\s+[Rr]equests?$`)
+	// rerankRegex matches the Vertex AI Search Ranking (Semantic Ranker) SKU. Verified against the
+	// live catalog: the SKU description is exactly "Vertex AI Search: Ranking" (GenAppBuilder), not
+	// the "... Ranking Requests" form assumed previously.
+	rerankRegex = regexp.MustCompile(`(?i)^Vertex AI Search: Ranking$`)
+
+	// agentBuilderPrefix marks Agent Builder ("AI Dev Tools: ...") token SKUs. They price a
+	// different product and share the Discovery Engine service, so they are skipped to keep them out
+	// of the token metric.
+	agentBuilderPrefix = "AI Dev Tools:"
 )
 
 // skuPattern maps a compiled regex to the billing direction, billing type, and price tier.
@@ -219,6 +230,12 @@ func (pm *PricingMap) ParseSkus(skus []*billingpb.Sku) error {
 		desc := strings.TrimSpace(sku.GetDescription())
 		regions := skuRegions(sku)
 
+		// Agent Builder token SKUs share the Discovery Engine service but price a different product;
+		// skip them so they do not leak into the token metric as junk models.
+		if strings.HasPrefix(desc, agentBuilderPrefix) {
+			continue
+		}
+
 		matched := false
 		for _, pat := range skuPatterns {
 			matches := pat.re.FindStringSubmatch(desc)
@@ -249,9 +266,8 @@ func (pm *PricingMap) ParseSkus(skus []*billingpb.Sku) error {
 			continue
 		}
 
-		if matches := rerankRegex.FindStringSubmatch(desc); len(matches) > 0 {
-			model := normalizeModelName(matches[1])
-			if !pm.familyAllowed(model) {
+		if rerankRegex.MatchString(desc) {
+			if !pm.familyAllowed(rerankModel) {
 				continue
 			}
 			price := normalizeToPerK(priceFromSku(sku), sku)
@@ -262,7 +278,7 @@ func (pm *PricingMap) ParseSkus(skus []*billingpb.Sku) error {
 				if snap.reranking[region] == nil {
 					snap.reranking[region] = make(map[string]float64)
 				}
-				snap.reranking[region][model] = price
+				snap.reranking[region][rerankModel] = price
 			}
 			continue
 		}

--- a/pkg/google/vertex/pricing_map.go
+++ b/pkg/google/vertex/pricing_map.go
@@ -147,6 +147,10 @@ type Snapshot struct {
 	tokenInput map[string]map[string]map[string]float64
 	// tokenOutput[region][model][tier] = price per 1k output tokens (only set if a SKU exists)
 	tokenOutput map[string]map[string]map[string]float64
+	// tokenCacheRead[region][model][tier] = price per 1k prompt-cache read tokens (Claude-on-Vertex)
+	tokenCacheRead map[string]map[string]map[string]float64
+	// tokenCacheWrite[region][model][tier] = price per 1k prompt-cache write tokens (Claude-on-Vertex)
+	tokenCacheWrite map[string]map[string]map[string]float64
 	// charInput[region][model][tier] = price per 1k input characters (only set if a SKU exists)
 	charInput map[string]map[string]map[string]float64
 	// charOutput[region][model][tier] = price per 1k output characters (only set if a SKU exists)
@@ -163,11 +167,13 @@ type PricingMap struct {
 	// familyFilter, when non-nil, drops any model whose family does not match before it enters the
 	// map. A nil filter (e.g. in tests) keeps everything.
 	familyFilter *regexp.Regexp
+	// billingAccount, when non-empty, enables the account-scoped Claude-on-Vertex price fetch.
+	billingAccount string
 }
 
 // NewPricingMap initialises and populates a PricingMap.
-func NewPricingMap(ctx context.Context, logger *slog.Logger, gcpClient client.Client, familyFilter *regexp.Regexp) (*PricingMap, error) {
-	pm := &PricingMap{gcpClient: gcpClient, logger: logger, familyFilter: familyFilter}
+func NewPricingMap(ctx context.Context, logger *slog.Logger, gcpClient client.Client, familyFilter *regexp.Regexp, billingAccount string) (*PricingMap, error) {
+	pm := &PricingMap{gcpClient: gcpClient, logger: logger, familyFilter: familyFilter, billingAccount: billingAccount}
 	if err := pm.Populate(ctx); err != nil {
 		return nil, err
 	}
@@ -209,18 +215,44 @@ func (pm *PricingMap) Populate(ctx context.Context) error {
 		skus = append(skus, pm.gcpClient.GetPricing(ctx, deSvcName)...)
 	}
 
-	return pm.ParseSkus(skus)
+	snap := pm.buildSnapshot(skus)
+
+	// Claude-on-Vertex prices are account-scoped (not in the public catalog), so they are fetched
+	// from the v1beta pricing API and layered in non-fatally: omitted with a warning if the billing
+	// account is unset or the lookup fails, rather than dropping the catalog pricing already parsed.
+	if pm.billingAccount != "" {
+		prices, err := pm.gcpClient.ListBillingAccountPrices(ctx, pm.billingAccount, claudeDisplayPrefix)
+		if err != nil {
+			pm.logger.Warn("failed to fetch Claude-on-Vertex prices, they will be unavailable", "error", err)
+		} else {
+			for _, p := range prices {
+				pm.applyClaudeAccountPrice(snap, p)
+			}
+		}
+	}
+
+	pm.current.Store(snap)
+	return nil
 }
 
 // ParseSkus parses the provided SKUs and updates the pricing map atomically.
 // Unknown SKUs are logged at debug level and skipped.
 func (pm *PricingMap) ParseSkus(skus []*billingpb.Sku) error {
+	pm.current.Store(pm.buildSnapshot(skus))
+	return nil
+}
+
+// buildSnapshot parses SKUs into a Snapshot without publishing it, so callers can layer in
+// account-scoped Claude prices before storing atomically.
+func (pm *PricingMap) buildSnapshot(skus []*billingpb.Sku) *Snapshot {
 	snap := &Snapshot{
-		tokenInput:  make(map[string]map[string]map[string]float64),
-		tokenOutput: make(map[string]map[string]map[string]float64),
-		charInput:   make(map[string]map[string]map[string]float64),
-		charOutput:  make(map[string]map[string]map[string]float64),
-		reranking:   make(map[string]map[string]float64),
+		tokenInput:      make(map[string]map[string]map[string]float64),
+		tokenOutput:     make(map[string]map[string]map[string]float64),
+		tokenCacheRead:  make(map[string]map[string]map[string]float64),
+		tokenCacheWrite: make(map[string]map[string]map[string]float64),
+		charInput:       make(map[string]map[string]map[string]float64),
+		charOutput:      make(map[string]map[string]map[string]float64),
+		reranking:       make(map[string]map[string]float64),
 	}
 
 	for _, sku := range skus {
@@ -286,8 +318,81 @@ func (pm *PricingMap) ParseSkus(skus []*billingpb.Sku) error {
 		pm.logger.Debug("skipping unknown Vertex AI SKU", "description", desc)
 	}
 
-	pm.current.Store(snap)
-	return nil
+	return snap
+}
+
+// claudeDisplayPrefix matches Claude-on-Vertex account-scoped SKU display names
+// (e.g. "Claude Sonnet 4.6 — Input Tokens — global — Context Window Size from 0 to 200000 Tokens").
+const claudeDisplayPrefix = "Claude "
+
+// claudeContextBand captures the lower bound of the "Context Window Size from X to Y Tokens" clause.
+// A non-zero lower bound marks the long-context (>200k) band.
+var claudeContextBand = regexp.MustCompile(`context window size from (\d+) to`)
+
+// applyClaudeAccountPrice parses one account-scoped Claude SKU and stores it. The display name is
+// em-dash delimited: "{model} — {token kind} — {region} — Context Window Size from {lo} to {hi}
+// Tokens". Model normalizes to Sigil's form (claude-sonnet-4-6); input/output and prompt-cache
+// read/write route to their token maps; the context band and cache-write TTL fold into price_tier.
+// SKUs missing the expected structure (e.g. legacy Claude 3 formats) are skipped.
+func (pm *PricingMap) applyClaudeAccountPrice(snap *Snapshot, p client.BillingAccountPrice) {
+	parts := strings.Split(p.Description, "—")
+	if len(parts) < 3 {
+		return
+	}
+	model := normalizeClaudeModel(parts[0])
+	if !pm.familyAllowed(model) {
+		return
+	}
+
+	kind := strings.ToLower(parts[1])
+	var target map[string]map[string]map[string]float64
+	var tokenType string
+	switch {
+	case strings.Contains(kind, "cache read"):
+		tokenType, target = tokenTypeCacheRead, snap.tokenCacheRead
+	case strings.Contains(kind, "cache write"):
+		tokenType, target = tokenTypeCacheWrite, snap.tokenCacheWrite
+	case strings.Contains(kind, "output"):
+		tokenType, target = tokenTypeOutput, snap.tokenOutput
+	case strings.Contains(kind, "input"):
+		tokenType, target = tokenTypeInput, snap.tokenInput
+	default:
+		return
+	}
+
+	region := strings.TrimSpace(parts[2])
+	if region == "" {
+		region = "global"
+	}
+	// Prices are per UnitQuantity of usage (Claude token SKUs are per-1M); scale to per-1k.
+	perK := 0.0
+	if p.UnitQuantity > 0 {
+		perK = p.USDPerUnit * 1000 / p.UnitQuantity
+	}
+	applyPrice(target, model, claudeTier(strings.ToLower(p.Description), tokenType), perK, []string{region})
+}
+
+// normalizeClaudeModel converts a Claude SKU model segment into a slug matching Sigil's
+// gen_ai_request_model. Dots and spaces both become hyphens, so "Claude Sonnet 4.6" and the
+// space-munged "Claude Opus 4 8" both normalize correctly ("claude-sonnet-4-6", "claude-opus-4-8").
+func normalizeClaudeModel(raw string) string {
+	s := strings.ToLower(strings.TrimSpace(raw))
+	s = strings.NewReplacer(".", "-", " ", "-").Replace(s)
+	return strings.Trim(s, "-")
+}
+
+// claudeTier composes price_tier from the dimensions not held by other labels: the context-window
+// band (standard, or long_context above 200k) and, for cache writes, the TTL (5-minute is the base;
+// 1-hour is marked with a _1h suffix).
+func claudeTier(lowerDesc, tokenType string) string {
+	tier := "on_demand"
+	if m := claudeContextBand.FindStringSubmatch(lowerDesc); len(m) == 2 && m[1] != "0" {
+		tier = "long_context"
+	}
+	if tokenType == tokenTypeCacheWrite && strings.Contains(lowerDesc, "3600 second") {
+		tier += "_1h"
+	}
+	return tier
 }
 
 // applyPrice writes a price into the target region/model/tier map for each region.

--- a/pkg/google/vertex/pricing_map.go
+++ b/pkg/google/vertex/pricing_map.go
@@ -162,15 +162,26 @@ type PricingMap struct {
 	gcpClient client.Client
 	logger    *slog.Logger
 	current   atomic.Pointer[Snapshot]
+	// familyFilter, when non-nil, drops any model whose family does not match before it enters the
+	// map. A nil filter (e.g. in tests) keeps everything.
+	familyFilter *regexp.Regexp
 }
 
 // NewPricingMap initialises and populates a PricingMap.
-func NewPricingMap(ctx context.Context, logger *slog.Logger, gcpClient client.Client) (*PricingMap, error) {
-	pm := &PricingMap{gcpClient: gcpClient, logger: logger}
+func NewPricingMap(ctx context.Context, logger *slog.Logger, gcpClient client.Client, familyFilter *regexp.Regexp) (*PricingMap, error) {
+	pm := &PricingMap{gcpClient: gcpClient, logger: logger, familyFilter: familyFilter}
 	if err := pm.Populate(ctx); err != nil {
 		return nil, err
 	}
 	return pm, nil
+}
+
+// familyAllowed reports whether a model's family passes the configured family filter.
+func (pm *PricingMap) familyAllowed(model string) bool {
+	if pm.familyFilter == nil {
+		return true
+	}
+	return pm.familyFilter.MatchString(familyFromModelID(model))
 }
 
 // Snapshot returns an immutable copy of the current pricing data.
@@ -229,19 +240,22 @@ func (pm *PricingMap) ParseSkus(skus []*billingpb.Sku) error {
 				continue
 			}
 			model := normalizeModelName(matches[1])
-			price := normalizeToPerK(priceFromSku(sku), sku)
-			var target map[string]map[string]map[string]float64
-			switch {
-			case pat.direction == "input" && pat.billingType == "token":
-				target = snap.tokenInput
-			case pat.direction == "output" && pat.billingType == "token":
-				target = snap.tokenOutput
-			case pat.direction == "input" && pat.billingType == "char":
-				target = snap.charInput
-			default:
-				target = snap.charOutput
+			// Recognize the SKU (so it isn't logged as unknown) but skip storing a filtered family.
+			if pm.familyAllowed(model) {
+				price := normalizeToPerK(priceFromSku(sku), sku)
+				var target map[string]map[string]map[string]float64
+				switch {
+				case pat.direction == "input" && pat.billingType == "token":
+					target = snap.tokenInput
+				case pat.direction == "output" && pat.billingType == "token":
+					target = snap.tokenOutput
+				case pat.direction == "input" && pat.billingType == "char":
+					target = snap.charInput
+				default:
+					target = snap.charOutput
+				}
+				applyPrice(target, model, pat.tier, price, regions)
 			}
-			applyPrice(target, model, pat.tier, price, regions)
 			matched = true
 			break
 		}
@@ -279,6 +293,9 @@ func (pm *PricingMap) ParseSkus(skus []*billingpb.Sku) error {
 
 		if matches := rerankRegex.FindStringSubmatch(desc); len(matches) > 0 {
 			model := normalizeModelName(matches[1])
+			if !pm.familyAllowed(model) {
+				continue
+			}
 			price := normalizeToPerK(priceFromSku(sku), sku)
 			for _, region := range regions {
 				if region == "" {

--- a/pkg/google/vertex/pricing_map_test.go
+++ b/pkg/google/vertex/pricing_map_test.go
@@ -87,14 +87,25 @@ func TestParseSkus_CharacterSKUsRoutedSeparately(t *testing.T) {
 func TestParseSkus_RerankingSKU(t *testing.T) {
 	pm := &PricingMap{logger: testLogger()}
 	err := pm.ParseSkus([]*billingpb.Sku{
-		// usageUnit "k{request}" is already per-1k, price passes through unchanged.
-		newTokenSKU("Semantic Ranker API Ranking Requests", "global", "k{request}", 0, 1000000),
+		// The real SKU is "Vertex AI Search: Ranking", priced per request ("count") -> per-1k.
+		newTokenSKU("Vertex AI Search: Ranking", "global", "count", 0, 1000000),
 	})
 	require.NoError(t, err)
 
 	snap := pm.Snapshot()
 	require.NotNil(t, snap.reranking["global"])
-	assert.InDelta(t, 0.001, snap.reranking["global"]["semantic-ranker-api"], 1e-9)
+	assert.InDelta(t, 1.0, snap.reranking["global"]["semantic-ranker"], 1e-9)
+}
+
+func TestParseSkus_AgentBuilderTokenSKUsSkipped(t *testing.T) {
+	pm := &PricingMap{logger: testLogger()}
+	err := pm.ParseSkus([]*billingpb.Sku{
+		newTokenSKU("AI Dev Tools: Claude Sonnet 4.6 Input Tokens", "global", "count", 0, 3000),
+	})
+	require.NoError(t, err)
+
+	// Agent Builder SKUs must not leak into the token metric as junk models.
+	assert.Empty(t, pm.Snapshot().tokenInput)
 }
 
 func TestParseSkus_ModelGardenMaaSPrefixStripped(t *testing.T) {
@@ -277,11 +288,10 @@ func TestRegexPatterns(t *testing.T) {
 			input string
 			match bool
 		}{
-			{"Semantic Ranker API Ranking Requests", true},
-			{"Semantic Ranker API Ranking Request", true}, // singular
-			{"Some Model Ranking requests", true},         // case insensitive
+			{"Vertex AI Search: Ranking", true},
+			{"vertex ai search: ranking", true},             // case insensitive
+			{"Semantic Ranker API Ranking Requests", false}, // old assumed form no longer matched
 			{"Gemini 1.5 Flash Input tokens", false},
-			{"Ranking Requests", false}, // no model prefix
 		}
 		for _, tc := range cases {
 			assert.Equal(t, tc.match, rerankRegex.MatchString(tc.input), "input: %q", tc.input)

--- a/pkg/google/vertex/pricing_map_test.go
+++ b/pkg/google/vertex/pricing_map_test.go
@@ -60,34 +60,6 @@ func TestParseSkus_TokenSKUNormalizesPerUnitPrice(t *testing.T) {
 	assert.InDelta(t, 0.00125, snap.tokenInput["us-central1"]["gemini-1.0-pro"]["on_demand"], 1e-9)
 }
 
-func TestParseSkus_ComputeOnDemand(t *testing.T) {
-	pm := &PricingMap{logger: testLogger()}
-	err := pm.ParseSkus([]*billingpb.Sku{
-		newComputeSKU("Custom Training n1-standard-4 running in us-central1", "us-central1", 0, 500000000),
-	})
-	require.NoError(t, err)
-
-	snap := pm.Snapshot()
-	require.NotNil(t, snap.compute["us-central1"])
-	require.NotNil(t, snap.compute["us-central1"]["n1-standard-4"])
-	require.NotNil(t, snap.compute["us-central1"]["n1-standard-4"]["training"])
-	assert.InDelta(t, 0.5, snap.compute["us-central1"]["n1-standard-4"]["training"].OnDemandPerHour, 1e-9)
-	assert.Equal(t, 0.0, snap.compute["us-central1"]["n1-standard-4"]["training"].SpotPerHour)
-}
-
-func TestParseSkus_ComputeSpot(t *testing.T) {
-	pm := &PricingMap{logger: testLogger()}
-	err := pm.ParseSkus([]*billingpb.Sku{
-		newComputeSKU("Spot Custom Prediction n1-highmem-8 running in europe-west1", "europe-west1", 0, 150000000),
-	})
-	require.NoError(t, err)
-
-	snap := pm.Snapshot()
-	require.NotNil(t, snap.compute["europe-west1"]["n1-highmem-8"]["prediction"])
-	assert.InDelta(t, 0.15, snap.compute["europe-west1"]["n1-highmem-8"]["prediction"].SpotPerHour, 1e-9)
-	assert.Equal(t, 0.0, snap.compute["europe-west1"]["n1-highmem-8"]["prediction"].OnDemandPerHour)
-}
-
 func TestParseSkus_CharacterSKUsRoutedSeparately(t *testing.T) {
 	// Character-priced models must land in snap.characters, not snap.tokens.
 	pm := &PricingMap{logger: testLogger()}
@@ -145,14 +117,13 @@ func TestParseSkus_ModelGardenMaaSPrefixStripped(t *testing.T) {
 func TestParseSkus_UnknownSKUsIgnored(t *testing.T) {
 	pm := &PricingMap{logger: testLogger()}
 	err := pm.ParseSkus([]*billingpb.Sku{
-		newComputeSKU("Some Unknown Vertex AI SKU", "us-central1", 0, 100000000),
+		newTokenSKU("Some Unknown Vertex AI SKU", "us-central1", "count", 0, 100000000),
 		newTokenSKU("Gemini 1.5 Flash Input tokens", "us-central1", "k{char}", 0, 1250000),
 	})
 	require.NoError(t, err)
 
 	snap := pm.Snapshot()
 	assert.Len(t, snap.tokenInput["us-central1"], 1)
-	assert.Empty(t, snap.compute)
 }
 
 func TestParseSkus_NilSKUIgnored(t *testing.T) {
@@ -301,24 +272,6 @@ func TestParseSkus_MaaSOnDemandSKU(t *testing.T) {
 }
 
 func TestRegexPatterns(t *testing.T) {
-	t.Run("computeRegex", func(t *testing.T) {
-		cases := []struct {
-			input string
-			match bool
-		}{
-			{"Custom Training n1-standard-4 running in us-central1", true},
-			{"Spot Custom Prediction n1-highmem-8 running in europe-west1", true},
-			{"Custom Prediction n2-standard-8 running in asia-east1", true},
-			{"SPOT CUSTOM TRAINING n1-standard-4 RUNNING IN us-central1", true},         // case insensitive
-			{"Custom n1-standard-4 running in us-central1", false},                      // missing Training/Prediction
-			{"Preemptible Custom Training n1-standard-4 running in us-central1", false}, // wrong preemptible prefix
-			{"Gemini 1.5 Flash Input tokens", false},
-		}
-		for _, tc := range cases {
-			assert.Equal(t, tc.match, computeRegex.MatchString(tc.input), "input: %q", tc.input)
-		}
-	})
-
 	t.Run("rerankRegex", func(t *testing.T) {
 		cases := []struct {
 			input string
@@ -344,22 +297,6 @@ func newTokenSKU(description, region, usageUnit string, units int64, nanos int32
 			{
 				PricingExpression: &billingpb.PricingExpression{
 					UsageUnit: usageUnit,
-					TieredRates: []*billingpb.PricingExpression_TierRate{
-						{UnitPrice: &money.Money{Units: units, Nanos: nanos}},
-					},
-				},
-			},
-		},
-	}
-}
-
-func newComputeSKU(description, region string, units int64, nanos int32) *billingpb.Sku {
-	return &billingpb.Sku{
-		Description:    description,
-		ServiceRegions: []string{region},
-		PricingInfo: []*billingpb.PricingInfo{
-			{
-				PricingExpression: &billingpb.PricingExpression{
 					TieredRates: []*billingpb.PricingExpression_TierRate{
 						{UnitPrice: &money.Money{Units: units, Nanos: nanos}},
 					},

--- a/pkg/google/vertex/pricing_map_test.go
+++ b/pkg/google/vertex/pricing_map_test.go
@@ -1,6 +1,7 @@
 package vertex
 
 import (
+	"regexp"
 	"testing"
 
 	"cloud.google.com/go/billing/apiv1/billingpb"
@@ -8,6 +9,21 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/type/money"
 )
+
+func TestParseSkus_FamilyFilterDropsUnmatchedFamilies(t *testing.T) {
+	pm := &PricingMap{logger: testLogger(), familyFilter: regexp.MustCompile(`^google$`)}
+	err := pm.ParseSkus([]*billingpb.Sku{
+		newTokenSKU("Gemini 1.5 Flash Input tokens", "us-central1", "k{char}", 0, 1250000),
+		newTokenSKU("Llama 4 Maverick Input Tokens", "us-central1", "k{char}", 0, 1250000),
+	})
+	require.NoError(t, err)
+
+	snap := pm.Snapshot()
+	// google family is kept.
+	assert.NotNil(t, snap.tokenInput["us-central1"]["gemini-1.5-flash"])
+	// meta family (llama) is dropped before entering the map.
+	assert.Nil(t, snap.tokenInput["us-central1"]["llama-4-maverick"])
+}
 
 func TestParseSkus_TokenInputSKU(t *testing.T) {
 	pm := &PricingMap{logger: testLogger()}

--- a/pkg/google/vertex/pricing_map_test.go
+++ b/pkg/google/vertex/pricing_map_test.go
@@ -5,10 +5,49 @@ import (
 	"testing"
 
 	"cloud.google.com/go/billing/apiv1/billingpb"
+	"github.com/grafana/cloudcost-exporter/pkg/google/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/type/money"
 )
+
+func TestApplyClaudeAccountPrice(t *testing.T) {
+	pm := &PricingMap{logger: testLogger()}
+	snap := pm.buildSnapshot(nil)
+
+	pm.applyClaudeAccountPrice(snap, client.BillingAccountPrice{
+		Description:  "Claude Sonnet 4.6 — Input Tokens — global — Context Window Size from 0 to 200000 Tokens",
+		USDPerUnit:   3,
+		UnitQuantity: 1_000_000,
+	})
+	// Space-munged model name (Opus/Haiku SKUs), long-context band, 1-hour cache write, regional.
+	pm.applyClaudeAccountPrice(snap, client.BillingAccountPrice{
+		Description:  "Claude Opus 4 8 — Input Cache Write Tokens (TTL 3600 seconds) — us-east5 — Context Window Size from 200001 to 1000000 Tokens",
+		USDPerUnit:   10,
+		UnitQuantity: 1_000_000,
+	})
+
+	// $3/1M -> $0.003/1k; model normalized to Sigil's form.
+	assert.InDelta(t, 0.003, snap.tokenInput["global"]["claude-sonnet-4-6"]["on_demand"], 1e-12)
+	// $10/1M -> $0.01/1k; routed to cache-write, tier captures long context + 1h TTL.
+	assert.InDelta(t, 0.01, snap.tokenCacheWrite["us-east5"]["claude-opus-4-8"]["long_context_1h"], 1e-12)
+}
+
+func TestApplyClaudeAccountPrice_FamilyFilterAndBadFormatSkipped(t *testing.T) {
+	pm := &PricingMap{logger: testLogger(), familyFilter: regexp.MustCompile(`^google$`)}
+	snap := pm.buildSnapshot(nil)
+
+	// Filtered family (anthropic) is dropped.
+	pm.applyClaudeAccountPrice(snap, client.BillingAccountPrice{
+		Description: "Claude Sonnet 4.6 — Input Tokens — global — Context Window Size from 0 to 200000 Tokens", USDPerUnit: 3, UnitQuantity: 1_000_000,
+	})
+	// Legacy format without the em-dash structure is skipped, not mis-parsed.
+	pm.applyClaudeAccountPrice(snap, client.BillingAccountPrice{
+		Description: "Claude 3 Haiku Input Tokens", USDPerUnit: 1, UnitQuantity: 1_000_000,
+	})
+
+	assert.Empty(t, snap.tokenInput)
+}
 
 func TestParseSkus_FamilyFilterDropsUnmatchedFamilies(t *testing.T) {
 	pm := &PricingMap{logger: testLogger(), familyFilter: regexp.MustCompile(`^google$`)}

--- a/pkg/google/vertex/vertex.go
+++ b/pkg/google/vertex/vertex.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 	"time"
 
@@ -58,8 +59,9 @@ var (
 
 // Config configures the Vertex AI collector.
 type Config struct {
-	ProjectId string // ProjectId is the auth project; used as the project_id fallback when Projects is empty.
-	Projects  string // Projects is a comma-separated list of projects to emit prices for.
+	ProjectId    string // ProjectId is the auth project; used as the project_id fallback when Projects is empty.
+	Projects     string // Projects is a comma-separated list of projects to emit prices for.
+	FamilyFilter string // FamilyFilter is a regex matched against the family label; only matching families are emitted. Mirrors Bedrock's --aws.bedrock.families.
 }
 
 // Collector collects Vertex AI pricing metrics.
@@ -81,13 +83,18 @@ func New(ctx context.Context, config *Config, logger *slog.Logger, gcpClient cli
 
 	logger = logger.With("collector", subsystem)
 
+	familyFilter, err := regexp.Compile(config.FamilyFilter)
+	if err != nil {
+		return nil, fmt.Errorf("invalid vertex family filter %q: %w", config.FamilyFilter, err)
+	}
+
 	projects := strings.Split(config.Projects, ",")
 	if len(projects) == 1 && projects[0] == "" {
 		logger.LogAttrs(ctx, slog.LevelInfo, "no vertex projects specified, defaulting to project", slog.String("projectId", config.ProjectId))
 		projects = []string{config.ProjectId}
 	}
 
-	pm, err := NewPricingMap(ctx, logger, gcpClient)
+	pm, err := NewPricingMap(ctx, logger, gcpClient, familyFilter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize pricing map: %w", err)
 	}

--- a/pkg/google/vertex/vertex.go
+++ b/pkg/google/vertex/vertex.go
@@ -59,8 +59,7 @@ var (
 
 // Config configures the Vertex AI collector.
 type Config struct {
-	ProjectId    string // ProjectId is the auth project; used as the project_id fallback when Projects is empty.
-	Projects     string // Projects is a comma-separated list of projects to emit prices for.
+	ProjectId    string // ProjectId is the auth project, emitted as the single project_id label (mirrors Bedrock's account_id).
 	FamilyFilter string // FamilyFilter is a regex matched against the family label; only matching families are emitted. Mirrors Bedrock's --aws.bedrock.families.
 }
 
@@ -68,10 +67,10 @@ type Config struct {
 type Collector struct {
 	pricingMap *PricingMap
 	logger     *slog.Logger
-	// projects is the list of project_id label values each price series is emitted under. Vertex
-	// pricing is project-independent, so a price is repeated once per configured project so
-	// downstream rules can join it against per-project usage.
-	projects []string
+	// projectID is the single project_id label value stamped on every series. Vertex pricing is
+	// project-independent, so it carries one billing-scope project like Bedrock's single account_id
+	// rather than duplicating every price across a list of projects.
+	projectID string
 }
 
 // New creates and initialises a Vertex AI Collector.
@@ -86,12 +85,6 @@ func New(ctx context.Context, config *Config, logger *slog.Logger, gcpClient cli
 	familyFilter, err := regexp.Compile(config.FamilyFilter)
 	if err != nil {
 		return nil, fmt.Errorf("invalid vertex family filter %q: %w", config.FamilyFilter, err)
-	}
-
-	projects := strings.Split(config.Projects, ",")
-	if len(projects) == 1 && projects[0] == "" {
-		logger.LogAttrs(ctx, slog.LevelInfo, "no vertex projects specified, defaulting to project", slog.String("projectId", config.ProjectId))
-		projects = []string{config.ProjectId}
 	}
 
 	pm, err := NewPricingMap(ctx, logger, gcpClient, familyFilter)
@@ -117,7 +110,7 @@ func New(ctx context.Context, config *Config, logger *slog.Logger, gcpClient cli
 	return &Collector{
 		pricingMap: pm,
 		logger:     logger,
-		projects:   projects,
+		projectID:  config.ProjectId,
 	}, nil
 }
 
@@ -140,40 +133,36 @@ func (c *Collector) Name() string {
 	return subsystem
 }
 
-// Collect emits Vertex AI pricing metrics. Prices are project-independent, so each series is
-// emitted once per configured project under a project_id label.
+// Collect emits Vertex AI pricing metrics. Prices are project-independent, so every series carries
+// the single project_id (the auth project), mirroring the single account_id on the Bedrock metrics.
 func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
 	snapshot := c.pricingMap.Snapshot()
-	for _, project := range c.projects {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
+	project := c.projectID
 
-		emitTokenCost(ch, vertexTokenCostDesc, project, snapshot.tokenInput, tokenTypeInput)
-		emitTokenCost(ch, vertexTokenCostDesc, project, snapshot.tokenOutput, tokenTypeOutput)
-		emitTokenCost(ch, vertexCharacterCostDesc, project, snapshot.charInput, tokenTypeInput)
-		emitTokenCost(ch, vertexCharacterCostDesc, project, snapshot.charOutput, tokenTypeOutput)
+	emitTokenCost(ch, vertexTokenCostDesc, project, snapshot.tokenInput, tokenTypeInput)
+	emitTokenCost(ch, vertexTokenCostDesc, project, snapshot.tokenOutput, tokenTypeOutput)
+	emitTokenCost(ch, vertexCharacterCostDesc, project, snapshot.charInput, tokenTypeInput)
+	emitTokenCost(ch, vertexCharacterCostDesc, project, snapshot.charOutput, tokenTypeOutput)
 
-		for region, machines := range snapshot.compute {
-			for machineType, useCases := range machines {
-				for useCase, pricing := range useCases {
-					if pricing.OnDemandPerHour > 0 {
-						ch <- prometheus.MustNewConstMetric(vertexComputeCostDesc, prometheus.GaugeValue,
-							pricing.OnDemandPerHour, project, machineType, useCase, region, "on_demand")
-					}
-					if pricing.SpotPerHour > 0 {
-						ch <- prometheus.MustNewConstMetric(vertexComputeCostDesc, prometheus.GaugeValue,
-							pricing.SpotPerHour, project, machineType, useCase, region, "spot")
-					}
+	for region, machines := range snapshot.compute {
+		for machineType, useCases := range machines {
+			for useCase, pricing := range useCases {
+				if pricing.OnDemandPerHour > 0 {
+					ch <- prometheus.MustNewConstMetric(vertexComputeCostDesc, prometheus.GaugeValue,
+						pricing.OnDemandPerHour, project, machineType, useCase, region, "on_demand")
+				}
+				if pricing.SpotPerHour > 0 {
+					ch <- prometheus.MustNewConstMetric(vertexComputeCostDesc, prometheus.GaugeValue,
+						pricing.SpotPerHour, project, machineType, useCase, region, "spot")
 				}
 			}
 		}
+	}
 
-		for region, models := range snapshot.reranking {
-			for model, price := range models {
-				ch <- prometheus.MustNewConstMetric(vertexRerankCostDesc, prometheus.GaugeValue,
-					price, project, region, model, familyFromModelID(model), rerankPriceTier)
-			}
+	for region, models := range snapshot.reranking {
+		for model, price := range models {
+			ch <- prometheus.MustNewConstMetric(vertexRerankCostDesc, prometheus.GaugeValue,
+				price, project, region, model, familyFromModelID(model), rerankPriceTier)
 		}
 	}
 	return ctx.Err()

--- a/pkg/google/vertex/vertex.go
+++ b/pkg/google/vertex/vertex.go
@@ -17,51 +17,75 @@ import (
 const (
 	subsystem            = "gcp_vertex"
 	PriceRefreshInterval = 24 * time.Hour
+
+	// gen_ai_token_type label values. Vertex prices input and output separately; the two are
+	// emitted on one metric distinguished by this label, matching the Bedrock token metric.
+	tokenTypeInput  = "input"
+	tokenTypeOutput = "output"
+
+	// rerankPriceTier is the price_tier value for reranking. The Ranking API is a single flat
+	// rate with no tiering, so the label is constant. It exists to keep price_tier present on
+	// every Vertex metric.
+	rerankPriceTier = "on_demand"
 )
 
 var (
-	vertexTokenInputDesc = utils.GenerateDesc(
-		cloudcostexporter.MetricPrefix, subsystem, utils.InputTokenCostSuffix,
-		"Vertex AI input cost in USD per 1k tokens, for models billed by token. Character-billed models use the character metric.",
-		[]string{"model_id", "family", "region", "price_tier"},
+	// vertexTokenCostDesc carries both input and output token prices, distinguished by
+	// gen_ai_token_type, mirroring the Bedrock token metric. price_tier stays a single composed
+	// label: Vertex pricing has no cross-region tier and composes quota/caching/long-context/
+	// thinking dimensions that do not split cleanly into Bedrock's region_tier/quota_tier.
+	vertexTokenCostDesc = utils.GenerateDesc(
+		cloudcostexporter.MetricPrefix, subsystem, utils.TokenCostSuffix,
+		"Vertex AI cost in USD per 1k tokens, by gen_ai_token_type, for models billed by token. Character-billed models use the character metric.",
+		[]string{"project_id", "region", "gen_ai_request_model", "family", "gen_ai_token_type", "price_tier"},
 	)
-	vertexTokenOutputDesc = utils.GenerateDesc(
-		cloudcostexporter.MetricPrefix, subsystem, utils.OutputTokenCostSuffix,
-		"Vertex AI output cost in USD per 1k tokens, for models billed by token. Character-billed models use the character metric.",
-		[]string{"model_id", "family", "region", "price_tier"},
-	)
-	vertexCharacterInputDesc = utils.GenerateDesc(
-		cloudcostexporter.MetricPrefix, subsystem, utils.CharacterInputCostSuffix,
-		"Vertex AI input character cost in USD per 1k characters (models billed per character, e.g. translation models).",
-		[]string{"model_id", "family", "region", "price_tier"},
-	)
-	vertexCharacterOutputDesc = utils.GenerateDesc(
-		cloudcostexporter.MetricPrefix, subsystem, utils.CharacterOutputCostSuffix,
-		"Vertex AI output character cost in USD per 1k characters (models billed per character, e.g. translation models).",
-		[]string{"model_id", "family", "region", "price_tier"},
+	vertexCharacterCostDesc = utils.GenerateDesc(
+		cloudcostexporter.MetricPrefix, subsystem, utils.CharacterCostSuffix,
+		"Vertex AI cost in USD per 1k characters, by gen_ai_token_type, for models billed per character (e.g. translation models).",
+		[]string{"project_id", "region", "gen_ai_request_model", "family", "gen_ai_token_type", "price_tier"},
 	)
 	vertexComputeCostDesc = utils.GenerateDesc(
 		cloudcostexporter.MetricPrefix, subsystem, utils.InstanceTotalCostSuffix,
 		"Vertex AI custom training and online prediction node cost in USD per hour.",
-		[]string{"machine_type", "use_case", "region", "price_tier"},
+		[]string{"project_id", "machine_type", "use_case", "region", "price_tier"},
 	)
 	vertexRerankCostDesc = utils.GenerateDesc(
 		cloudcostexporter.MetricPrefix, subsystem, utils.SearchUnitCostSuffix,
 		"Vertex AI reranking cost in USD per 1k ranking requests.",
-		[]string{"model_id", "family", "region"},
+		[]string{"project_id", "region", "gen_ai_request_model", "family", "price_tier"},
 	)
 )
+
+// Config configures the Vertex AI collector.
+type Config struct {
+	ProjectId string // ProjectId is the auth project; used as the project_id fallback when Projects is empty.
+	Projects  string // Projects is a comma-separated list of projects to emit prices for.
+}
 
 // Collector collects Vertex AI pricing metrics.
 type Collector struct {
 	pricingMap *PricingMap
 	logger     *slog.Logger
+	// projects is the list of project_id label values each price series is emitted under. Vertex
+	// pricing is project-independent, so a price is repeated once per configured project so
+	// downstream rules can join it against per-project usage.
+	projects []string
 }
 
 // New creates and initialises a Vertex AI Collector.
 // Pricing is fetched at construction time; an error means the collector cannot be used.
-func New(ctx context.Context, logger *slog.Logger, gcpClient client.Client) (*Collector, error) {
+func New(ctx context.Context, config *Config, logger *slog.Logger, gcpClient client.Client) (*Collector, error) {
+	if config.ProjectId == "" {
+		return nil, fmt.Errorf("projectID cannot be empty")
+	}
+
 	logger = logger.With("collector", subsystem)
+
+	projects := strings.Split(config.Projects, ",")
+	if len(projects) == 1 && projects[0] == "" {
+		logger.LogAttrs(ctx, slog.LevelInfo, "no vertex projects specified, defaulting to project", slog.String("projectId", config.ProjectId))
+		projects = []string{config.ProjectId}
+	}
 
 	pm, err := NewPricingMap(ctx, logger, gcpClient)
 	if err != nil {
@@ -86,6 +110,7 @@ func New(ctx context.Context, logger *slog.Logger, gcpClient client.Client) (*Co
 	return &Collector{
 		pricingMap: pm,
 		logger:     logger,
+		projects:   projects,
 	}, nil
 }
 
@@ -96,10 +121,8 @@ func (c *Collector) Register(_ provider.Registry) error {
 
 // Describe implements provider.Collector.
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
-	ch <- vertexTokenInputDesc
-	ch <- vertexTokenOutputDesc
-	ch <- vertexCharacterInputDesc
-	ch <- vertexCharacterOutputDesc
+	ch <- vertexTokenCostDesc
+	ch <- vertexCharacterCostDesc
 	ch <- vertexComputeCostDesc
 	ch <- vertexRerankCostDesc
 	return nil
@@ -110,92 +133,56 @@ func (c *Collector) Name() string {
 	return subsystem
 }
 
-// Collect emits Vertex AI pricing metrics.
+// Collect emits Vertex AI pricing metrics. Prices are project-independent, so each series is
+// emitted once per configured project under a project_id label.
 func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
 	snapshot := c.pricingMap.Snapshot()
-	for region, models := range snapshot.tokenInput {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
+	for _, project := range c.projects {
+		if err := ctx.Err(); err != nil {
+			return err
 		}
-		for model, tiers := range models {
-			for tier, price := range tiers {
-				ch <- prometheus.MustNewConstMetric(vertexTokenInputDesc, prometheus.GaugeValue,
-					price, model, familyFromModelID(model), region, tier)
-			}
-		}
-	}
-	for region, models := range snapshot.tokenOutput {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-		for model, tiers := range models {
-			for tier, price := range tiers {
-				ch <- prometheus.MustNewConstMetric(vertexTokenOutputDesc, prometheus.GaugeValue,
-					price, model, familyFromModelID(model), region, tier)
-			}
-		}
-	}
-	for region, models := range snapshot.charInput {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-		for model, tiers := range models {
-			for tier, price := range tiers {
-				ch <- prometheus.MustNewConstMetric(vertexCharacterInputDesc, prometheus.GaugeValue,
-					price, model, familyFromModelID(model), region, tier)
-			}
-		}
-	}
-	for region, models := range snapshot.charOutput {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-		for model, tiers := range models {
-			for tier, price := range tiers {
-				ch <- prometheus.MustNewConstMetric(vertexCharacterOutputDesc, prometheus.GaugeValue,
-					price, model, familyFromModelID(model), region, tier)
-			}
-		}
-	}
-	for region, machines := range snapshot.compute {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-		for machineType, useCases := range machines {
-			for useCase, pricing := range useCases {
-				if pricing.OnDemandPerHour > 0 {
-					ch <- prometheus.MustNewConstMetric(vertexComputeCostDesc, prometheus.GaugeValue,
-						pricing.OnDemandPerHour, machineType, useCase, region, "on_demand")
-				}
-				if pricing.SpotPerHour > 0 {
-					ch <- prometheus.MustNewConstMetric(vertexComputeCostDesc, prometheus.GaugeValue,
-						pricing.SpotPerHour, machineType, useCase, region, "spot")
+
+		emitTokenCost(ch, vertexTokenCostDesc, project, snapshot.tokenInput, tokenTypeInput)
+		emitTokenCost(ch, vertexTokenCostDesc, project, snapshot.tokenOutput, tokenTypeOutput)
+		emitTokenCost(ch, vertexCharacterCostDesc, project, snapshot.charInput, tokenTypeInput)
+		emitTokenCost(ch, vertexCharacterCostDesc, project, snapshot.charOutput, tokenTypeOutput)
+
+		for region, machines := range snapshot.compute {
+			for machineType, useCases := range machines {
+				for useCase, pricing := range useCases {
+					if pricing.OnDemandPerHour > 0 {
+						ch <- prometheus.MustNewConstMetric(vertexComputeCostDesc, prometheus.GaugeValue,
+							pricing.OnDemandPerHour, project, machineType, useCase, region, "on_demand")
+					}
+					if pricing.SpotPerHour > 0 {
+						ch <- prometheus.MustNewConstMetric(vertexComputeCostDesc, prometheus.GaugeValue,
+							pricing.SpotPerHour, project, machineType, useCase, region, "spot")
+					}
 				}
 			}
 		}
-	}
-	for region, models := range snapshot.reranking {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-		for model, price := range models {
-			ch <- prometheus.MustNewConstMetric(vertexRerankCostDesc, prometheus.GaugeValue,
-				price, model, familyFromModelID(model), region)
+
+		for region, models := range snapshot.reranking {
+			for model, price := range models {
+				ch <- prometheus.MustNewConstMetric(vertexRerankCostDesc, prometheus.GaugeValue,
+					price, project, region, model, familyFromModelID(model), rerankPriceTier)
+			}
 		}
 	}
-	return nil
+	return ctx.Err()
+}
+
+// emitTokenCost emits every region/model/tier price in src under desc, tagged with the project and
+// gen_ai_token_type. Shared by the token and character metrics, which have identical label shapes.
+func emitTokenCost(ch chan<- prometheus.Metric, desc *prometheus.Desc, project string, src map[string]map[string]map[string]float64, tokenType string) {
+	for region, models := range src {
+		for model, tiers := range models {
+			for tier, price := range tiers {
+				ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue,
+					price, project, region, model, familyFromModelID(model), tokenType, tier)
+			}
+		}
+	}
 }
 
 // familyFromModelID derives the model provider family from a normalised model ID.

--- a/pkg/google/vertex/vertex.go
+++ b/pkg/google/vertex/vertex.go
@@ -45,11 +45,6 @@ var (
 		"Vertex AI cost in USD per 1k characters, by gen_ai_token_type, for models billed per character (e.g. translation models).",
 		[]string{"project_id", "region", "gen_ai_request_model", "family", "gen_ai_token_type", "price_tier"},
 	)
-	vertexComputeCostDesc = utils.GenerateDesc(
-		cloudcostexporter.MetricPrefix, subsystem, utils.InstanceTotalCostSuffix,
-		"Vertex AI custom training and online prediction node cost in USD per hour.",
-		[]string{"project_id", "machine_type", "use_case", "region", "price_tier"},
-	)
 	vertexRerankCostDesc = utils.GenerateDesc(
 		cloudcostexporter.MetricPrefix, subsystem, utils.SearchUnitCostSuffix,
 		"Vertex AI reranking cost in USD per 1k ranking requests.",
@@ -123,7 +118,6 @@ func (c *Collector) Register(_ provider.Registry) error {
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
 	ch <- vertexTokenCostDesc
 	ch <- vertexCharacterCostDesc
-	ch <- vertexComputeCostDesc
 	ch <- vertexRerankCostDesc
 	return nil
 }
@@ -143,21 +137,6 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 	emitTokenCost(ch, vertexTokenCostDesc, project, snapshot.tokenOutput, tokenTypeOutput)
 	emitTokenCost(ch, vertexCharacterCostDesc, project, snapshot.charInput, tokenTypeInput)
 	emitTokenCost(ch, vertexCharacterCostDesc, project, snapshot.charOutput, tokenTypeOutput)
-
-	for region, machines := range snapshot.compute {
-		for machineType, useCases := range machines {
-			for useCase, pricing := range useCases {
-				if pricing.OnDemandPerHour > 0 {
-					ch <- prometheus.MustNewConstMetric(vertexComputeCostDesc, prometheus.GaugeValue,
-						pricing.OnDemandPerHour, project, machineType, useCase, region, "on_demand")
-				}
-				if pricing.SpotPerHour > 0 {
-					ch <- prometheus.MustNewConstMetric(vertexComputeCostDesc, prometheus.GaugeValue,
-						pricing.SpotPerHour, project, machineType, useCase, region, "spot")
-				}
-			}
-		}
-	}
 
 	for region, models := range snapshot.reranking {
 		for model, price := range models {

--- a/pkg/google/vertex/vertex.go
+++ b/pkg/google/vertex/vertex.go
@@ -101,6 +101,13 @@ func New(ctx context.Context, config *Config, logger *slog.Logger, gcpClient cli
 	}
 
 	go func() {
+		// Layer in account-scoped Claude prices off the startup path: New returned with the catalog
+		// already populated, so this only adds Claude (skipped when no billing account was resolved).
+		if billingAccount != "" {
+			if err := pm.Populate(ctx); err != nil {
+				logger.Error("failed to load Claude-on-Vertex pricing", "error", err)
+			}
+		}
 		ticker := time.NewTicker(PriceRefreshInterval)
 		defer ticker.Stop()
 		for {

--- a/pkg/google/vertex/vertex.go
+++ b/pkg/google/vertex/vertex.go
@@ -21,8 +21,11 @@ const (
 
 	// gen_ai_token_type label values. Vertex prices input and output separately; the two are
 	// emitted on one metric distinguished by this label, matching the Bedrock token metric.
-	tokenTypeInput  = "input"
-	tokenTypeOutput = "output"
+	// Prompt-cache read/write apply to Claude-on-Vertex SKUs only.
+	tokenTypeInput      = "input"
+	tokenTypeOutput     = "output"
+	tokenTypeCacheRead  = "cache_read"
+	tokenTypeCacheWrite = "cache_write"
 
 	// rerankPriceTier is the price_tier value for reranking. The Ranking API is a single flat
 	// rate with no tiering, so the label is constant. It exists to keep price_tier present on
@@ -82,7 +85,17 @@ func New(ctx context.Context, config *Config, logger *slog.Logger, gcpClient cli
 		return nil, fmt.Errorf("invalid vertex family filter %q: %w", config.FamilyFilter, err)
 	}
 
-	pm, err := NewPricingMap(ctx, logger, gcpClient, familyFilter)
+	// Claude-on-Vertex prices are account-scoped (not in the public catalog). Resolve the billing
+	// account from the auth project so it needs no configuration, the way the AWS collectors derive
+	// the account from STS. Best-effort: if it cannot be resolved, Claude is left unpriced.
+	billingAccount, err := gcpClient.GetProjectBillingAccount(ctx, config.ProjectId)
+	if err != nil {
+		logger.LogAttrs(ctx, slog.LevelWarn, "could not resolve billing account; Claude-on-Vertex pricing will be unavailable",
+			slog.String("projectId", config.ProjectId), slog.String("error", err.Error()))
+		billingAccount = ""
+	}
+
+	pm, err := NewPricingMap(ctx, logger, gcpClient, familyFilter, billingAccount)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize pricing map: %w", err)
 	}
@@ -135,6 +148,8 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 
 	emitTokenCost(ch, vertexTokenCostDesc, project, snapshot.tokenInput, tokenTypeInput)
 	emitTokenCost(ch, vertexTokenCostDesc, project, snapshot.tokenOutput, tokenTypeOutput)
+	emitTokenCost(ch, vertexTokenCostDesc, project, snapshot.tokenCacheRead, tokenTypeCacheRead)
+	emitTokenCost(ch, vertexTokenCostDesc, project, snapshot.tokenCacheWrite, tokenTypeCacheWrite)
 	emitTokenCost(ch, vertexCharacterCostDesc, project, snapshot.charInput, tokenTypeInput)
 	emitTokenCost(ch, vertexCharacterCostDesc, project, snapshot.charOutput, tokenTypeOutput)
 
@@ -166,6 +181,8 @@ func emitTokenCost(ch chan<- prometheus.Metric, desc *prometheus.Desc, project s
 // throughout. Unknown prefixes return "unknown" rather than assuming a provider.
 func familyFromModelID(model string) string {
 	switch {
+	case strings.HasPrefix(model, "claude"):
+		return "anthropic" // Claude-on-Vertex, priced from the account-scoped billing API
 	case strings.HasPrefix(model, "gemini"):
 		return "google"
 	case strings.Contains(model, "gemma"):

--- a/pkg/google/vertex/vertex_test.go
+++ b/pkg/google/vertex/vertex_test.go
@@ -19,6 +19,12 @@ import (
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
+func TestNew_FailsIfProjectIDEmpty(t *testing.T) {
+	_, err := New(t.Context(), &Config{ProjectId: ""}, testLogger(), &stubVertexClient{})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "projectID cannot be empty")
+}
+
 func TestNew_FailsIfPricingInitFails(t *testing.T) {
 	_, err := New(t.Context(), testConfig(), testLogger(),
 		&stubVertexClient{serviceNameErr: fmt.Errorf("billing API down")})

--- a/pkg/google/vertex/vertex_test.go
+++ b/pkg/google/vertex/vertex_test.go
@@ -86,6 +86,36 @@ func TestCollect_StampsSingleAuthProjectID(t *testing.T) {
 	assert.Equal(t, "auth-project", results[0].Labels["project_id"])
 }
 
+func TestCollect_EmitsClaudeOnVertexPrices(t *testing.T) {
+	c, err := New(t.Context(), testConfig(), testLogger(),
+		&stubVertexClient{
+			serviceName:    "services/vertex-ai",
+			billingAccount: "test-account", // resolved from the project; triggers the Claude fetch
+			skus:           []*billingpb.Sku{newTokenSKU("Gemini 1.5 Flash Input tokens", "us-central1", "k{char}", 0, 1250000)},
+			claudePrices: []client.BillingAccountPrice{
+				{Description: "Claude Sonnet 4.6 — Input Tokens — global — Context Window Size from 0 to 200000 Tokens", USDPerUnit: 3, UnitQuantity: 1_000_000},
+				{Description: "Claude Sonnet 4.6 — Input Cache Read Tokens — global — Context Window Size from 0 to 200000 Tokens", USDPerUnit: 0.3, UnitQuantity: 1_000_000},
+			},
+		})
+	require.NoError(t, err)
+
+	results, err := collectVertexMetrics(t, c)
+	require.NoError(t, err)
+
+	// The Claude series carries family=anthropic and the Sigil-matching model slug.
+	claudeInput := findMetric(results, func(m *utils.MetricResult) bool {
+		return m.Labels["family"] == "anthropic" && m.Labels["gen_ai_token_type"] == "input"
+	})
+	require.NotNil(t, claudeInput)
+	assert.Equal(t, "claude-sonnet-4-6", claudeInput.Labels["gen_ai_request_model"])
+	assert.InDelta(t, 0.003, claudeInput.Value, 1e-12)
+
+	cacheRead := metricByLabel(results, "cloudcost_gcp_vertex_usd_per_1k_tokens", "gen_ai_token_type", "cache_read")
+	require.NotNil(t, cacheRead)
+	assert.Equal(t, "claude-sonnet-4-6", cacheRead.Labels["gen_ai_request_model"])
+	assert.InDelta(t, 0.0003, cacheRead.Value, 1e-12)
+}
+
 func TestCollect_EmitsCharacterMetrics(t *testing.T) {
 	c, err := New(t.Context(), testConfig(), testLogger(),
 		&stubVertexClient{
@@ -218,6 +248,9 @@ type stubVertexClient struct {
 	deServiceNameErr error
 	skus             []*billingpb.Sku
 	deSkus           []*billingpb.Sku // Discovery Engine SKUs
+	billingAccount   string           // resolved by GetProjectBillingAccount; empty skips the Claude fetch
+	claudePrices     []client.BillingAccountPrice
+	claudePricesErr  error
 }
 
 func (s *stubVertexClient) GetServiceName(_ context.Context, svc string) (string, error) {
@@ -250,6 +283,14 @@ func (s *stubVertexClient) GetPricing(_ context.Context, svcName string) []*bill
 		return s.deSkus
 	}
 	return s.skus
+}
+
+func (s *stubVertexClient) ListBillingAccountPrices(_ context.Context, _, _ string) ([]client.BillingAccountPrice, error) {
+	return s.claudePrices, s.claudePricesErr
+}
+
+func (s *stubVertexClient) GetProjectBillingAccount(_ context.Context, _ string) (string, error) {
+	return s.billingAccount, nil
 }
 
 func (s *stubVertexClient) GetZones(_ string) ([]*compute.Zone, error) {
@@ -314,6 +355,15 @@ func collectVertexMetrics(t *testing.T, c *Collector) ([]*utils.MetricResult, er
 func metricByName(metrics []*utils.MetricResult, fqName string) *utils.MetricResult {
 	for _, m := range metrics {
 		if m.FqName == fqName {
+			return m
+		}
+	}
+	return nil
+}
+
+func findMetric(metrics []*utils.MetricResult, pred func(*utils.MetricResult) bool) *utils.MetricResult {
+	for _, m := range metrics {
+		if pred(m) {
 			return m
 		}
 	}

--- a/pkg/google/vertex/vertex_test.go
+++ b/pkg/google/vertex/vertex_test.go
@@ -20,21 +20,21 @@ import (
 )
 
 func TestNew_FailsIfPricingInitFails(t *testing.T) {
-	_, err := New(t.Context(), testLogger(),
+	_, err := New(t.Context(), testConfig(), testLogger(),
 		&stubVertexClient{serviceNameErr: fmt.Errorf("billing API down")})
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "failed to initialize pricing map")
 }
 
 func TestNew_FailsIfNoPricingDataReturned(t *testing.T) {
-	_, err := New(t.Context(), testLogger(),
+	_, err := New(t.Context(), testConfig(), testLogger(),
 		&stubVertexClient{serviceName: "services/vertex-ai", skus: nil})
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "failed to initialize pricing map")
 }
 
 func TestCollect_EmitsTokenMetrics(t *testing.T) {
-	c, err := New(t.Context(), testLogger(),
+	c, err := New(t.Context(), testConfig(), testLogger(),
 		&stubVertexClient{
 			serviceName: "services/vertex-ai",
 			skus: []*billingpb.Sku{
@@ -48,25 +48,50 @@ func TestCollect_EmitsTokenMetrics(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 
-	inputMetric := metricByName(results, "cloudcost_gcp_vertex_input_usd_per_1k_tokens")
+	inputMetric := metricByLabel(results, "cloudcost_gcp_vertex_usd_per_1k_tokens", "gen_ai_token_type", "input")
 	require.NotNil(t, inputMetric)
-	assert.Equal(t, "gemini-1.5-flash", inputMetric.Labels["model_id"])
+	assert.Equal(t, testProject, inputMetric.Labels["project_id"])
+	assert.Equal(t, "gemini-1.5-flash", inputMetric.Labels["gen_ai_request_model"])
 	assert.Equal(t, "google", inputMetric.Labels["family"])
 	assert.Equal(t, "us-central1", inputMetric.Labels["region"])
 	assert.Equal(t, "on_demand", inputMetric.Labels["price_tier"])
 	assert.InDelta(t, 0.00125, inputMetric.Value, 1e-9)
 
-	outputMetric := metricByName(results, "cloudcost_gcp_vertex_output_usd_per_1k_tokens")
+	outputMetric := metricByLabel(results, "cloudcost_gcp_vertex_usd_per_1k_tokens", "gen_ai_token_type", "output")
 	require.NotNil(t, outputMetric)
-	assert.Equal(t, "gemini-1.5-flash", outputMetric.Labels["model_id"])
+	assert.Equal(t, testProject, outputMetric.Labels["project_id"])
+	assert.Equal(t, "gemini-1.5-flash", outputMetric.Labels["gen_ai_request_model"])
 	assert.Equal(t, "google", outputMetric.Labels["family"])
 	assert.Equal(t, "us-central1", outputMetric.Labels["region"])
 	assert.Equal(t, "on_demand", outputMetric.Labels["price_tier"])
 	assert.InDelta(t, 0.005, outputMetric.Value, 1e-9)
 }
 
+func TestCollect_EmitsOneSeriesPerProject(t *testing.T) {
+	c, err := New(t.Context(), &Config{ProjectId: "auth-project", Projects: "proj-a,proj-b"}, testLogger(),
+		&stubVertexClient{
+			serviceName: "services/vertex-ai",
+			skus: []*billingpb.Sku{
+				newTokenSKU("Gemini 1.5 Flash Input tokens", "us-central1", "k{char}", 0, 1250000),
+			},
+		})
+	require.NoError(t, err)
+
+	results, err := collectVertexMetrics(t, c)
+	require.NoError(t, err)
+
+	// One input-token SKU emitted once per configured project, with identical prices.
+	a := metricByLabel(results, "cloudcost_gcp_vertex_usd_per_1k_tokens", "project_id", "proj-a")
+	b := metricByLabel(results, "cloudcost_gcp_vertex_usd_per_1k_tokens", "project_id", "proj-b")
+	require.NotNil(t, a)
+	require.NotNil(t, b)
+	assert.InDelta(t, a.Value, b.Value, 1e-9)
+	// The auth project is only a fallback; it is not used when Projects is set.
+	assert.Nil(t, metricByLabel(results, "cloudcost_gcp_vertex_usd_per_1k_tokens", "project_id", "auth-project"))
+}
+
 func TestCollect_EmitsCharacterMetrics(t *testing.T) {
-	c, err := New(t.Context(), testLogger(),
+	c, err := New(t.Context(), testConfig(), testLogger(),
 		&stubVertexClient{
 			serviceName: "services/vertex-ai",
 			skus: []*billingpb.Sku{
@@ -80,17 +105,19 @@ func TestCollect_EmitsCharacterMetrics(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 
-	inputMetric := metricByName(results, "cloudcost_gcp_vertex_input_usd_per_1k_characters")
+	inputMetric := metricByLabel(results, "cloudcost_gcp_vertex_usd_per_1k_characters", "gen_ai_token_type", "input")
 	require.NotNil(t, inputMetric)
-	assert.Equal(t, "translation-llm", inputMetric.Labels["model_id"])
+	assert.Equal(t, testProject, inputMetric.Labels["project_id"])
+	assert.Equal(t, "translation-llm", inputMetric.Labels["gen_ai_request_model"])
 	assert.Equal(t, "google", inputMetric.Labels["family"])
 	assert.Equal(t, "global", inputMetric.Labels["region"])
 	assert.Equal(t, "on_demand", inputMetric.Labels["price_tier"])
 	assert.InDelta(t, 0.05, inputMetric.Value, 1e-9)
 
-	outputMetric := metricByName(results, "cloudcost_gcp_vertex_output_usd_per_1k_characters")
+	outputMetric := metricByLabel(results, "cloudcost_gcp_vertex_usd_per_1k_characters", "gen_ai_token_type", "output")
 	require.NotNil(t, outputMetric)
-	assert.Equal(t, "translation-llm", outputMetric.Labels["model_id"])
+	assert.Equal(t, testProject, outputMetric.Labels["project_id"])
+	assert.Equal(t, "translation-llm", outputMetric.Labels["gen_ai_request_model"])
 	assert.Equal(t, "google", outputMetric.Labels["family"])
 	assert.Equal(t, "global", outputMetric.Labels["region"])
 	assert.Equal(t, "on_demand", outputMetric.Labels["price_tier"])
@@ -126,7 +153,7 @@ func TestFamilyFromModelID(t *testing.T) {
 }
 
 func TestCollect_EmitsComputeMetrics(t *testing.T) {
-	c, err := New(t.Context(), testLogger(),
+	c, err := New(t.Context(), testConfig(), testLogger(),
 		&stubVertexClient{
 			serviceName: "services/vertex-ai",
 			skus: []*billingpb.Sku{
@@ -153,7 +180,7 @@ func TestCollect_EmitsComputeMetrics(t *testing.T) {
 }
 
 func TestCollect_OmitsOnDemandComputeMetricWhenPriceIsZero(t *testing.T) {
-	c, err := New(t.Context(), testLogger(),
+	c, err := New(t.Context(), testConfig(), testLogger(),
 		&stubVertexClient{
 			serviceName: "services/vertex-ai",
 			skus: []*billingpb.Sku{
@@ -170,7 +197,7 @@ func TestCollect_OmitsOnDemandComputeMetricWhenPriceIsZero(t *testing.T) {
 }
 
 func TestCollect_EmitsRerankingMetrics(t *testing.T) {
-	c, err := New(t.Context(), testLogger(),
+	c, err := New(t.Context(), testConfig(), testLogger(),
 		&stubVertexClient{
 			serviceName: "services/vertex-ai",
 			skus: []*billingpb.Sku{
@@ -187,14 +214,16 @@ func TestCollect_EmitsRerankingMetrics(t *testing.T) {
 
 	rerank := metricByName(results, "cloudcost_gcp_vertex_search_unit_usd_per_1k_search_units")
 	require.NotNil(t, rerank)
-	assert.Equal(t, "semantic-ranker-api", rerank.Labels["model_id"])
+	assert.Equal(t, testProject, rerank.Labels["project_id"])
+	assert.Equal(t, "semantic-ranker-api", rerank.Labels["gen_ai_request_model"])
 	assert.Equal(t, "google", rerank.Labels["family"]) // "semantic" prefix maps to google
 	assert.Equal(t, "global", rerank.Labels["region"])
+	assert.Equal(t, "on_demand", rerank.Labels["price_tier"])
 	assert.InDelta(t, 0.001, rerank.Value, 1e-9)
 }
 
 func TestCollect_DiscoveryEngineUnavailable_RerankingOmitted(t *testing.T) {
-	c, err := New(t.Context(), testLogger(),
+	c, err := New(t.Context(), testConfig(), testLogger(),
 		&stubVertexClient{
 			serviceName:      "services/vertex-ai",
 			deServiceNameErr: fmt.Errorf("Discovery Engine Ranking API not found; check that Vertex AI Search is enabled in the GCP project"),
@@ -208,11 +237,11 @@ func TestCollect_DiscoveryEngineUnavailable_RerankingOmitted(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Nil(t, metricByName(results, "cloudcost_gcp_vertex_search_unit_usd_per_1k_search_units"))
-	assert.NotNil(t, metricByName(results, "cloudcost_gcp_vertex_input_usd_per_1k_tokens"))
+	assert.NotNil(t, metricByName(results, "cloudcost_gcp_vertex_usd_per_1k_tokens"))
 }
 
 func TestCollect_ContextCancellation(t *testing.T) {
-	c, err := New(t.Context(), testLogger(),
+	c, err := New(t.Context(), testConfig(), testLogger(),
 		&stubVertexClient{
 			serviceName: "services/vertex-ai",
 			skus: []*billingpb.Sku{
@@ -305,6 +334,12 @@ func (s *stubVertexClient) ListManagedKafkaClusters(_ context.Context, _ string,
 func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
+
+func testConfig() *Config {
+	return &Config{ProjectId: testProject}
+}
+
+const testProject = "test-project"
 
 func collectVertexMetrics(t *testing.T, c *Collector) ([]*utils.MetricResult, error) {
 	t.Helper()

--- a/pkg/google/vertex/vertex_test.go
+++ b/pkg/google/vertex/vertex_test.go
@@ -87,17 +87,22 @@ func TestCollect_StampsSingleAuthProjectID(t *testing.T) {
 }
 
 func TestCollect_EmitsClaudeOnVertexPrices(t *testing.T) {
-	c, err := New(t.Context(), testConfig(), testLogger(),
-		&stubVertexClient{
-			serviceName:    "services/vertex-ai",
-			billingAccount: "test-account", // resolved from the project; triggers the Claude fetch
-			skus:           []*billingpb.Sku{newTokenSKU("Gemini 1.5 Flash Input tokens", "us-central1", "k{char}", 0, 1250000)},
-			claudePrices: []client.BillingAccountPrice{
-				{Description: "Claude Sonnet 4.6 — Input Tokens — global — Context Window Size from 0 to 200000 Tokens", USDPerUnit: 3, UnitQuantity: 1_000_000},
-				{Description: "Claude Sonnet 4.6 — Input Cache Read Tokens — global — Context Window Size from 0 to 200000 Tokens", USDPerUnit: 0.3, UnitQuantity: 1_000_000},
-			},
-		})
+	stub := &stubVertexClient{
+		serviceName:    "services/vertex-ai",
+		billingAccount: "test-account",
+		skus:           []*billingpb.Sku{newTokenSKU("Gemini 1.5 Flash Input tokens", "us-central1", "k{char}", 0, 1250000)},
+		claudePrices: []client.BillingAccountPrice{
+			{Description: "Claude Sonnet 4.6 — Input Tokens — global — Context Window Size from 0 to 200000 Tokens", USDPerUnit: 3, UnitQuantity: 1_000_000},
+			{Description: "Claude Sonnet 4.6 — Input Cache Read Tokens — global — Context Window Size from 0 to 200000 Tokens", USDPerUnit: 0.3, UnitQuantity: 1_000_000},
+		},
+	}
+	// In production the account-scoped Claude prices load off the startup path (New populates the
+	// catalog, then a background refresh adds Claude). Run a full Populate synchronously here so the
+	// Claude prices are deterministically present.
+	pm, err := NewPricingMap(t.Context(), testLogger(), stub, nil, "test-account")
 	require.NoError(t, err)
+	require.NoError(t, pm.Populate(t.Context()))
+	c := &Collector{pricingMap: pm, logger: testLogger(), projectID: testProject}
 
 	results, err := collectVertexMetrics(t, c)
 	require.NoError(t, err)

--- a/pkg/google/vertex/vertex_test.go
+++ b/pkg/google/vertex/vertex_test.go
@@ -67,8 +67,8 @@ func TestCollect_EmitsTokenMetrics(t *testing.T) {
 	assert.InDelta(t, 0.005, outputMetric.Value, 1e-9)
 }
 
-func TestCollect_EmitsOneSeriesPerProject(t *testing.T) {
-	c, err := New(t.Context(), &Config{ProjectId: "auth-project", Projects: "proj-a,proj-b"}, testLogger(),
+func TestCollect_StampsSingleAuthProjectID(t *testing.T) {
+	c, err := New(t.Context(), &Config{ProjectId: "auth-project"}, testLogger(),
 		&stubVertexClient{
 			serviceName: "services/vertex-ai",
 			skus: []*billingpb.Sku{
@@ -80,14 +80,10 @@ func TestCollect_EmitsOneSeriesPerProject(t *testing.T) {
 	results, err := collectVertexMetrics(t, c)
 	require.NoError(t, err)
 
-	// One input-token SKU emitted once per configured project, with identical prices.
-	a := metricByLabel(results, "cloudcost_gcp_vertex_usd_per_1k_tokens", "project_id", "proj-a")
-	b := metricByLabel(results, "cloudcost_gcp_vertex_usd_per_1k_tokens", "project_id", "proj-b")
-	require.NotNil(t, a)
-	require.NotNil(t, b)
-	assert.InDelta(t, a.Value, b.Value, 1e-9)
-	// The auth project is only a fallback; it is not used when Projects is set.
-	assert.Nil(t, metricByLabel(results, "cloudcost_gcp_vertex_usd_per_1k_tokens", "project_id", "auth-project"))
+	// Prices are project-independent: every series carries the single auth project_id (like
+	// Bedrock's single account_id), not a per-project fan-out.
+	require.Len(t, results, 1)
+	assert.Equal(t, "auth-project", results[0].Labels["project_id"])
 }
 
 func TestCollect_EmitsCharacterMetrics(t *testing.T) {

--- a/pkg/google/vertex/vertex_test.go
+++ b/pkg/google/vertex/vertex_test.go
@@ -156,7 +156,8 @@ func TestCollect_EmitsRerankingMetrics(t *testing.T) {
 				newTokenSKU("Gemini 1.5 Flash Input tokens", "us-central1", "k{char}", 0, 1250000),
 			},
 			deSkus: []*billingpb.Sku{
-				newTokenSKU("Semantic Ranker API Ranking Requests", "global", "k{request}", 0, 1000000),
+				// Per-request ("count") price scaled to per-1k: 0.001 -> 1.0.
+				newTokenSKU("Vertex AI Search: Ranking", "global", "count", 0, 1000000),
 			},
 		})
 	require.NoError(t, err)
@@ -167,11 +168,11 @@ func TestCollect_EmitsRerankingMetrics(t *testing.T) {
 	rerank := metricByName(results, "cloudcost_gcp_vertex_search_unit_usd_per_1k_search_units")
 	require.NotNil(t, rerank)
 	assert.Equal(t, testProject, rerank.Labels["project_id"])
-	assert.Equal(t, "semantic-ranker-api", rerank.Labels["gen_ai_request_model"])
+	assert.Equal(t, "semantic-ranker", rerank.Labels["gen_ai_request_model"])
 	assert.Equal(t, "google", rerank.Labels["family"]) // "semantic" prefix maps to google
 	assert.Equal(t, "global", rerank.Labels["region"])
 	assert.Equal(t, "on_demand", rerank.Labels["price_tier"])
-	assert.InDelta(t, 0.001, rerank.Value, 1e-9)
+	assert.InDelta(t, 1.0, rerank.Value, 1e-9)
 }
 
 func TestCollect_DiscoveryEngineUnavailable_RerankingOmitted(t *testing.T) {

--- a/pkg/google/vertex/vertex_test.go
+++ b/pkg/google/vertex/vertex_test.go
@@ -148,50 +148,6 @@ func TestFamilyFromModelID(t *testing.T) {
 	}
 }
 
-func TestCollect_EmitsComputeMetrics(t *testing.T) {
-	c, err := New(t.Context(), testConfig(), testLogger(),
-		&stubVertexClient{
-			serviceName: "services/vertex-ai",
-			skus: []*billingpb.Sku{
-				newComputeSKU("Custom Training n1-standard-4 running in us-central1", "us-central1", 0, 500000000),
-				newComputeSKU("Spot Custom Training n1-standard-4 running in us-central1", "us-central1", 0, 150000000),
-			},
-		})
-	require.NoError(t, err)
-
-	results, err := collectVertexMetrics(t, c)
-	require.NoError(t, err)
-	require.Len(t, results, 2)
-
-	onDemand := metricByLabel(results, "cloudcost_gcp_vertex_instance_total_usd_per_hour", "price_tier", "on_demand")
-	require.NotNil(t, onDemand)
-	assert.Equal(t, "n1-standard-4", onDemand.Labels["machine_type"])
-	assert.Equal(t, "training", onDemand.Labels["use_case"])
-	assert.Equal(t, "us-central1", onDemand.Labels["region"])
-	assert.InDelta(t, 0.5, onDemand.Value, 1e-9)
-
-	spot := metricByLabel(results, "cloudcost_gcp_vertex_instance_total_usd_per_hour", "price_tier", "spot")
-	require.NotNil(t, spot)
-	assert.InDelta(t, 0.15, spot.Value, 1e-9)
-}
-
-func TestCollect_OmitsOnDemandComputeMetricWhenPriceIsZero(t *testing.T) {
-	c, err := New(t.Context(), testConfig(), testLogger(),
-		&stubVertexClient{
-			serviceName: "services/vertex-ai",
-			skus: []*billingpb.Sku{
-				newComputeSKU("Spot Custom Training n1-standard-4 running in us-central1", "us-central1", 0, 150000000),
-			},
-		})
-	require.NoError(t, err)
-
-	results, err := collectVertexMetrics(t, c)
-	require.NoError(t, err)
-
-	assert.Nil(t, metricByLabel(results, "cloudcost_gcp_vertex_instance_total_usd_per_hour", "price_tier", "on_demand"))
-	assert.NotNil(t, metricByLabel(results, "cloudcost_gcp_vertex_instance_total_usd_per_hour", "price_tier", "spot"))
-}
-
 func TestCollect_EmitsRerankingMetrics(t *testing.T) {
 	c, err := New(t.Context(), testConfig(), testLogger(),
 		&stubVertexClient{

--- a/pkg/google/vpc/vpc_test.go
+++ b/pkg/google/vpc/vpc_test.go
@@ -98,6 +98,14 @@ func (m *mockGCPClient) GetPricing(ctx context.Context, serviceName string) []*b
 	return []*billingpb.Sku{} // Return empty SKUs for testing
 }
 
+func (m *mockGCPClient) ListBillingAccountPrices(context.Context, string, string) ([]client.BillingAccountPrice, error) {
+	return nil, nil
+}
+
+func (m *mockGCPClient) GetProjectBillingAccount(context.Context, string) (string, error) {
+	return "", nil
+}
+
 func (m *mockGCPClient) ExportRegionalDiscounts(ctx context.Context, m2 *metrics.Metrics) error {
 	return nil
 }

--- a/pkg/utils/consts.go
+++ b/pkg/utils/consts.go
@@ -27,19 +27,13 @@ const (
 	PersistentVolumeCostPerGiBSuffix = "persistent_volume_usd_per_gib_hour"
 	// RegionUnknown is used as a label value when a region or other attribute cannot be determined.
 	RegionUnknown = "unknown"
-	// InputTokenCostSuffix is the suffix for per-1k-input-token cost metrics.
-	InputTokenCostSuffix = "input_usd_per_1k_tokens"
-	// OutputTokenCostSuffix is the suffix for per-1k-output-token cost metrics.
-	OutputTokenCostSuffix = "output_usd_per_1k_tokens"
 	// TokenCostSuffix is the suffix for per-1k-token cost metrics that carry a token_type label
 	// (input, output, and prompt-cache read/write) instead of encoding direction in the name.
 	TokenCostSuffix = "usd_per_1k_tokens"
-	// CharacterInputCostSuffix is the suffix for per-1k-input-character cost metrics.
-	// Used for models billed per character rather than per token (e.g. translation models).
-	CharacterInputCostSuffix = "input_usd_per_1k_characters"
-	// CharacterOutputCostSuffix is the suffix for per-1k-output-character cost metrics.
-	// Used for models billed per character rather than per token (e.g. translation models).
-	CharacterOutputCostSuffix = "output_usd_per_1k_characters"
+	// CharacterCostSuffix is the suffix for per-1k-character cost metrics that carry a token_type
+	// label (input, output) instead of encoding direction in the name. Used for models billed per
+	// character rather than per token (e.g. translation models).
+	CharacterCostSuffix = "usd_per_1k_characters"
 	// SearchUnitCostSuffix is the suffix for per-1k-search-unit cost metrics (e.g. Cohere Rerank).
 	SearchUnitCostSuffix = "search_unit_usd_per_1k_search_units"
 )


### PR DESCRIPTION
Bring the GCP Vertex collector in line with the AWS Bedrock collector, and price the model the Assistant actually runs on Vertex (Claude).

Closes #1067

## Summary

Experimental Vertex metrics (`--gcp.experimental.services=vertex`).

**Metric shape (#1067)**
- Consolidate the split `_input_`/`_output_` token and character metrics into `cloudcost_gcp_vertex_usd_per_1k_tokens` / `_usd_per_1k_characters`, keyed by `gen_ai_token_type`.
- Rename `model_id` -> `gen_ai_request_model` (matches the Bedrock token metric).
- Single `project_id` label (the auth project), stamped on every series, mirroring Bedrock's single `account_id` from STS. No per-project fan-out (prices are project-independent).

**Family filter**
- `--gcp.vertex.families`, a regex on `family`, mirroring `--aws.bedrock.families`. Default `.*`.

**Focus on model pricing (drop what doesn't map)**
- Remove the `compute` metric: it priced infra nodes (out of scope) and its regex never matched the live catalog, so it emitted zero series.
- Fix reranking: the regex expected `... Ranking Requests`, but the live SKU is `Vertex AI Search: Ranking` (the Semantic Ranker), so it emitted nothing. Match it, label `gen_ai_request_model=semantic-ranker`.
- Skip `AI Dev Tools:` (Agent Builder) SKUs that were leaking into the token metric as junk `ai-dev-tools:-claude-*` models.

**Price Claude on Vertex (`family="anthropic"`)**
- Claude prices are not in the public Cloud Catalog; they are account-scoped. Add a v1beta Cloud Billing client that lists the per-model `Claude ...` services under the project's billing account and reads their **list** prices, with `gen_ai_token_type` including `cache_read`/`cache_write`.
- The billing account is resolved from `--project-id` via `getBillingInfo` (read-only), so no new flag is needed, consistent with the other GCP collectors and with how the AWS collectors derive the account from STS.
- Best-effort: if the billing account can't be resolved or has no Claude SKUs, Claude is left unpriced and the rest still emits. Model slugs match Sigil's `gen_ai_request_model`; regional endpoints carry their own +10% price via the `region` label.

Resulting schema:

```
cloudcost_gcp_vertex_usd_per_1k_tokens{project_id, region, gen_ai_request_model, family, gen_ai_token_type, price_tier}
cloudcost_gcp_vertex_usd_per_1k_characters{project_id, region, gen_ai_request_model, family, gen_ai_token_type, price_tier}
cloudcost_gcp_vertex_search_unit_usd_per_1k_search_units{project_id, region, gen_ai_request_model, family, price_tier}
```

## Why

#1060 simplified the Bedrock token metrics and the labels were later renamed to `gen_ai_request_model` / `gen_ai_token_type`. The Vertex collector predated that and kept the old pattern, so aligning the two simplifies the shared cost recording rules. Claude is the Assistant's Vertex completion model, so pricing it is what makes the price-vs-usage join actually work for Vertex.

`price_tier` stays a single composed label rather than splitting into Bedrock's `region_tier` / `quota_tier`: Vertex has no cross-region inference tier, and `price_tier` composes dimensions that do not decompose cleanly. Documented in `docs/metrics/gcp/vertex.md`.

Experimental metrics, so the schema change carries no backward-compatibility constraint.

## Notes

- Claude list prices come from the account-scoped v1beta API because GCP does not publish them in the public catalog (verified). The collector reads `listPrice`, which is account-independent; only the account's negotiated `contractPrice` would differ, and it is not used.
- The account-scoped fetch adds startup latency proportional to the number of Claude SKUs (one price call each); it runs only when the project's billing account exposes `Claude ...` services.
