### PR TITLE
feat(aws/ec2): add GPU cost dimension to instance pricing

### DIFF
--- a/docs/metrics/aws/ec2.md
+++ b/docs/metrics/aws/ec2.md
@@ -5,6 +5,7 @@
 | cloudcost_aws_ec2_instance_cpu_usd_per_core_hour   | Gauge       | The processing cost of a EC2 Compute Instance in USD/(core*h) | `account_id`=&lt;AWS account ID&gt; <br/> `cluster_name`=&lt;name of the cluster the instance is associated with, if it exists. Can be empty&gt; <br/> `instance`=&lt;name of the compute instance&gt; <br/> `instance_id`=&lt;The unique id associated with the compute instance&gt; <br/> `region`=&lt;AWS region code&gt; <br/> `family`=&lt;broader compute family (General Purpose, Compute Optimized, Memory Optimized, ...) &gt; <br/> `machine_type`=&lt;specific machine type, e.g.: m7a.large&gt; <br/>  `price_tier`=&lt;spot|ondemand|capacityblock&gt; `architecture`=&lt;arm64\|x86_64 &gt; |
 | cloudcost_aws_ec2_instance_memory_usd_per_gib_hour | Gauge       | The memory cost of a EC2 Compute Instance in USD/(GiB*h)       | `account_id`=&lt;AWS account ID&gt; <br/> `cluster_name`=&lt;name of the cluster the instance is associated with, if it exists. Can be empty&gt; <br/> `instance`=&lt;name of the compute instance&gt; <br/> `instance_id`=&lt;The unique id associated with the compute instance&gt; <br/> `region`=&lt;AWS region code&gt; <br/> `family`=&lt;broader compute family (General Purpose, Compute Optimized, Memory Optimized, ...)  &gt; <br/> `machine_type`=&lt;specific machine type, e.g.: m7a.large&gt; <br/>  `price_tier`=&lt;spot|ondemand|capacityblock&gt; `architecture`=&lt;arm64\|x86_64 &gt;                                     |
 | cloudcost_aws_ec2_instance_total_usd_per_hour      | Gauge       | The total cost of an EC2 Compute Instance in USD/*h)           | `account_id`=&lt;AWS account ID&gt; <br/> `cluster_name`=&lt;name of the cluster the instance is associated with, if it exists. Can be empty&gt; <br/> `instance`=&lt;name of the compute instance&gt; <br/> `instance_id`=&lt;The unique id associated with the compute instance&gt; <br/> `region`=&lt;AWS region code&gt; <br/> `family`=&lt;broader compute family (General Purpose, Compute Optimized, Memory Optimized, ...)  &gt; <br/> `machine_type`=&lt;specific machine type, e.g.: m7a.large&gt; <br/>  `price_tier`=&lt;spot|ondemand|capacityblock&gt; `architecture`=&lt;arm64\|x86_64 &gt;                                     |
+| cloudcost_aws_ec2_instance_gpu_usd_per_gpu_hour    | Gauge       | The GPU cost of a EC2 Compute Instance in USD/(gpu*h). Emitted only for instances with accelerators. | `account_id`=&lt;AWS account ID&gt; <br/> `cluster_name`=&lt;name of the cluster the instance is associated with, if it exists. Can be empty&gt; <br/> `instance`=&lt;name of the compute instance&gt; <br/> `instance_id`=&lt;The unique id associated with the compute instance&gt; <br/> `region`=&lt;AWS region code&gt; <br/> `family`=&lt;broader compute family (GPU instance, ...)&gt; <br/> `machine_type`=&lt;specific machine type, e.g.: p5.48xlarge&gt; <br/>  `price_tier`=&lt;spot|ondemand|capacityblock&gt; `architecture`=&lt;arm64\|x86_64 &gt; |
 
 ## EBS Metrics
 
@@ -20,6 +21,14 @@ There are a few assumptions that we're making specific to Grafana Labs:
 1. All costs are in USD
 2. Only consider Linux based instances
 3. `cloudcost-exporter` emits the list price and does not take into account any discounts or savings plans
+
+### GPU instances
+
+For instances with accelerators, the total is split three ways instead of two: a fixed fraction (`gpuCostRatio`, currently `0.70`) is attributed to the GPUs, and the remainder is split across CPU and memory with the same family ratio used for non-GPU instances. The GPU count comes from the pricing product's `gpu` attribute.
+
+- `cloudcost_aws_ec2_instance_gpu_usd_per_gpu_hour` is emitted **only** when the instance type has GPUs; CPU-only instances emit no GPU series.
+- The total is preserved regardless of the split: `gpu * gpu_count + cpu * vcpus + memory * gib == total`.
+- `gpuCostRatio` is an imperfect approximation, matching the existing CPU/memory ratio approach. It was derived from AWS list prices: pricing a p5.48xlarge's CPU and memory at the marginal per-vCPU and per-GiB rates of comparable non-GPU instances accounts for ~30% of its hourly cost, leaving ~0.70 for the accelerators. It is tuned to p-series (training) GPUs; g-series inference GPUs skew lower. It moves the bulk of a GPU node's cost onto the GPU dimension so per-team attribution can key on GPU requests rather than CPU/memory.
 
 ### Capacity Blocks for ML
 

--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -46,6 +46,13 @@ var (
 		"The memory cost of a ec2 instance in USD/(GiB*h)",
 		[]string{"account_id", "instance", "instance_id", "region", "family", "machine_type", "cluster_name", "price_tier", "architecture"},
 	)
+	InstanceGPUHourlyCostDesc = utils.GenerateDesc(
+		cloudcostexporter.MetricPrefix,
+		subsystem,
+		utils.InstanceGPUCostSuffix,
+		"The gpu cost of a ec2 instance in USD/(gpu*h)",
+		[]string{"account_id", "instance", "instance_id", "region", "family", "machine_type", "cluster_name", "price_tier", "architecture"},
+	)
 	InstanceTotalHourlyCostDesc = utils.GenerateDesc(
 		cloudcostexporter.MetricPrefix,
 		subsystem,
@@ -341,14 +348,20 @@ func (c *Collector) processInstance(instance ec2Types.Instance, ch chan<- promet
 	ch <- prometheus.MustNewConstMetric(InstanceCPUHourlyCostDesc, prometheus.GaugeValue, price.Cpu, labelValues...)
 	ch <- prometheus.MustNewConstMetric(InstanceMemoryHourlyCostDesc, prometheus.GaugeValue, price.Ram, labelValues...)
 	ch <- prometheus.MustNewConstMetric(InstanceTotalHourlyCostDesc, prometheus.GaugeValue, price.Total, labelValues...)
+	// Only GPU instances carry a GPU rate; emit it to avoid zero-valued series for
+	// the vast majority of instance types that have no accelerators.
+	if price.Gpu > 0 {
+		ch <- prometheus.MustNewConstMetric(InstanceGPUHourlyCostDesc, prometheus.GaugeValue, price.Gpu, labelValues...)
+	}
 }
 
 // capacityBlockPrice returns the amortized price of a Capacity Block instance,
-// weighting the per-instance-hour total into CPU and RAM with the same ratio
-// model as on-demand/spot so the per-core/per-GiB metrics the bottom-up cost
-// model consumes are populated. If instance attributes are unavailable (no
+// weighting the per-instance-hour total into GPU, CPU and RAM with the same ratio
+// model as on-demand/spot so the per-gpu/per-core/per-GiB metrics the bottom-up
+// cost model consumes are populated. Capacity blocks are GPU instances, so the
+// GPU share carries most of the cost. If instance attributes are unavailable (no
 // on-demand price to source vCPU/memory from), the total is still emitted with
-// zero CPU/RAM split rather than dropping the instance.
+// zero GPU/CPU/RAM split rather than dropping the instance.
 func (c *Collector) capacityBlockPrice(reservationID, instanceType string) (*Prices, error) {
 	if c.capacityBlockPricingMap == nil {
 		return nil, ErrCapacityBlockPriceNotFound
@@ -367,7 +380,7 @@ func (c *Collector) capacityBlockPrice(reservationID, instanceType string) (*Pri
 		c.logger.Debug(fmt.Sprintf("could not weight capacity block price for %s: %s", instanceType, err))
 		return &Prices{Total: total}, nil
 	}
-	return &Prices{Cpu: weighted.Cpu, Ram: weighted.Ram, Total: total}, nil
+	return &Prices{Cpu: weighted.Cpu, Gpu: weighted.Gpu, Ram: weighted.Ram, Total: total}, nil
 }
 
 func (c *Collector) emitMetricsFromVolumesChannel(volumesCh chan []ec2Types.Volume, ch chan<- prometheus.Metric) {
@@ -441,6 +454,7 @@ func (c *Collector) processVolume(volume ec2Types.Volume, ch chan<- prometheus.M
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
 	ch <- InstanceCPUHourlyCostDesc
 	ch <- InstanceMemoryHourlyCostDesc
+	ch <- InstanceGPUHourlyCostDesc
 	ch <- InstanceTotalHourlyCostDesc
 	ch <- PersistentVolumeHourlyCostDesc
 	return nil

--- a/pkg/aws/ec2/ec2_test.go
+++ b/pkg/aws/ec2/ec2_test.go
@@ -543,15 +543,85 @@ func TestCollector_Collect_CapacityBlock(t *testing.T) {
 		close(ch)
 	}()
 
-	var total *utils.MetricResult
+	var total, gpu *utils.MetricResult
 	for metric := range ch {
 		m := utils.ReadMetrics(metric)
-		if m.FqName == "cloudcost_aws_ec2_instance_total_usd_per_hour" {
+		switch m.FqName {
+		case "cloudcost_aws_ec2_instance_total_usd_per_hour":
 			total = m
+		case "cloudcost_aws_ec2_instance_gpu_usd_per_gpu_hour":
+			gpu = m
 		}
 	}
 	require.NotNil(t, total, "expected a total cost metric for the capacity block instance")
+	assert.Nil(t, gpu, "m5.large has no GPUs, so no gpu metric should be emitted")
 	assert.Equal(t, "capacityblock", total.Labels["price_tier"])
 	// 1000 USD / (1 instance * 100h) = 10 USD/instance-hour.
 	assert.InDelta(t, 10.0, total.Value, 0.0001)
+}
+
+func TestCollector_Collect_GPU(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	regions := []ec2Types.Region{{RegionName: aws.String("us-east-1")}}
+
+	c := mock_client.NewMockClient(ctrl)
+	c.EXPECT().ListSpotPrices(gomock.Any()).
+		DoAndReturn(func(ctx context.Context) ([]ec2Types.SpotPrice, error) {
+			return []ec2Types.SpotPrice{}, nil
+		}).MinTimes(1)
+	// A GPU instance: the pricing product carries gpu="8" for the 8 accelerators.
+	// On-demand price is 8.0 USD/hr for round numbers.
+	c.EXPECT().ListOnDemandPrices(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, region string) ([]string, error) {
+			return []string{
+				`{"product":{"productFamily":"Compute Instance","attributes":{"memory":"2048 GiB","vcpu":"192","gpu":"8","regionCode":"us-east-1","instanceFamily":"GPU instance","operatingSystem":"Linux","instanceType":"p5.48xlarge","tenancy":"Shared","usagetype":"BoxUsage:p5.48xlarge","marketoption":"OnDemand"}},"serviceCode":"AmazonEC2","terms":{"OnDemand":{"O.JRTCKXETXF":{"priceDimensions":{"O.JRTCKXETXF.6YS6EN2CT7":{"unit":"Hrs","pricePerUnit":{"USD":"8.0000000000"}}}}}}}`,
+			}, nil
+		}).MinTimes(1)
+	c.EXPECT().ListStoragePrices(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, region string) ([]string, error) {
+			return []string{}, nil
+		}).MinTimes(1)
+	c.EXPECT().ListComputeInstances(gomock.Any()).
+		DoAndReturn(func(ctx context.Context) ([]ec2Types.Reservation, error) {
+			return []ec2Types.Reservation{{Instances: []ec2Types.Instance{{
+				InstanceId:     aws.String("i-gpu"),
+				InstanceType:   ec2Types.InstanceType("p5.48xlarge"),
+				PrivateDnsName: aws.String("ip-10-0-0-2.ec2.internal"),
+				Placement:      &ec2Types.Placement{AvailabilityZone: aws.String("us-east-1a")},
+			}}}}, nil
+		}).Times(1)
+	c.EXPECT().ListEBSVolumes(gomock.Any()).
+		DoAndReturn(func(ctx context.Context) ([]ec2Types.Volume, error) { return nil, nil }).Times(1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	collector, err := New(ctx, &Config{
+		Regions:        regions,
+		ScrapeInterval: time.Minute,
+		AccountID:      "123456789012",
+		RegionMap:      map[string]client.Client{"us-east-1": c},
+	}, logger)
+	require.NoError(t, err)
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		require.NoError(t, collector.Collect(t.Context(), ch))
+		close(ch)
+	}()
+
+	metrics := map[string]*utils.MetricResult{}
+	for metric := range ch {
+		m := utils.ReadMetrics(metric)
+		metrics[m.FqName] = m
+	}
+
+	gpu := metrics["cloudcost_aws_ec2_instance_gpu_usd_per_gpu_hour"]
+	require.NotNil(t, gpu, "expected a gpu cost metric for the GPU instance")
+	assert.Equal(t, "ondemand", gpu.Labels["price_tier"])
+	assert.Equal(t, "p5.48xlarge", gpu.Labels["machine_type"])
+	// gpuCostRatio (0.88) of the 8.0 total, spread over 8 GPUs = 0.88 USD/gpu-hour.
+	assert.InDelta(t, 8.0*gpuCostRatio/8, gpu.Value, 1e-9)
+	// Total is preserved regardless of the split.
+	require.NotNil(t, metrics["cloudcost_aws_ec2_instance_total_usd_per_hour"])
+	assert.InDelta(t, 8.0, metrics["cloudcost_aws_ec2_instance_total_usd_per_hour"].Value, 1e-9)
 }

--- a/pkg/aws/ec2/ec2_test.go
+++ b/pkg/aws/ec2/ec2_test.go
@@ -619,9 +619,21 @@ func TestCollector_Collect_GPU(t *testing.T) {
 	require.NotNil(t, gpu, "expected a gpu cost metric for the GPU instance")
 	assert.Equal(t, "ondemand", gpu.Labels["price_tier"])
 	assert.Equal(t, "p5.48xlarge", gpu.Labels["machine_type"])
-	// gpuCostRatio (0.88) of the 8.0 total, spread over 8 GPUs = 0.88 USD/gpu-hour.
+	// gpuCostRatio of the 8.0 total, spread over 8 GPUs.
 	assert.InDelta(t, 8.0*gpuCostRatio/8, gpu.Value, 1e-9)
-	// Total is preserved regardless of the split.
-	require.NotNil(t, metrics["cloudcost_aws_ec2_instance_total_usd_per_hour"])
-	assert.InDelta(t, 8.0, metrics["cloudcost_aws_ec2_instance_total_usd_per_hour"].Value, 1e-9)
+
+	cpu := metrics["cloudcost_aws_ec2_instance_cpu_usd_per_core_hour"]
+	mem := metrics["cloudcost_aws_ec2_instance_memory_usd_per_gib_hour"]
+	total := metrics["cloudcost_aws_ec2_instance_total_usd_per_hour"]
+	require.NotNil(t, cpu)
+	require.NotNil(t, mem)
+	require.NotNil(t, total)
+	// The remaining (1-gpuCostRatio) is split cpu/ram by the default 0.65 ratio
+	// ("GPU instance" family is not in cpuToCostRatio).
+	assert.InDelta(t, 8.0*(1-gpuCostRatio)*0.65/192, cpu.Value, 1e-9)
+	assert.InDelta(t, 8.0*(1-gpuCostRatio)*0.35/2048, mem.Value, 1e-9)
+	// The headline invariant: the split preserves the total exactly.
+	// gpu*gpus + cpu*vcpus + ram*gib == total.
+	assert.InDelta(t, 8.0, total.Value, 1e-9)
+	assert.InDelta(t, total.Value, gpu.Value*8+cpu.Value*192+mem.Value*2048, 1e-9)
 }

--- a/pkg/aws/ec2/pricing_map.go
+++ b/pkg/aws/ec2/pricing_map.go
@@ -17,6 +17,15 @@ import (
 
 const (
 	defaultInstanceFamily = "General purpose"
+	// gpuCostRatio is the fraction of a GPU instance's total cost attributed to its
+	// accelerators; the remainder is split across cpu/ram with cpuToCostRatio. Like
+	// cpuToCostRatio it's an imperfect approximation. It was derived from AWS list
+	// prices: pricing a p5.48xlarge's cpu+ram at the marginal $/vCPU and $/GiB of
+	// comparable non-GPU instances accounts for ~30% of its hourly cost, leaving ~0.70
+	// for the 8 H100s. Tuned to p-series (training) GPUs; g-series inference GPUs skew
+	// lower and would need a per-type ratio. The total is preserved regardless of the
+	// split.
+	gpuCostRatio = 0.70
 )
 
 var (
@@ -57,9 +66,11 @@ type FamilyPricing struct {
 	Family map[string]*Prices // Each Family can have many PriceTiers
 }
 
-// ComputePrices holds the price of a ec2 instances CPU and RAM. The price is in USD
+// ComputePrices holds the price of a ec2 instances CPU, GPU and RAM. The price is in USD.
+// Gpu is per-GPU-hour and is only non-zero for instance types with accelerators.
 type Prices struct {
 	Cpu   float64
+	Gpu   float64
 	Ram   float64
 	Total float64
 }
@@ -441,6 +452,7 @@ func (cpm *ComputePricingMap) AddToComputePricingMap(price float64, attribute In
 	}
 	cpm.Regions[attribute.Region].Family[attribute.InstanceType] = &Prices{
 		Cpu:   weightedPrice.Cpu,
+		Gpu:   weightedPrice.Gpu,
 		Ram:   weightedPrice.Ram,
 		Total: price,
 	}
@@ -473,10 +485,36 @@ func weightedPriceForInstance(price float64, attributes InstanceAttributes) (*Pr
 		ratio = cpuToCostRatio[defaultInstanceFamily]
 	}
 
+	// Carve the GPU share off the total first, then split the remainder across
+	// cpu/ram with the family ratio. Non-GPU instances (gpus == 0) keep the
+	// original two-way split. The total is preserved either way:
+	//   gpu*gpus + cpu*cpus + ram*ram == price
+	gpuPrice := 0.0
+	remaining := price
+	if gpus := gpuCountFromAttributes(attributes); gpus > 0 {
+		gpuPrice = price * gpuCostRatio / gpus
+		remaining = price * (1 - gpuCostRatio)
+	}
+
 	return &Prices{
-		Cpu: price * ratio / cpus,
-		Ram: price * (1 - ratio) / ram,
+		Gpu: gpuPrice,
+		Cpu: remaining * ratio / cpus,
+		Ram: remaining * (1 - ratio) / ram,
 	}, nil
+}
+
+// gpuCountFromAttributes parses the GPU count from the pricing product's gpu
+// attribute. Non-GPU instance types carry no gpu attribute, so an empty or
+// unparseable value yields 0.
+func gpuCountFromAttributes(attributes InstanceAttributes) float64 {
+	if attributes.GPU == "" {
+		return 0
+	}
+	gpus, err := strconv.ParseFloat(attributes.GPU, 64)
+	if err != nil {
+		return 0
+	}
+	return gpus
 }
 
 func (cpm *ComputePricingMap) GetPriceForInstanceType(region string, instanceType string) (*Prices, error) {
@@ -537,6 +575,7 @@ type InstanceAttributes struct {
 	Region            string `json:"regionCode"`
 	InstanceType      string `json:"instanceType"`
 	VCPU              string `json:"vcpu"`
+	GPU               string `json:"gpu"`
 	Memory            string `json:"memory"`
 	InstanceFamily    string `json:"instanceFamily"`
 	PhysicalProcessor string `json:"physicalProcessor"`

--- a/pkg/aws/ec2/pricing_map.go
+++ b/pkg/aws/ec2/pricing_map.go
@@ -46,6 +46,11 @@ var cpuToCostRatio = map[string]float64{
 	"Memory optimized":  0.48,
 	"General purpose":   0.65,
 	"Storage optimized": 0.48,
+	// GPU instances report instanceFamily "GPU instance". The gpu share is carved
+	// out first (see gpuCostRatio); this only splits the cpu/ram remainder, for
+	// which the General purpose default is fine. Listed explicitly so GPU
+	// instances don't log a "no ratio found, defaulting" warn on every refresh.
+	"GPU instance": 0.65,
 }
 
 // ComputePricingMap collects a map of FamilyPricing structs where the key is the region

--- a/pkg/aws/ec2/pricing_map_test.go
+++ b/pkg/aws/ec2/pricing_map_test.go
@@ -491,6 +491,49 @@ func Test_weightedPriceForInstance(t *testing.T) {
 				Ram: 0.35,
 			},
 		},
+		"GPU instance carves the gpu share off the total, splitting the remainder cpu/ram": {
+			// gpuCostRatio (0.88) of the total goes to the 8 GPUs; the remaining 0.12
+			// splits by the default ratio (GPU instance family is not in cpuToCostRatio).
+			price: 1.0,
+			attributes: InstanceAttributes{
+				VCPU:           "1",
+				Memory:         "1 GiB",
+				GPU:            "8",
+				InstanceFamily: "GPU instance",
+			},
+			want: &Prices{
+				Gpu: 1.0 * gpuCostRatio / 8,
+				Cpu: 1.0 * (1 - gpuCostRatio) * 0.65,
+				Ram: 1.0 * (1 - gpuCostRatio) * 0.35,
+			},
+		},
+		"GPU instance with a single accelerator": {
+			price: 1.0,
+			attributes: InstanceAttributes{
+				VCPU:           "2",
+				Memory:         "4 GiB",
+				GPU:            "1",
+				InstanceFamily: "GPU instance",
+			},
+			want: &Prices{
+				Gpu: 1.0 * gpuCostRatio / 1,
+				Cpu: 1.0 * (1 - gpuCostRatio) * 0.65 / 2,
+				Ram: 1.0 * (1 - gpuCostRatio) * 0.35 / 4,
+			},
+		},
+		"A gpu count of zero is treated as a non-gpu instance": {
+			price: 1.0,
+			attributes: InstanceAttributes{
+				VCPU:           "1",
+				Memory:         "1 GiB",
+				GPU:            "0",
+				InstanceFamily: "General purpose",
+			},
+			want: &Prices{
+				Cpu: 0.65,
+				Ram: 0.35,
+			},
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -500,7 +543,12 @@ func Test_weightedPriceForInstance(t *testing.T) {
 				return
 			}
 			assert.NoError(t, err)
-			assert.Equal(t, tt.want, got)
+			// Prices are computed floats; compare with a tight tolerance rather than
+			// exact equality to avoid constant-folding vs runtime-rounding mismatches.
+			assert.InDelta(t, tt.want.Gpu, got.Gpu, 1e-9)
+			assert.InDelta(t, tt.want.Cpu, got.Cpu, 1e-9)
+			assert.InDelta(t, tt.want.Ram, got.Ram, 1e-9)
+			assert.InDelta(t, tt.want.Total, got.Total, 1e-9)
 		})
 	}
 }

--- a/pkg/aws/ec2/pricing_map_test.go
+++ b/pkg/aws/ec2/pricing_map_test.go
@@ -492,7 +492,7 @@ func Test_weightedPriceForInstance(t *testing.T) {
 			},
 		},
 		"GPU instance carves the gpu share off the total, splitting the remainder cpu/ram": {
-			// gpuCostRatio (0.88) of the total goes to the 8 GPUs; the remaining 0.12
+			// gpuCostRatio (0.70) of the total goes to the 8 GPUs; the remaining 0.30
 			// splits by the default ratio (GPU instance family is not in cpuToCostRatio).
 			price: 1.0,
 			attributes: InstanceAttributes{

--- a/pkg/utils/consts.go
+++ b/pkg/utils/consts.go
@@ -19,6 +19,8 @@ const (
 	InstanceCPUCostSuffix = "instance_cpu_usd_per_core_hour"
 	// InstanceMemoryCostSuffix is the suffix for per-GiB-hour memory cost metrics.
 	InstanceMemoryCostSuffix = "instance_memory_usd_per_gib_hour"
+	// InstanceGPUCostSuffix is the suffix for per-GPU-hour GPU cost metrics.
+	InstanceGPUCostSuffix = "instance_gpu_usd_per_gpu_hour"
 	// InstanceTotalCostSuffix is the suffix for total per-hour instance cost metrics.
 	InstanceTotalCostSuffix = "instance_total_usd_per_hour"
 	// PersistentVolumeCostSuffix is the suffix for per-hour EBS volume cost metrics.


### PR DESCRIPTION
## What

Adds a GPU cost dimension to the EC2 collector: a new metric `cloudcost_aws_ec2_instance_gpu_usd_per_gpu_hour`, emitted per GPU for instances that have accelerators.

GPU machine costs are currently allocated as CPU/memory costs, causing these workloads to be under-attributed. A per-GPU rate enables accurate attribution based on GPU requests - which make up the bulk of the pricing for these machines.

## How it works

- `weightedPriceForInstance` now carves a fixed fraction of the instance total (`gpuCostRatio`, `0.70`) to the GPUs, then splits the remainder across cpu/ram with the existing family ratio. The total is preserved exactly:
  `gpu * gpu_count + cpu * vcpus + ram * gib == total`.
- GPU count comes from the pricing product's `gpu` attribute (added to `InstanceAttributes`). No new API call or IAM permission.
- The metric is emitted **only when `gpu_count > 0`**, so CPU-only instances (the vast majority) don't get a zero-valued series.
- Applies across all price tiers: on-demand, spot, and capacity block.

## The gpuCostRatio

Like the existing `cpuToCostRatio`, it's an imperfect approximation.

Deriving per-vCPU and per-GiB rates from comparable non-GPU AMD instances (same vCPU count, differing only in memory) and pricing a p5.48xlarge's cpu+ram at those rates accounts for ~30% of its hourly cost, leaving 70% for the 8 accelerators. 

Example:
- [f2.48xlarge](https://instances.vantage.sh/aws/ec2/f2.48xlarge?currency=USD): 
  - vCPUs: 192
  - Memory (GiB): 2048
  - GPU: 0
  - On Demand pricing: $15.84/hr
- [p5.48xlarge](https://instances.vantage.sh/aws/ec2/p5.48xlarge?currency=USD) 
  - vCPUs: 192
  - Memory (GiB): 2048
  - GPU: 8
  - On Demand pricing: $55.04/hr

The main technical difference between these machine types are the GPUs in the `p5.48xlarge`.
Price difference we can attribute to GPUs: $55.04 - $15.84 = **$39.2**

GPU price as a percentage of total: $39.2 / $55.04 ≈ **70%**

## Testing

- `Test_weightedPriceForInstance` gains multi-GPU, single-GPU, and gpu_count=0 cases (assertions use `InDelta` for the computed floats).
- `TestCollector_Collect_GPU` drives a p5.48xlarge through the collector and asserts the gpu metric is emitted at `total * gpuCostRatio / 8` with the total preserved; a non-GPU capacity-block instance asserts no gpu series (covering the emission gate).
- `go build`, `go vet`, `golangci-lint`, and the full `go test ./...` pass.

Running the `/metrics` server locally
```
❯ curl localhost:8080/metrics | grep capacityblock
cloudcost_aws_ec2_instance_cpu_usd_per_core_hour{<<instance_details>>, price_tier="capacityblock"} 0.042176869648066245

cloudcost_aws_ec2_instance_gpu_usd_per_gpu_hour{<<instance_details>>, price_tier="capacityblock"} 3.6336995389103226

cloudcost_aws_ec2_instance_memory_usd_per_gib_hour{<<instance_details>>, price_tier="capacityblock"} 0.002129120823580267

cloudcost_aws_ec2_instance_total_usd_per_hour{<<instance_details>>, price_tier="capacityblock"} 41.52799473040369
```

Looking at the reported price based on the ratio identified, `gpu` should account for 70% of the cost.
- Reported cost per hour: **$41.53**
- Reported cost per gpu/hour: **$3.63**
- Number of gpus in this instance: **8**
- GPU cost per hour for this instance: $3.63 x 8 = **$29.04**

GPU cost as a percent of total cost: $29.04 / $41.53 ≈ **70%**

## Issue ref
https://github.com/grafana/deployment_tools/issues/662578
