### PR TITLE
feat(aws/ec2): add CapacityBlockPricingMap

### DIFF
--- a/pkg/aws/ec2/capacity_block_integration_test.go
+++ b/pkg/aws/ec2/capacity_block_integration_test.go
@@ -1,0 +1,72 @@
+package ec2
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
+	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/grafana/cloudcost-exporter/pkg/aws/client"
+)
+
+// TestIntegration_generateCapacityBlockPricingMap builds the pricing map against
+// the real AWS APIs (Cost Explorer for the fee, DescribeCapacityReservations for
+// duration/count) and prints the amortized per-instance-hour prices it collects.
+// Skipped unless CB_INTEGRATION=1.
+//
+// DescribeCapacityReservations is per-account and regional, so use creds for the
+// account that owns the reservation and set the region where the block lives.
+// Cost Explorer is account-global and only reachable via us-east-1, which the
+// test configures separately (mirroring the production client wiring):
+//
+//	AWS_PROFILE=<profile> AWS_REGION=us-east-2 CB_INTEGRATION=1 \
+//	  go test ./pkg/aws/ec2/ -run TestIntegration_generateCapacityBlockPricingMap -v
+func TestIntegration_generateCapacityBlockPricingMap(t *testing.T) {
+	if os.Getenv("CB_INTEGRATION") != "1" {
+		t.Skip("set CB_INTEGRATION=1 to run against the real AWS APIs")
+	}
+
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	ctx := context.Background()
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		t.Fatalf("load AWS config: %v", err)
+	}
+	region := cfg.Region
+	if region == "" {
+		t.Fatal("no region configured; set AWS_REGION to where the Capacity Block lives")
+	}
+	// Cost Explorer is only reachable via us-east-1, regardless of the EC2 region.
+	globalCfg, err := config.LoadDefaultConfig(ctx, config.WithRegion("us-east-1"))
+	if err != nil {
+		t.Fatalf("load global AWS config: %v", err)
+	}
+
+	awsClient := client.NewAWSClient(client.Config{
+		EC2Service:     awsec2.NewFromConfig(cfg),
+		BillingService: costexplorer.NewFromConfig(globalCfg),
+	})
+
+	m := NewCapacityBlockPricingMap(slog.Default(), &Config{
+		Regions:   []ec2Types.Region{{RegionName: aws.String(region)}},
+		RegionMap: map[string]client.Client{region: awsClient},
+	})
+
+	if err := m.GenerateCapacityBlockPricingMap(ctx); err != nil {
+		t.Fatalf("GenerateCapacityBlockPricingMap: %v", err)
+	}
+
+	if len(m.Reservations) == 0 {
+		t.Logf("no capacity block prices found (check region/account; the reservation may have expired)")
+	}
+	for id, rate := range m.Reservations {
+		t.Logf("reservation_id=%s usd_per_instance_hour=%.4f", id, rate)
+	}
+}

--- a/pkg/aws/ec2/capacity_block_pricing_map.go
+++ b/pkg/aws/ec2/capacity_block_pricing_map.go
@@ -1,0 +1,195 @@
+package ec2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	"github.com/grafana/cloudcost-exporter/pkg/aws/client"
+)
+
+var ErrCapacityBlockPriceNotFound = errors.New("no capacity block price found")
+
+// CapacityBlockPricingMap holds the amortized hourly price of EC2 Capacity Block
+// for ML instances, keyed by capacity reservation ID. The value is USD per
+// instance-hour.
+//
+// Attribution is per-reservation: Cost Explorer keys the upfront fee only by region+type,
+// but it dates the fee to the reservation's StartDate, so each active reservation is
+// matched to the fee on its own StartDate day. This avoids smearing fees across renewed,
+// expired, or concurrent same-type blocks — each instance is priced from its own
+// reservation's fee via the instance's CapacityReservationId.
+type CapacityBlockPricingMap struct {
+	// Reservations maps a capacity reservation ID -> USD per instance-hour.
+	Reservations map[string]float64
+	m            sync.RWMutex
+	logger       *slog.Logger
+	cfgRegions   []ec2Types.Region
+	regionMap    map[string]client.Client
+}
+
+func NewCapacityBlockPricingMap(l *slog.Logger, config *Config) *CapacityBlockPricingMap {
+	return &CapacityBlockPricingMap{
+		Reservations: make(map[string]float64),
+		m:            sync.RWMutex{},
+		logger:       l.With("subsystem", "capacityBlockPricing"),
+		cfgRegions:   config.Regions,
+		regionMap:    config.RegionMap,
+	}
+}
+
+// reservationPricing holds the per-reservation inputs needed to price a block.
+type reservationPricing struct {
+	id            string
+	region        string
+	instanceType  string
+	startDay      time.Time // StartDate truncated to the UTC day
+	instanceHours float64   // TotalInstanceCount * (EndDate - StartDate)
+}
+
+// GenerateCapacityBlockPricingMap prices each active Capacity Block reservation
+// as fee / (instance_count * block_hours), keyed by reservation ID.
+//
+// The fee comes from Cost Explorer, dated to the reservation's StartDate, so we
+// query a one-day window on that day per reservation. Reservations that share a
+// region+type+StartDate day are grouped and split proportionally by
+// instance-hours, since Cost Explorer reports one summed fee for them (it exposes
+// no reservation ID at that granularity).
+func (m *CapacityBlockPricingMap) GenerateCapacityBlockPricingMap(ctx context.Context) error {
+	m.logger.LogAttrs(ctx, slog.LevelInfo, "Refreshing capacity block pricing map")
+
+	feeClient := m.billingClient()
+	if feeClient == nil {
+		return ErrClientNotFound
+	}
+
+	// Collect active capacity-block reservations across all configured regions.
+	// DescribeCapacityReservations is regional, so each region client is queried.
+	var reservations []reservationPricing
+	for _, region := range m.cfgRegions {
+		regionClient, ok := m.regionMap[*region.RegionName]
+		if !ok {
+			return ErrClientNotFound
+		}
+		active, err := regionClient.ListActiveCapacityReservations(ctx)
+		if err != nil {
+			return fmt.Errorf("listing capacity reservations in %s: %w", *region.RegionName, err)
+		}
+		for _, r := range active {
+			if rp, ok := newReservationPricing(r); ok {
+				reservations = append(reservations, rp)
+			}
+		}
+	}
+
+	// Group by region+type+StartDate day: Cost Explorer reports one summed fee
+	// for reservations that share these, so they must be priced together.
+	type groupKey struct {
+		region       string
+		instanceType string
+		day          string
+	}
+	groups := make(map[groupKey][]reservationPricing)
+	for _, r := range reservations {
+		k := groupKey{r.region, r.instanceType, r.startDay.Format("2006-01-02")}
+		groups[k] = append(groups[k], r)
+	}
+
+	newRates := make(map[string]float64)
+	for key, group := range groups {
+		// Fee is dated to StartDate; a one-day window on that UTC day isolates it.
+		start := group[0].startDay
+		end := start.AddDate(0, 0, 1)
+		fees, err := feeClient.GetCapacityBlockCosts(ctx, start, end)
+		if err != nil {
+			m.logger.Error("failed to fetch capacity block fee",
+				"region", key.region, "instance_type", key.instanceType, "start", key.day, "error", err)
+			continue
+		}
+		fee, ok := fees.GetFee(key.region, key.instanceType)
+		if !ok {
+			m.logger.Warn("active capacity reservation has no fee in Cost Explorer, skipping",
+				"region", key.region, "instance_type", key.instanceType, "start", key.day)
+			continue
+		}
+
+		var totalInstanceHours float64
+		for _, r := range group {
+			totalInstanceHours += r.instanceHours
+		}
+		if totalInstanceHours <= 0 {
+			continue
+		}
+		// Proportional split across the group reduces to a shared per-instance-hour
+		// rate; totals are preserved regardless of the split.
+		rate := fee / totalInstanceHours
+		if len(group) > 1 {
+			m.logger.Warn("multiple capacity reservations share region+type+start day; splitting fee by instance-hours",
+				"region", key.region, "instance_type", key.instanceType, "start", key.day, "reservations", len(group))
+		}
+		for _, r := range group {
+			newRates[r.id] = rate
+			m.logger.Debug("computed capacity block rate",
+				"reservation_id", r.id, "region", key.region, "instance_type", key.instanceType,
+				"usd_per_instance_hour", rate, "fee_usd", fee, "group_instance_hours", totalInstanceHours)
+		}
+	}
+
+	m.m.Lock()
+	m.Reservations = newRates
+	m.m.Unlock()
+	return nil
+}
+
+// newReservationPricing extracts the pricing inputs from a reservation, or
+// ok=false if any required field is missing or the duration is non-positive.
+func newReservationPricing(r ec2Types.CapacityReservation) (reservationPricing, bool) {
+	if r.CapacityReservationId == nil || r.InstanceType == nil || r.AvailabilityZone == nil ||
+		r.StartDate == nil || r.EndDate == nil || r.TotalInstanceCount == nil {
+		return reservationPricing{}, false
+	}
+	az := *r.AvailabilityZone
+	if len(az) < 2 {
+		return reservationPricing{}, false
+	}
+	hours := r.EndDate.Sub(*r.StartDate).Hours()
+	if hours <= 0 {
+		return reservationPricing{}, false
+	}
+	s := r.StartDate.UTC()
+	return reservationPricing{
+		id:           *r.CapacityReservationId,
+		region:       az[:len(az)-1], // strip the AZ letter (e.g. us-east-2a -> us-east-2)
+		instanceType: *r.InstanceType,
+		startDay:     time.Date(s.Year(), s.Month(), s.Day(), 0, 0, 0, 0, time.UTC),
+		// instance-hours = count * duration; the fee is amortized across all of them.
+		instanceHours: hours * float64(*r.TotalInstanceCount),
+	}, true
+}
+
+// billingClient returns the client used for the account-global Cost Explorer
+// call. Every region client is configured with the same Cost Explorer service,
+// so the first configured region's client is used deterministically.
+func (m *CapacityBlockPricingMap) billingClient() client.Client {
+	if len(m.cfgRegions) == 0 {
+		return nil
+	}
+	return m.regionMap[*m.cfgRegions[0].RegionName]
+}
+
+// GetPriceForReservation returns the amortized USD per instance-hour for a
+// capacity reservation, matched from a running instance's CapacityReservationId.
+func (m *CapacityBlockPricingMap) GetPriceForReservation(reservationID string) (float64, error) {
+	m.m.RLock()
+	defer m.m.RUnlock()
+	rate, ok := m.Reservations[reservationID]
+	if !ok {
+		return 0, ErrCapacityBlockPriceNotFound
+	}
+	return rate, nil
+}

--- a/pkg/aws/ec2/capacity_block_pricing_map_test.go
+++ b/pkg/aws/ec2/capacity_block_pricing_map_test.go
@@ -1,0 +1,97 @@
+package ec2
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/cloudcost-exporter/pkg/aws/client"
+)
+
+func newTestCapacityBlockPricingMap(region string, mc *mockClient) *CapacityBlockPricingMap {
+	return NewCapacityBlockPricingMap(slog.Default(), &Config{
+		Regions:   []ec2Types.Region{{RegionName: aws.String(region)}},
+		RegionMap: map[string]client.Client{region: mc},
+	})
+}
+
+// start returns a fixed StartDate and the matching EndDate for a duration.
+func startEnd(durationHours float64) (time.Time, time.Time) {
+	start := time.Date(2026, 7, 10, 17, 16, 0, 0, time.UTC)
+	return start, start.Add(time.Duration(durationHours) * time.Hour)
+}
+
+func TestGenerateCapacityBlockPricingMap_pricesPerReservation(t *testing.T) {
+	start, end := startEnd(336) // 14 days
+
+	mc := &mockClient{
+		capacityBlockCosts: &client.CapacityBlockCosts{
+			Regions: map[string]map[string]float64{"us-east-2": {"p5.48xlarge": 14710.60}},
+		},
+		capacityReservations: []ec2Types.CapacityReservation{
+			{
+				CapacityReservationId: aws.String("cr-1"),
+				InstanceType:          aws.String("p5.48xlarge"),
+				AvailabilityZone:      aws.String("us-east-2a"),
+				TotalInstanceCount:    aws.Int32(1),
+				StartDate:             &start,
+				EndDate:               &end,
+			},
+		},
+	}
+
+	m := newTestCapacityBlockPricingMap("us-east-2", mc)
+	require.NoError(t, m.GenerateCapacityBlockPricingMap(context.Background()))
+
+	got, err := m.GetPriceForReservation("cr-1")
+	assert.NoError(t, err)
+	assert.InDelta(t, 14710.60/336.0, got, 0.0001)
+}
+
+func TestGenerateCapacityBlockPricingMap_splitsSameDaySameTypeReservations(t *testing.T) {
+	start, end := startEnd(100)
+
+	// Two reservations sharing region+type+StartDate day: CE reports one summed
+	// fee, split proportionally by instance-hours (2 * 100h = 200h).
+	mc := &mockClient{
+		capacityBlockCosts: &client.CapacityBlockCosts{
+			Regions: map[string]map[string]float64{"us-east-2": {"p5.48xlarge": 2000.0}},
+		},
+		capacityReservations: []ec2Types.CapacityReservation{
+			{CapacityReservationId: aws.String("cr-a"), InstanceType: aws.String("p5.48xlarge"), AvailabilityZone: aws.String("us-east-2a"), TotalInstanceCount: aws.Int32(1), StartDate: &start, EndDate: &end},
+			{CapacityReservationId: aws.String("cr-b"), InstanceType: aws.String("p5.48xlarge"), AvailabilityZone: aws.String("us-east-2b"), TotalInstanceCount: aws.Int32(1), StartDate: &start, EndDate: &end},
+		},
+	}
+
+	m := newTestCapacityBlockPricingMap("us-east-2", mc)
+	require.NoError(t, m.GenerateCapacityBlockPricingMap(context.Background()))
+
+	for _, id := range []string{"cr-a", "cr-b"} {
+		got, err := m.GetPriceForReservation(id)
+		assert.NoError(t, err, id)
+		assert.InDelta(t, 2000.0/200.0, got, 0.0001, id)
+	}
+}
+
+func TestGenerateCapacityBlockPricingMap_skipsReservationWithoutFee(t *testing.T) {
+	start, end := startEnd(336)
+
+	mc := &mockClient{
+		capacityBlockCosts: &client.CapacityBlockCosts{Regions: map[string]map[string]float64{}}, // no fees
+		capacityReservations: []ec2Types.CapacityReservation{
+			{CapacityReservationId: aws.String("cr-1"), InstanceType: aws.String("p5.48xlarge"), AvailabilityZone: aws.String("us-east-2a"), TotalInstanceCount: aws.Int32(1), StartDate: &start, EndDate: &end},
+		},
+	}
+
+	m := newTestCapacityBlockPricingMap("us-east-2", mc)
+	require.NoError(t, m.GenerateCapacityBlockPricingMap(context.Background()))
+
+	_, err := m.GetPriceForReservation("cr-1")
+	assert.ErrorIs(t, err, ErrCapacityBlockPriceNotFound)
+}


### PR DESCRIPTION
Follow-up to #1089

## What

Add `CapacityBlockPricingMap`, which amortizes the upfront fee of an active [EC2 Capacity Block for ML](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-blocks.html) reservation into a per-instance-hour price, **keyed by capacity reservation ID**:

```
price = fee / (instance_count * block_hours)
```

## How it works

- Collect active capacity-block reservations (`ListActiveCapacityReservations`).
- For each, query Cost Explorer with a **1-day window on the reservation's `StartDate`** (verified: AWS dates the upfront fee to the start day) → the fee for that reservation.
- `rate = fee / (TotalInstanceCount × (EndDate − StartDate))`, stored per `CapacityReservationId`.
- Reservations sharing region + type + `StartDate` day are grouped and split proportionally by instance-hours (Cost Explorer reports one summed fee for them, with no reservation ID at that granularity); a warning is logged. Totals are preserved regardless of the split.
- Reservations with no matching fee yet (e.g. a block whose charge hasn't landed) are skipped.

## Changes

- `pkg/aws/ec2/capacity_block_pricing_map.go` — `CapacityBlockPricingMap`, `GenerateCapacityBlockPricingMap`, `GetPriceForReservation`.
- `pkg/aws/ec2/capacity_block_pricing_map_test.go` — per-reservation pricing, same-day proportional split, no-fee skip.
- `pkg/aws/ec2/capacity_block_integration_test.go` — `CB_INTEGRATION`-gated check against the real Cost Explorer + `DescribeCapacityReservations` APIs.

## Testing

`go test ./pkg/aws/ec2/` passes. Unit tests cover the amortization, the same-day split, and the no-fee skip. The integration test was run against a live account with an active reservation to confirm the real fee/duration/price line up.

```
❯ AWS_PROFILE=workloads-dev AWS_REGION=us-east-2 CB_INTEGRATION=1 \
go test ./pkg/aws/ec2/ -run TestIntegration_generateCapacityBlockPricingMap -v
=== RUN   TestIntegration_generateCapacityBlockPricingMap
time=2026-07-21T15:37:56.191-07:00 level=INFO msg="Refreshing capacity block pricing map" subsystem=capacityBlockPricing
time=2026-07-21T15:37:57.542-07:00 level=INFO msg="Getting capacity block costs" start=2026-07-10 end=2026-07-11
time=2026-07-21T15:37:58.743-07:00 level=DEBUG msg="processed capacity block fee" day=2026-07-10 usage_type=USE2-CapacityBlockFee:p5.48xlarge region=us-east-2 instance_type=p5.48xlarge amount_usd=14710.6 running_net_usd=14710.6
time=2026-07-21T15:37:58.743-07:00 level=DEBUG msg="computed capacity block rate" subsystem=capacityBlockPricing reservation_id=cr-0cec8e86ef4d83d5f region=us-east-2 instance_type=p5.48xlarge usd_per_instance_hour=41.52799473040369 fee_usd=14710.6 group_instance_hours=354.23333333333335
    capacity_block_integration_test.go:70: reservation_id=cr-0cec8e86ef4d83d5f usd_per_instance_hour=41.5280
--- PASS: TestIntegration_generateCapacityBlockPricingMap (2.55s)
```
The integration test shows the total fee for the one active instance as **$14,710**, properly computed the reservation duration of ~14 days, 18hrs to (14 * 24) + 18 = **354.23hrs**

This matches the information we got when the purchase was made:
<img width="269" height="178" alt="image" src="https://github.com/user-attachments/assets/038a02cb-14b9-4567-b52a-d2378cc2fb72" />

The price per hour was then calculated to $14,710 / 354.23hrs = **$41.527/hr**

## Issue ref
https://github.com/grafana/deployment_tools/issues/648469