### PR TITLE
feat(aws/client): fetch EC2 Capacity Block costs from Cost Explorer

### DIFF
--- a/pkg/aws/client/billing.go
+++ b/pkg/aws/client/billing.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"log/slog"
+	"strconv"
 	"strings"
 	"time"
 
@@ -147,4 +148,129 @@ func getComponentFromKey(key string) string {
 		val += "-" + split[2]
 	}
 	return val
+}
+
+const capacityBlockFeeMarker = "CapacityBlockFee"
+
+// getCapacityBlockCosts fetches the net upfront fees for EC2 Capacity Block for ML
+// reservations from Cost Explorer over [startDate, endDate).
+//
+// Capacity Block fees are booked as one-off charges (RECORD_TYPE=Upfront) under a
+// usage type like "USE2-CapacityBlockFee:p5.48xlarge"; Cost Explorer does not
+// amortize them. We filter server-side to the Upfront and Refund charge types and
+// group by USAGE_TYPE, then sum UnblendedCost per usage type: refunds carry the
+// same usage type as a negative amount, so summing nets out cancelled
+// reservations. Upfront alone would double-count a cancelled-then-refunded block.
+func (b *billing) getCapacityBlockCosts(ctx context.Context, startDate time.Time, endDate time.Time) (*CapacityBlockCosts, error) {
+	slog.Info("Getting capacity block costs", "start", startDate.Format("2006-01-02"), "end", endDate.Format("2006-01-02"))
+	input := &costexplorer.GetCostAndUsageInput{
+		TimePeriod: &types.DateInterval{
+			Start: aws.String(startDate.Format("2006-01-02")),
+			End:   aws.String(endDate.Format("2006-01-02")),
+		},
+		Granularity: types.GranularityDaily,
+		Metrics:     []string{"UnblendedCost"},
+		GroupBy: []types.GroupDefinition{
+			{
+				Type: types.GroupDefinitionTypeDimension,
+				Key:  aws.String("USAGE_TYPE"),
+			},
+		},
+		Filter: &types.Expression{
+			Dimensions: &types.DimensionValues{
+				Key:    types.DimensionRecordType,
+				Values: []string{"Upfront", "Refund"},
+			},
+		},
+	}
+
+	var outputs []*costexplorer.GetCostAndUsageOutput
+	for {
+		b.m.RequestCount.Inc()
+		output, err := b.costExplorerService.GetCostAndUsage(ctx, input)
+		if err != nil {
+			slog.Error("Error getting capacity block costs", "error", err)
+			b.m.RequestErrorsCount.Inc()
+			return nil, err
+		}
+		outputs = append(outputs, output)
+		if output.NextPageToken == nil {
+			break
+		}
+		input.NextPageToken = output.NextPageToken
+	}
+
+	return parseCapacityBlockCosts(outputs), nil
+}
+
+// parseCapacityBlockCosts sums Capacity Block fees per region+instance type across
+// all returned time periods and record types.
+func parseCapacityBlockCosts(outputs []*costexplorer.GetCostAndUsageOutput) *CapacityBlockCosts {
+	costs := &CapacityBlockCosts{Regions: make(map[string]map[string]float64)}
+	for _, output := range outputs {
+		for _, result := range output.ResultsByTime {
+			day := ""
+			if result.TimePeriod != nil && result.TimePeriod.Start != nil {
+				day = *result.TimePeriod.Start
+			}
+			for _, group := range result.Groups {
+				if len(group.Keys) == 0 {
+					continue
+				}
+				usageType := group.Keys[0]
+				region, instanceType, ok := parseCapacityBlockUsageType(usageType)
+				if !ok {
+					slog.Debug("skipping non-capacity-block usage type", "day", day, "usage_type", usageType)
+					continue
+				}
+				metric, ok := group.Metrics["UnblendedCost"]
+				if !ok || metric.Amount == nil {
+					slog.Debug("capacity block group missing UnblendedCost", "day", day, "usage_type", usageType)
+					continue
+				}
+				fee, err := strconv.ParseFloat(*metric.Amount, 64)
+				if err != nil {
+					slog.Warn("error parsing capacity block fee", "usage_type", usageType, "error", err)
+					continue
+				}
+				costs.addFee(region, instanceType, fee)
+				slog.Debug("processed capacity block fee",
+					"day", day,
+					"usage_type", usageType,
+					"region", region,
+					"instance_type", instanceType,
+					"amount_usd", fee,
+					"running_net_usd", costs.Regions[region][instanceType],
+				)
+			}
+		}
+	}
+	return costs
+}
+
+// parseCapacityBlockUsageType parses a Cost Explorer Capacity Block fee usage type
+// (e.g. "USE2-CapacityBlockFee:p5.48xlarge") into its region and instance type.
+// Returns ok=false for usage types that are not Capacity Block fees. Usage types
+// for us-east-1 may omit the region prefix.
+func parseCapacityBlockUsageType(usageType string) (region string, instanceType string, ok bool) {
+	if !strings.Contains(usageType, capacityBlockFeeMarker) {
+		return "", "", false
+	}
+	colon := strings.LastIndex(usageType, ":")
+	if colon < 0 || colon == len(usageType)-1 {
+		return "", "", false
+	}
+	instanceType = usageType[colon+1:]
+
+	// The billing-region prefix, if present, precedes "-CapacityBlockFee".
+	prefixEnd := strings.Index(usageType, "-"+capacityBlockFeeMarker)
+	if prefixEnd <= 0 {
+		// No region prefix: us-east-1 usage types can appear without one.
+		return BillingToRegionMap["US"], instanceType, true
+	}
+	region, ok = BillingToRegionMap[usageType[:prefixEnd]]
+	if !ok {
+		return "", "", false
+	}
+	return region, instanceType, true
 }

--- a/pkg/aws/client/billing_data.go
+++ b/pkg/aws/client/billing_data.go
@@ -134,6 +134,33 @@ type PricingModel struct {
 	Model map[string]*Pricing
 }
 
+// CapacityBlockCosts holds the net upfront fee (USD) paid for EC2 Capacity Block
+// for ML reservations, keyed by region then instance type. Fees are netted across
+// Cost Explorer record types (Upfront minus Refunds) so cancelled or
+// refunded reservations discount out of the total.
+type CapacityBlockCosts struct {
+	// Regions maps a region code to a map of instance type -> net fee in USD.
+	Regions map[string]map[string]float64
+}
+
+// addFee accumulates a fee for a region+instance type. Refunds rows
+// carry negative amounts, so accumulating across record types nets them out.
+func (c *CapacityBlockCosts) addFee(region, instanceType string, fee float64) {
+	if c.Regions[region] == nil {
+		c.Regions[region] = make(map[string]float64)
+	}
+	c.Regions[region][instanceType] += fee
+}
+
+// GetFee returns the net fee for a region+instance type, and whether one exists.
+func (c *CapacityBlockCosts) GetFee(region, instanceType string) (float64, bool) {
+	if c.Regions[region] == nil {
+		return 0, false
+	}
+	fee, ok := c.Regions[region][instanceType]
+	return fee, ok
+}
+
 type Pricing struct {
 	Usage    float64
 	Cost     float64

--- a/pkg/aws/client/billing_integration_test.go
+++ b/pkg/aws/client/billing_integration_test.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
+)
+
+// TestIntegration_getCapacityBlockCosts hits the real Cost Explorer API and prints
+// the net Capacity Block fees it finds. It is skipped unless CE_INTEGRATION=1, so
+// it never runs in CI. Run with AWS creds for an account (or the payer account,
+// which sees all linked accounts) that has Capacity Block fees. Cost Explorer is
+// only reachable via us-east-1.
+//
+//	AWS_PROFILE=management CE_INTEGRATION=1 \
+//	  go test ./pkg/aws/client/ -run TestIntegration_getCapacityBlockCosts -v
+func TestIntegration_getCapacityBlockCosts(t *testing.T) {
+	if os.Getenv("CE_INTEGRATION") != "1" {
+		t.Skip("set CE_INTEGRATION=1 to run against the real Cost Explorer API")
+	}
+
+	// Debug level so the per-row parse/process traces in parseCapacityBlockCosts
+	// are visible.
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	ctx := context.Background()
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion("us-east-1"))
+	if err != nil {
+		t.Fatalf("load AWS config: %v", err)
+	}
+
+	b := newBilling(costexplorer.NewFromConfig(cfg), NewMetrics())
+
+	end := time.Now().UTC()
+	start := end.AddDate(0, 0, -30)
+	costs, err := b.getCapacityBlockCosts(ctx, start, end)
+	if err != nil {
+		t.Fatalf("getCapacityBlockCosts: %v", err)
+	}
+
+	if len(costs.Regions) == 0 {
+		t.Logf("no CapacityBlockFee charges found between %s and %s",
+			start.Format("2006-01-02"), end.Format("2006-01-02"))
+	}
+	for region, byType := range costs.Regions {
+		for instanceType, fee := range byType {
+			t.Logf("region=%s instance_type=%s net_fee_usd=%.2f", region, instanceType, fee)
+		}
+	}
+}

--- a/pkg/aws/client/billing_test.go
+++ b/pkg/aws/client/billing_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
 	"github.com/aws/aws-sdk-go-v2/service/costexplorer/types"
 	"github.com/grafana/cloudcost-exporter/pkg/aws/services/mocks"
@@ -583,4 +584,62 @@ cloudcost_exporter_aws_s3_cost_api_requests_total 1
 			assert.NoError(t, err)
 		})
 	}
+}
+
+func Test_parseCapacityBlockUsageType(t *testing.T) {
+	tests := []struct {
+		usageType    string
+		wantRegion   string
+		wantInstance string
+		wantOK       bool
+	}{
+		{"USE2-CapacityBlockFee:p5.48xlarge", "us-east-2", "p5.48xlarge", true},
+		{"USE1-CapacityBlockFee:p5.48xlarge", "us-east-1", "p5.48xlarge", true},
+		{"CapacityBlockFee:p5.48xlarge", "us-east-1", "p5.48xlarge", true}, // no region prefix -> us-east-1
+		{"USE2-BoxUsage:m7i.large", "", "", false},                         // not a capacity block fee
+		{"ZZZ9-CapacityBlockFee:p5.48xlarge", "", "", false},               // unknown billing region
+		{"USE2-CapacityBlockFee:", "", "", false},                          // missing instance type
+	}
+	for _, tt := range tests {
+		region, instance, ok := parseCapacityBlockUsageType(tt.usageType)
+		assert.Equal(t, tt.wantOK, ok, tt.usageType)
+		assert.Equal(t, tt.wantRegion, region, tt.usageType)
+		assert.Equal(t, tt.wantInstance, instance, tt.usageType)
+	}
+}
+
+func Test_parseCapacityBlockCosts_netsRefunds(t *testing.T) {
+	group := func(usageType, amount string) types.Group {
+		return types.Group{
+			Keys:    []string{usageType},
+			Metrics: map[string]types.MetricValue{"UnblendedCost": {Amount: aws.String(amount)}},
+		}
+	}
+	outputs := []*costexplorer.GetCostAndUsageOutput{
+		{
+			ResultsByTime: []types.ResultByTime{
+				// Day 1: cancelled us-east-2b reservation booked as an upfront fee.
+				{Groups: []types.Group{group("USE2-CapacityBlockFee:p5.48xlarge", "11628.29")}},
+				// Day 2: the real reservation, the refund of the cancelled one, and
+				// an unrelated usage type that must be ignored.
+				{Groups: []types.Group{
+					group("USE2-CapacityBlockFee:p5.48xlarge", "14710.60"),
+					group("USE2-CapacityBlockFee:p5.48xlarge", "-11628.29"),
+					group("USE2-BoxUsage:m7i.large", "5.00"),
+				}},
+			},
+		},
+	}
+
+	costs := parseCapacityBlockCosts(outputs)
+
+	// The cancelled reservation's fee is netted out by its refund, leaving only
+	// the real reservation's fee.
+	fee, ok := costs.GetFee("us-east-2", "p5.48xlarge")
+	assert.True(t, ok)
+	assert.InDelta(t, 14710.60, fee, 0.001)
+
+	// Unrelated usage types are not captured.
+	_, ok = costs.GetFee("us-east-2", "m7i.large")
+	assert.False(t, ok)
 }


### PR DESCRIPTION
## What

Add `getCapacityBlockCosts` to the AWS billing client: it retrieves the net upfront fee for [EC2 Capacity Block for ML](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html) reservations from Cost Explorer, keyed by region and instance type.

This is the cost source for bottom-up modelling of GPU nodes purchased via Capacity Blocks, which the EC2 collector does not price today. Wiring it into the collector follows in a second PR; this one adds and validates the data-fetching layer on its own.

## Changes

- `pkg/aws/client/billing.go` — `getCapacityBlockCosts`, plus `parseCapacityBlockCosts` and `parseCapacityBlockUsageType` helpers.
- `pkg/aws/client/billing_data.go` — `CapacityBlockCosts` type (region → instance type → net USD fee) with `GetFee`.
- `pkg/aws/client/billing_test.go` — unit tests for usage-type parsing and refund-netting.
- `pkg/aws/client/billing_integration_test.go` — gated test that exercises the real Cost Explorer API.

## Testing

- `go test ./pkg/aws/client/` — unit tests cover parsing (region/instance extraction, reject cases) and the refund-netting logic.
- Ran the integration test against a live account with an active Capacity Block reservation; the region/type parsing and day-by-day netting produced the expected net fee, including correct handling of a cancelled reservation being refunded out over time.

```
❯ AWS_PROFILE=management CE_INTEGRATION=1 \
  go test ./pkg/aws/client/ -run TestIntegration_getCapacityBlockCosts -v
=== RUN   TestIntegration_getCapacityBlockCosts
time=2026-07-20T23:53:29.372-07:00 level=INFO msg="Getting capacity block costs" start=2026-06-21 end=2026-07-21
time=2026-07-20T23:53:30.680-07:00 level=DEBUG msg="processed capacity block fee" day=2026-07-09 usage_type=USE2-CapacityBlockFee:p5.48xlarge region=us-east-2 instance_type=p5.48xlarge amount_usd=2674.51 running_net_usd=2674.51
time=2026-07-20T23:53:30.680-07:00 level=DEBUG msg="processed capacity block fee" day=2026-07-10 usage_type=USE2-CapacityBlockFee:p5.48xlarge region=us-east-2 instance_type=p5.48xlarge amount_usd=14710.6 running_net_usd=17385.11
    billing_integration_test.go:52: region=us-east-2 instance_type=p5.48xlarge net_fee_usd=17385.11
```

the **$17,385.11** matches what we see in the billing console for these costs:
<img width="687" height="814" alt="image" src="https://github.com/user-attachments/assets/9c9aad71-adfa-4e67-977c-31e949503687" />


## Follow-ups (not in this PR)

- EC2 collector: a capacity-block pricing map that amortizes the fee over the reservation duration (from `DescribeCapacityReservations`) and emits per-core/per-GiB/total rates under a new `capacityblock` price tier.

## Issue ref
https://github.com/grafana/deployment_tools/issues/648469