### PR TITLE
feat(aws/client): expose GetCapacityBlockCosts on the Client interface

### DIFF
--- a/pkg/aws/client/aws_client.go
+++ b/pkg/aws/client/aws_client.go
@@ -58,6 +58,10 @@ func (c *AWSClient) GetBillingData(ctx context.Context, startDate time.Time, end
 	return c.billing.getBillingData(ctx, startDate, endDate)
 }
 
+func (c *AWSClient) GetCapacityBlockCosts(ctx context.Context, startDate time.Time, endDate time.Time) (*CapacityBlockCosts, error) {
+	return c.billing.getCapacityBlockCosts(ctx, startDate, endDate)
+}
+
 func (c *AWSClient) DescribeRegions(ctx context.Context, allRegions bool) ([]types.Region, error) {
 	return c.computeService.describeRegions(ctx, allRegions)
 }

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -16,6 +16,7 @@ import (
 
 type Client interface {
 	GetBillingData(ctx context.Context, startDate time.Time, endDate time.Time) (*BillingData, error)
+	GetCapacityBlockCosts(ctx context.Context, startDate time.Time, endDate time.Time) (*CapacityBlockCosts, error)
 	DescribeRegions(ctx context.Context, allRegions bool) ([]types.Region, error)
 	ListComputeInstances(ctx context.Context) ([]types.Reservation, error)
 	ListActiveCapacityReservations(ctx context.Context) ([]types.CapacityReservation, error)

--- a/pkg/aws/client/mocks/client.go
+++ b/pkg/aws/client/mocks/client.go
@@ -93,6 +93,21 @@ func (mr *MockClientMockRecorder) GetBillingData(ctx, startDate, endDate any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBillingData", reflect.TypeOf((*MockClient)(nil).GetBillingData), ctx, startDate, endDate)
 }
 
+// GetCapacityBlockCosts mocks base method.
+func (m *MockClient) GetCapacityBlockCosts(ctx context.Context, startDate, endDate time.Time) (*client.CapacityBlockCosts, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCapacityBlockCosts", ctx, startDate, endDate)
+	ret0, _ := ret[0].(*client.CapacityBlockCosts)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCapacityBlockCosts indicates an expected call of GetCapacityBlockCosts.
+func (mr *MockClientMockRecorder) GetCapacityBlockCosts(ctx, startDate, endDate any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCapacityBlockCosts", reflect.TypeOf((*MockClient)(nil).GetCapacityBlockCosts), ctx, startDate, endDate)
+}
+
 // GetRDSUnitData mocks base method.
 func (m *MockClient) GetRDSUnitData(ctx context.Context, instType, region, deploymentOption, engineCode, isOutpost string) (string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/aws/ec2/mock_client_test.go
+++ b/pkg/aws/ec2/mock_client_test.go
@@ -27,6 +27,9 @@ type mockClient struct {
 	// Capacity block fields
 	capacityReservations []ec2Types.CapacityReservation
 	capacityReservErr    error
+
+	capacityBlockCosts *client.CapacityBlockCosts
+	capacityBlockErr   error
 }
 
 func (m *mockClient) ListOnDemandPrices(ctx context.Context, region string) ([]string, error) {
@@ -43,6 +46,10 @@ func (m *mockClient) ListStoragePrices(ctx context.Context, region string) ([]st
 
 func (m *mockClient) GetBillingData(ctx context.Context, startDate time.Time, endDate time.Time) (*client.BillingData, error) {
 	panic("not implemented")
+}
+
+func (m *mockClient) GetCapacityBlockCosts(ctx context.Context, startDate time.Time, endDate time.Time) (*client.CapacityBlockCosts, error) {
+	return m.capacityBlockCosts, m.capacityBlockErr
 }
 
 func (m *mockClient) DescribeRegions(ctx context.Context, allRegions bool) ([]ec2Types.Region, error) {

--- a/pkg/aws/vpc/vpc_test.go
+++ b/pkg/aws/vpc/vpc_test.go
@@ -33,6 +33,11 @@ func (m *MockClient) GetBillingData(ctx context.Context, startDate, endDate time
 	return args.Get(0).(*awsclient.BillingData), args.Error(1)
 }
 
+func (m *MockClient) GetCapacityBlockCosts(ctx context.Context, startDate, endDate time.Time) (*awsclient.CapacityBlockCosts, error) {
+	args := m.Called(ctx, startDate, endDate)
+	return args.Get(0).(*awsclient.CapacityBlockCosts), args.Error(1)
+}
+
 func (m *MockClient) DescribeRegions(ctx context.Context, allRegions bool) ([]ec2Types.Region, error) {
 	args := m.Called(ctx, allRegions)
 	return args.Get(0).([]ec2Types.Region), args.Error(1)


### PR DESCRIPTION
follow-up to: https://github.com/grafana/cloudcost-exporter/pull/1088

## What

Expose `GetCapacityBlockCosts` on the `Client` interface and the `AWSClient` implementation, delegating to the billing service's `getCapacityBlockCosts` added in #1088.

## Why

#1088 added the billing-client method that fetches [EC2 Capacity Block for ML](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html) fees from Cost Explorer, but it was unexported and only reachable internally. This PR promotes it onto the `Client` interface so collectors can call it. 

## Changes

- `pkg/aws/client/client.go` — add `GetCapacityBlockCosts` to the `Client` interface.
- `pkg/aws/client/aws_client.go` — `AWSClient` passthrough delegating to `billing.getCapacityBlockCosts`.
- `pkg/aws/client/mocks/client.go` — regenerated (`make generate`) for the new interface method.
- `pkg/aws/ec2/mock_client_test.go`, `pkg/aws/vpc/vpc_test.go` — extend the hand-written mocks so they still satisfy `Client` (the ec2 mock also gains an injectable field the pricing-map tests will use).

## Testing

Pure plumbing — no behavior change and no metric change. `make generate` + `go test ./pkg/aws/...` pass; adding the interface method is covered by the mocks compiling and existing tests remaining green.

## Issue ref
https://github.com/grafana/deployment_tools/issues/648469
