### PR TITLE
perf(aws/rds): pricing and inventory in a background store

### DIFF
--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -91,7 +91,7 @@ func providerFlags(fs *flag.FlagSet, cfg *config.Config) {
 	flag.StringVar(&cfg.Providers.AWS.Region, "aws.region", "", "AWS region")
 	flag.StringVar(&cfg.Providers.AWS.RoleARN, "aws.roleARN", "", "Optional AWS role ARN to assume for cross-account access.")
 	fs.StringVar(&cfg.Providers.AWS.BedrockFamilyFilter, "aws.bedrock.families", ".*", "Regex matched against the Bedrock model family label. Only matching families are emitted.")
-	flag.DurationVar(&cfg.Providers.AWS.RDSRegionListTimeout, "aws.rds.region-timeout", 0, "Per-region timeout for listing RDS instances. 0 (default) bounds each region only by -collector-interval. Set a positive value (e.g. 15s) to fail slow or unreachable regions fast and protect scrape availability.")
+	flag.DurationVar(&cfg.Providers.AWS.RDSRegionListTimeout, "aws.rds.region-timeout", 0, "Per-region timeout for the background RDS refresh (listing plus pricing). 0 (default) uses an internal safety ceiling. Set a positive value (e.g. 15s) to fail slow or unreachable regions faster.")
 	fs.BoolVar(&cfg.Providers.AWS.CapacityBlocks, "aws.ec2.capacity-blocks", false, "Price EC2 Capacity Block for ML reservations. Requires ce:GetCostAndUsage on the EC2 role; off by default since it adds Cost Explorer calls and only applies to accounts that purchase Capacity Blocks.")
 	// TODO - PUT PROJECT-ID UNDER GCP
 	flag.StringVar(&cfg.ProjectID, "project-id", "", "Project ID to target.")

--- a/docs/metrics/aws/rds.md
+++ b/docs/metrics/aws/rds.md
@@ -8,7 +8,7 @@
 
 | Metric name                                      | Metric type | Description                                                              | Labels                                                                                                                              |
 |--------------------------------------------------|-------------|-------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| cloudcost_exporter_aws_rds_populate_errors_total | Counter     | Errors during background store population, by store, region, and operation | `store`=&lt;always `instances`&gt; <br/> `region`=&lt;AWS region&gt; <br/> `operation`=&lt;`lookup_client`, `list_instances`, `get_pricing`, `validate_pricing`&gt; |
+| cloudcost_exporter_aws_rds_populate_errors_total | Counter     | Errors during background store population by store, region, and operation | `store`=&lt;always `instances`&gt; <br/> `region`=&lt;AWS region&gt; <br/> `operation`=&lt;`lookup_client`, `list_instances`, `get_pricing`, `validate_pricing`&gt; |
 
 ## Overview
 

--- a/docs/metrics/aws/rds.md
+++ b/docs/metrics/aws/rds.md
@@ -4,9 +4,17 @@
 |------------------------------------------------|-------------|--------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
 | cloudcost_aws_rds_hourly_rate_usd_per_hour     | Gauge       | Hourly cost of AWS RDS instances by region, tier, and instance ID. Cost represented in USD/hour | `account_id`=&lt;AWS account ID&gt; <br/> `region`=&lt;AWS region&gt; <br/> `tier`=&lt;RDS instance tier&gt; <br/> `id`=&lt;RDS instance ID&gt; <br/> `arn_name`=&lt;RDS instance ARN name&gt; |
 
+### Operational Metrics
+
+| Metric name                                      | Metric type | Description                                                              | Labels                                                                                                                              |
+|--------------------------------------------------|-------------|-------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| cloudcost_exporter_aws_rds_populate_errors_total | Counter     | Errors during background store population, by store, region, and operation | `store`=&lt;always `instances`&gt; <br/> `region`=&lt;AWS region&gt; <br/> `operation`=&lt;`lookup_client`, `list_instances`, `get_pricing`, `validate_pricing`&gt; |
+
 ## Overview
 
 The RDS collector exports pricing metrics for Amazon Relational Database Service instances across all configured AWS regions. It collects hourly pricing rates for RDS database instances based on their instance type and tier.
+
+Instance inventory (`DescribeDBInstances`) and pricing (`GetProducts`) are refreshed in the background on a ticker rather than on the Prometheus scrape path. A scrape reads the warm cache and makes zero AWS calls, so scrape latency no longer tracks AWS API latency or a cold pricing map. Warming starts at startup, so there is a short cold-start gap: no metrics emit until the first background refresh finishes. When a refresh fails to warm a price for an instance, that instance is skipped and `cloudcost_exporter_aws_rds_populate_errors_total` is incremented; the scrape still succeeds.
 
 ## Configuration
 
@@ -23,15 +31,15 @@ Or via command line:
 --aws.services=ec2,s3,rds
 ```
 
-### Per-region list timeout
+### Per-region Timeout
 
-The collector queries `DescribeDBInstances` in each region concurrently. `--aws.rds.region-timeout` bounds each region's call:
+The background refresh queries `DescribeDBInstances` and pricing in each region concurrently. `--aws.rds.region-timeout` bounds each region's work:
 
 ```bash
 --aws.rds.region-timeout=15s
 ```
 
-The default is `0`, which leaves each region bounded only by the collector context (`--collector-interval`) — a slow or unreachable region can consume the whole budget and overrun the Prometheus `scrape_timeout`, failing the scrape (`up=0`). Set a positive value (e.g. `15s`) to fail such regions fast: the region is logged and skipped while the others still report, keeping total collection under the scrape timeout and protecting scrape availability. Raise it to wait for complete data from slow regions at the cost of longer scrapes.
+The default is `0`, which applies an internal safety ceiling so a hung AWS call can never stall the background refresh. Set a positive value (e.g. `15s`) to fail slow or unreachable regions faster: the region is logged, counted in `cloudcost_exporter_aws_rds_populate_errors_total`, and skipped while the others still warm. Because the refresh runs off the scrape path, a slow region delays only the freshness of that region's data, not the scrape itself.
 
 ## Labels
 
@@ -44,7 +52,8 @@ The default is `0`, which leaves each region bounded only by the collector conte
 ## Notes
 
 - Pricing data is fetched from the AWS Pricing API (us-east-1 region)
-- Metrics are refreshed periodically based on the configured scrape interval
+- Inventory and pricing are refreshed in the background on the configured scrape interval; scrapes read the warm cache and make no AWS calls
+- No metrics emit until the first background refresh completes after startup
 - All costs are represented in USD per hour
 
 ## IAM Permissions

--- a/docs/metrics/aws/rds.md
+++ b/docs/metrics/aws/rds.md
@@ -8,13 +8,11 @@
 
 | Metric name                                      | Metric type | Description                                                              | Labels                                                                                                                              |
 |--------------------------------------------------|-------------|-------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| cloudcost_exporter_aws_rds_populate_errors_total | Counter     | Errors during background store population by store, region, and operation | `store`=&lt;always `instances`&gt; <br/> `region`=&lt;AWS region&gt; <br/> `operation`=&lt;`lookup_client`, `list_instances`, `get_pricing`, `validate_pricing`&gt; |
+| cloudcost_exporter_aws_rds_populate_errors_total | Counter     | Errors during background store population by store, region, and operation | `store`=&lt;always `instances`&gt; <br/> `region`=&lt;AWS region&gt; <br/> `operation`=&lt;`lookup_client`, `list_instances`, `list_prices`, `parse_pricing`&gt; |
 
 ## Overview
 
 The RDS collector exports pricing metrics for Amazon Relational Database Service instances across all configured AWS regions. It collects hourly pricing rates for RDS database instances based on their instance type and tier.
-
-Instance inventory (`DescribeDBInstances`) and pricing (`GetProducts`) are refreshed in the background on a ticker rather than on the Prometheus scrape path. A scrape reads the warm cache and makes zero AWS calls, so scrape latency no longer tracks AWS API latency or a cold pricing map. Warming starts at startup, so there is a short cold-start gap: no metrics emit until the first background refresh finishes. When a refresh fails to warm a price for an instance, that instance is skipped and `cloudcost_exporter_aws_rds_populate_errors_total` is incremented; the scrape still succeeds.
 
 ## Configuration
 
@@ -33,7 +31,7 @@ Or via command line:
 
 ### Per-region Timeout
 
-The background refresh queries `DescribeDBInstances` and pricing in each region concurrently. `--aws.rds.region-timeout` bounds each region's work:
+The background refresh lists instances (`DescribeDBInstances`) and prices (`GetProducts`) in each region concurrently. `--aws.rds.region-timeout` bounds each region's work:
 
 ```bash
 --aws.rds.region-timeout=15s
@@ -51,7 +49,8 @@ The default is `0`, which applies an internal safety ceiling so a hung AWS call 
 
 ## Notes
 
-- Pricing data is fetched from the AWS Pricing API (us-east-1 region)
+- Pricing is listed in bulk per region from the AWS Pricing API and keyed by instance type, engine, deployment option, and license so `Collect` matches each instance to its price
+- Instances whose engine is not recognized are skipped; recognized engines are MySQL, MariaDB, PostgreSQL, Aurora MySQL, Aurora PostgreSQL, Oracle, and SQL Server
 - Inventory and pricing are refreshed in the background on the configured scrape interval; scrapes read the warm cache and make no AWS calls
 - No metrics emit until the first background refresh completes after startup
 - All costs are represented in USD per hour

--- a/docs/metrics/aws/rds.md
+++ b/docs/metrics/aws/rds.md
@@ -50,6 +50,7 @@ The default is `0`, which applies an internal safety ceiling so a hung AWS call 
 ## Notes
 
 - Pricing is listed in bulk per region from the AWS Pricing API and keyed by instance type, engine, deployment option, and license so `Collect` matches each instance to its price
+- Aurora MySQL and Aurora PostgreSQL additionally key on storage mode (Standard vs I/O-Optimized), since I/O-Optimized carries a different instance-hour price; an Aurora instance with an unrecognized or missing storage mode is skipped rather than priced against the wrong SKU
 - Instances whose engine is not recognized are skipped; recognized engines are MySQL, MariaDB, PostgreSQL, Aurora MySQL, Aurora PostgreSQL, Oracle, and SQL Server
 - Instance inventory and pricing refresh independently in the background, each in its own store: inventory refreshes on `--scrape-interval` (default `1h`); pricing refreshes on a fixed 24-hour interval, since it's a stable bulk-per-region fetch that doesn't need frequent refresh
 - Scrapes read both warm stores and make no AWS calls

--- a/docs/metrics/aws/rds.md
+++ b/docs/metrics/aws/rds.md
@@ -8,7 +8,7 @@
 
 | Metric name                                      | Metric type | Description                                                              | Labels                                                                                                                              |
 |--------------------------------------------------|-------------|-------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| cloudcost_exporter_aws_rds_populate_errors_total | Counter     | Errors during background store population by store, region, and operation | `store`=&lt;always `instances`&gt; <br/> `region`=&lt;AWS region&gt; <br/> `operation`=&lt;`lookup_client`, `list_instances`, `list_prices`, `parse_pricing`&gt; |
+| cloudcost_exporter_aws_rds_populate_errors_total | Counter     | Errors during background store population by store, region, and operation | `store`=&lt;`instances` or `pricing`&gt; <br/> `region`=&lt;AWS region&gt; <br/> `operation`=&lt;`lookup_client`, `list_instances`, `list_prices`, `parse_pricing`&gt; |
 
 ## Overview
 
@@ -31,13 +31,13 @@ Or via command line:
 
 ### Per-region Timeout
 
-The background refresh lists instances (`DescribeDBInstances`) and prices (`GetProducts`) in each region concurrently. `--aws.rds.region-timeout` bounds each region's work:
+Instance inventory (`DescribeDBInstances`) and pricing (`GetProducts`) refresh independently, each in its own background store with its own per-region call. `--aws.rds.region-timeout` bounds each region's work in both stores:
 
 ```bash
 --aws.rds.region-timeout=15s
 ```
 
-The default is `0`, which applies an internal safety ceiling so a hung AWS call can never stall the background refresh. Set a positive value (e.g. `15s`) to fail slow or unreachable regions faster: the region is logged, counted in `cloudcost_exporter_aws_rds_populate_errors_total`, and skipped while the others still warm. Because the refresh runs off the scrape path, a slow region delays only the freshness of that region's data, not the scrape itself.
+The default is `0`, which applies an internal safety ceiling so a hung AWS call can never stall either background refresh. Set a positive value (e.g. `15s`) to fail slow or unreachable regions faster: the region is logged, counted in `cloudcost_exporter_aws_rds_populate_errors_total`, and skipped while the others still warm. Because the refresh runs off the scrape path, a slow region delays only the freshness of that region's data, not the scrape itself.
 
 ## Labels
 
@@ -51,8 +51,9 @@ The default is `0`, which applies an internal safety ceiling so a hung AWS call 
 
 - Pricing is listed in bulk per region from the AWS Pricing API and keyed by instance type, engine, deployment option, and license so `Collect` matches each instance to its price
 - Instances whose engine is not recognized are skipped; recognized engines are MySQL, MariaDB, PostgreSQL, Aurora MySQL, Aurora PostgreSQL, Oracle, and SQL Server
-- Inventory and pricing are refreshed in the background on the configured scrape interval; scrapes read the warm cache and make no AWS calls
-- No metrics emit until the first background refresh completes after startup
+- Instance inventory and pricing refresh independently in the background, each in its own store: inventory refreshes on `--scrape-interval` (default `1h`); pricing refreshes on a fixed 24-hour interval, since it's a stable bulk-per-region fetch that doesn't need frequent refresh
+- Scrapes read both warm stores and make no AWS calls
+- No metrics emit until both the instance and pricing background stores complete their first refresh after startup
 - All costs are represented in USD per hour
 
 ## IAM Permissions

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -46,7 +46,7 @@ type Config struct {
 	ExcludeRegions       []string // AWS region names to skip (e.g. me-central-1)
 	ScrapeInterval       time.Duration
 	CollectorTimeout     time.Duration
-	RDSRegionListTimeout time.Duration // per-region timeout for RDS DescribeDBInstances; 0 uses the collector default
+	RDSRegionListTimeout time.Duration // per-region timeout for the background RDS refresh; 0 uses an internal safety ceiling
 	Logger               *slog.Logger
 	AccountID            string
 	BedrockFamilyFilter  string // regex matched against family label; default "anthropic|amazon"

--- a/pkg/aws/client/aws_client.go
+++ b/pkg/aws/client/aws_client.go
@@ -106,8 +106,8 @@ func (c *AWSClient) ListRDSInstances(ctx context.Context) ([]rdsTypes.DBInstance
 	return c.rdsService.listRDSInstances(ctx)
 }
 
-func (c *AWSClient) GetRDSUnitData(ctx context.Context, instType, region, deploymentOption, databaseEngine, locationType string) (string, error) {
-	return c.priceService.getRDSUnitData(ctx, instType, region, deploymentOption, databaseEngine, locationType)
+func (c *AWSClient) ListRDSPrices(ctx context.Context, region string) ([]string, error) {
+	return c.priceService.listRDSPrices(ctx, region)
 }
 
 func (c *AWSClient) ListVPCServicePrices(ctx context.Context, region string, filters []pricingTypes.Filter) ([]string, error) {

--- a/pkg/aws/client/client.go
+++ b/pkg/aws/client/client.go
@@ -29,7 +29,7 @@ type Client interface {
 	ListELBPrices(ctx context.Context, region string) ([]string, error)
 	DescribeLoadBalancers(ctx context.Context) ([]elbTypes.LoadBalancer, error)
 	ListRDSInstances(ctx context.Context) ([]rdsTypes.DBInstance, error)
-	GetRDSUnitData(ctx context.Context, instType, region, deploymentOption, engineCode, isOutpost string) (string, error)
+	ListRDSPrices(ctx context.Context, region string) ([]string, error)
 	ListMSKClusters(ctx context.Context) ([]msktypes.Cluster, error)
 	ListMSKServicePrices(ctx context.Context, region string, filters []pricingTypes.Filter) ([]string, error)
 	ListBedrockPrices(ctx context.Context, region string) ([]string, error)

--- a/pkg/aws/client/mocks/client.go
+++ b/pkg/aws/client/mocks/client.go
@@ -108,21 +108,6 @@ func (mr *MockClientMockRecorder) GetCapacityBlockCosts(ctx, startDate, endDate 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCapacityBlockCosts", reflect.TypeOf((*MockClient)(nil).GetCapacityBlockCosts), ctx, startDate, endDate)
 }
 
-// GetRDSUnitData mocks base method.
-func (m *MockClient) GetRDSUnitData(ctx context.Context, instType, region, deploymentOption, engineCode, isOutpost string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRDSUnitData", ctx, instType, region, deploymentOption, engineCode, isOutpost)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRDSUnitData indicates an expected call of GetRDSUnitData.
-func (mr *MockClientMockRecorder) GetRDSUnitData(ctx, instType, region, deploymentOption, engineCode, isOutpost any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRDSUnitData", reflect.TypeOf((*MockClient)(nil).GetRDSUnitData), ctx, instType, region, deploymentOption, engineCode, isOutpost)
-}
-
 // ListActiveCapacityReservations mocks base method.
 func (m *MockClient) ListActiveCapacityReservations(ctx context.Context) ([]types.CapacityReservation, error) {
 	m.ctrl.T.Helper()
@@ -286,6 +271,21 @@ func (m *MockClient) ListRDSInstances(ctx context.Context) ([]types3.DBInstance,
 func (mr *MockClientMockRecorder) ListRDSInstances(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRDSInstances", reflect.TypeOf((*MockClient)(nil).ListRDSInstances), ctx)
+}
+
+// ListRDSPrices mocks base method.
+func (m *MockClient) ListRDSPrices(ctx context.Context, region string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRDSPrices", ctx, region)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRDSPrices indicates an expected call of ListRDSPrices.
+func (mr *MockClientMockRecorder) ListRDSPrices(ctx, region any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRDSPrices", reflect.TypeOf((*MockClient)(nil).ListRDSPrices), ctx, region)
 }
 
 // ListSpotPrices mocks base method.

--- a/pkg/aws/client/pricing.go
+++ b/pkg/aws/client/pricing.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"time"
 
-	"log/slog"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -226,56 +224,15 @@ func (p *pricing) getPricesFromProductList(ctx context.Context, input *awsPricin
 	return productOutputs, nil
 }
 
-func (p *pricing) getRDSUnitData(ctx context.Context, instType, region, deploymentOption, databaseEngine, locationType string) (string, error) {
-	input := &awsPricing.GetProductsInput{
-		ServiceCode: aws.String("AmazonRDS"),
-		Filters: []pricingTypes.Filter{
-			{
-				Field: aws.String("productFamily"),
-				Type:  pricingTypes.FilterTypeTermMatch,
-				Value: aws.String("Database Instance"),
-			},
-			{
-				Field: aws.String("instanceType"),
-				Type:  pricingTypes.FilterTypeTermMatch,
-				Value: aws.String(instType),
-			},
-			{
-				Field: aws.String("regionCode"),
-				Type:  pricingTypes.FilterTypeTermMatch,
-				Value: aws.String(region),
-			},
-			{
-				Field: aws.String("deploymentOption"),
-				Type:  pricingTypes.FilterTypeTermMatch,
-				Value: aws.String(deploymentOption),
-			},
-			{
-				Field: aws.String("databaseEngine"),
-				Type:  pricingTypes.FilterTypeContains,
-				Value: aws.String(databaseEngine),
-			},
-			{
-				Field: aws.String("locationType"),
-				Type:  pricingTypes.FilterTypeTermMatch,
-				Value: aws.String(locationType),
-			},
+// listRDSPrices lists every RDS Database Instance product in a region. The RDS
+// collector parses each product's attributes into a pricing key, so pricing is
+// listed once per region rather than looked up per instance.
+func (p *pricing) listRDSPrices(ctx context.Context, region string) ([]string, error) {
+	return p.listServicePrices(ctx, "AmazonRDS", region, []pricingTypes.Filter{
+		{
+			Field: aws.String("productFamily"),
+			Type:  pricingTypes.FilterTypeTermMatch,
+			Value: aws.String("Database Instance"),
 		},
-	}
-
-	products, err := p.client.GetProducts(ctx, input)
-	if err != nil {
-		slog.ErrorContext(ctx, "error getting rds prices", "error", err)
-		return "", err
-	}
-
-	if len(products.PriceList) == 0 {
-		slog.WarnContext(ctx, "no price list found for RDS instance", "instanceType", instType, "region", region)
-		return "", nil
-	}
-	if len(products.PriceList) > 1 {
-		slog.WarnContext(ctx, "ambiguous price list, expected 1 got multiple", "count", len(products.PriceList), "instanceType", instType, "region", region)
-		return "", nil
-	}
-	return products.PriceList[0], nil
+	})
 }

--- a/pkg/aws/client/pricing_test.go
+++ b/pkg/aws/client/pricing_test.go
@@ -305,91 +305,60 @@ func TestListStoragePrices(t *testing.T) {
 	}
 }
 
-func Test_GetRDSUnitData(t *testing.T) {
-	tests := []struct {
-		name        string
-		GetProducts func(ctx context.Context, input *awsPricing.GetProductsInput, optFns ...func(*awsPricing.Options)) (*awsPricing.GetProductsOutput, error)
-		want        string
-		wantErr     bool
-	}{
-		{
-			name: "only one price",
-			GetProducts: func(ctx context.Context, input *awsPricing.GetProductsInput, optFns ...func(*awsPricing.Options)) (*awsPricing.GetProductsOutput, error) {
-				return &awsPricing.GetProductsOutput{
-						PriceList: []string{
-							`{
-							"terms": {
-								"OnDemand": {
-									"term1": {
-										"priceDimensions": {
-											"dim1": {
-												"pricePerUnit": {"USD": "0.0840000000"}
-											}
-										}
-									}
-								}
-							}
-						}`,
-						},
-					},
-					nil
-			},
-			want:    `{"terms":{"OnDemand":{"term1":{"priceDimensions":{"dim1":{"pricePerUnit":{"USD":"0.0840000000"}}}}}}}`,
-			wantErr: false,
-		},
-		{
-			name: "multiple prices - ambiguous match, skips without error",
-			GetProducts: func(ctx context.Context, input *awsPricing.GetProductsInput, optFns ...func(*awsPricing.Options)) (*awsPricing.GetProductsOutput, error) {
-				return &awsPricing.GetProductsOutput{
-					PriceList: []string{
-						`{"terms": {"OnDemand": {"term1": {"priceDimensions": {"dim1": {"pricePerUnit": {"USD": "0.0840000000"}}}}}}}`,
-						`{"terms": {"OnDemand": {"term2": {"priceDimensions": {"dim2": {"pricePerUnit": {"USD": "0.0240000000"}}}}}}}`,
-					},
-				}, nil
-			},
-			want:    "",
-			wantErr: false,
-		},
-		{
-			name: "empty price list - no match, skips without error",
-			GetProducts: func(ctx context.Context, input *awsPricing.GetProductsInput, optFns ...func(*awsPricing.Options)) (*awsPricing.GetProductsOutput, error) {
-				return &awsPricing.GetProductsOutput{
-					PriceList: []string{},
-				}, nil
-			},
-			want:    "",
-			wantErr: false,
-		},
-		{
-			name: "pricing API errors",
-			GetProducts: func(ctx context.Context, input *awsPricing.GetProductsInput, optFns ...func(*awsPricing.Options)) (*awsPricing.GetProductsOutput, error) {
-				return &awsPricing.GetProductsOutput{}, errors.New("test error")
-			},
-			want:    "",
-			wantErr: true,
-		},
+func Test_ListRDSPrices(t *testing.T) {
+	getFilterValue := func(filters []pricingTypes.Filter, field string) string {
+		for _, filter := range filters {
+			if aws.ToString(filter.Field) == field {
+				return aws.ToString(filter.Value)
+			}
+		}
+		return ""
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			client := mocks.NewMockPricing(ctrl)
+	t.Run("filters by service, region, and Database Instance family and paginates", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		client := mocks.NewMockPricing(ctrl)
 
+		gomock.InOrder(
 			client.EXPECT().
 				GetProducts(gomock.Any(), gomock.Any(), gomock.Any()).
-				DoAndReturn(tt.GetProducts).
-				Times(1)
-			c := newPricing(client, nil)
-			result, err := c.getRDSUnitData(t.Context(), "input1", "input2", "input3", "input4", "input5")
+				DoAndReturn(func(ctx context.Context, input *awsPricing.GetProductsInput, optFns ...func(*awsPricing.Options)) (*awsPricing.GetProductsOutput, error) {
+					assert.Equal(t, "AmazonRDS", aws.ToString(input.ServiceCode))
+					assert.Equal(t, "us-east-1", getFilterValue(input.Filters, "regionCode"))
+					assert.Equal(t, "Database Instance", getFilterValue(input.Filters, "productFamily"))
+					return &awsPricing.GetProductsOutput{
+						PriceList: []string{`{"price":"one"}`},
+						NextToken: aws.String("next"),
+					}, nil
+				}).Times(1),
+			client.EXPECT().
+				GetProducts(gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, input *awsPricing.GetProductsInput, optFns ...func(*awsPricing.Options)) (*awsPricing.GetProductsOutput, error) {
+					assert.Equal(t, "next", aws.ToString(input.NextToken))
+					return &awsPricing.GetProductsOutput{
+						PriceList: []string{`{"price":"two"}`},
+					}, nil
+				}).Times(1),
+		)
 
-			t.Logf("Test: %s, Result: %s, Error: %v, WantErr: %v", tt.name, result, err, tt.wantErr)
-			if tt.wantErr {
-				assert.Error(t, err)
-				return
-			}
-			assert.NoError(t, err)
-		})
-	}
+		c := newPricing(client, nil)
+		got, err := c.listRDSPrices(t.Context(), "us-east-1")
+		assert.NoError(t, err)
+		assert.Equal(t, []string{`{"price":"one"}`, `{"price":"two"}`}, got)
+	})
+
+	t.Run("returns the pricing API error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		client := mocks.NewMockPricing(ctrl)
+		client.EXPECT().
+			GetProducts(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&awsPricing.GetProductsOutput{}, errors.New("test error")).
+			Times(1)
+
+		c := newPricing(client, nil)
+		_, err := c.listRDSPrices(t.Context(), "us-east-1")
+		assert.Error(t, err)
+	})
 }
 
 func Test_ListMSKServicePrices(t *testing.T) {

--- a/pkg/aws/ec2/mock_client_test.go
+++ b/pkg/aws/ec2/mock_client_test.go
@@ -88,7 +88,7 @@ func (m *mockClient) ListRDSInstances(ctx context.Context) ([]rdsTypes.DBInstanc
 	panic("not implemented")
 }
 
-func (m *mockClient) GetRDSUnitData(ctx context.Context, instType, region, deploymentOption, engineCode, isOutpost string) (string, error) {
+func (m *mockClient) ListRDSPrices(ctx context.Context, region string) ([]string, error) {
 	panic("not implemented")
 }
 

--- a/pkg/aws/rds/pricing_map.go
+++ b/pkg/aws/rds/pricing_map.go
@@ -10,7 +10,26 @@ import (
 )
 
 type AWSPriceData struct {
-	Terms *AWSTerms `json:"terms"`
+	Product *AWSProduct `json:"product"`
+	Terms   *AWSTerms   `json:"terms"`
+}
+
+type AWSProduct struct {
+	Attributes *AWSProductAttributes `json:"attributes"`
+}
+
+// AWSProductAttributes holds the RDS Database Instance product attributes that
+// make up a pricing key. These come straight from the AWS Pricing API, so the
+// engine and edition are display names ("PostgreSQL", "Oracle"), not the
+// instance Engine codes ("postgres", "oracle-ee").
+type AWSProductAttributes struct {
+	InstanceType     string `json:"instanceType"`
+	RegionCode       string `json:"regionCode"`
+	DatabaseEngine   string `json:"databaseEngine"`
+	DatabaseEdition  string `json:"databaseEdition"`
+	DeploymentOption string `json:"deploymentOption"`
+	LicenseModel     string `json:"licenseModel"`
+	LocationType     string `json:"locationType"`
 }
 
 type AWSTerms struct {
@@ -50,24 +69,20 @@ func (pm *pricingMap) Get(key string) (float64, bool) {
 	return v, ok
 }
 
-func validateRDSPriceData(ctx context.Context, priceList string) (float64, error) {
-	var priceData AWSPriceData
-	if err := json.Unmarshal([]byte(priceList), &priceData); err != nil {
-		slog.ErrorContext(ctx, "error unmarshaling price JSON", "error", err)
-		return 0, err
-	}
-
-	if priceData.Terms == nil {
+// priceFromTerms extracts the single on-demand USD price from a product's
+// pricing terms.
+func priceFromTerms(ctx context.Context, terms *AWSTerms) (float64, error) {
+	if terms == nil {
 		slog.ErrorContext(ctx, "Terms is nil")
 		return 0, fmt.Errorf("terms is nil")
 	}
-	if priceData.Terms.OnDemand == nil {
+	if terms.OnDemand == nil {
 		slog.ErrorContext(ctx, "OnDemand is nil")
 		return 0, fmt.Errorf("OnDemand is nil")
 	}
 
 	var term *AWSTerm
-	for _, t := range priceData.Terms.OnDemand {
+	for _, t := range terms.OnDemand {
 		if t == nil || t.PriceDimensions == nil {
 			slog.ErrorContext(ctx, "PriceDimensions is nil")
 			return 0, fmt.Errorf("PriceDimensions is nil")
@@ -99,4 +114,46 @@ func validateRDSPriceData(ctx context.Context, priceList string) (float64, error
 	}
 
 	return price, nil
+}
+
+// parseRDSPriceProduct turns a single Pricing API product into its pricing key
+// and on-demand USD price. ok is false when the product lacks the attributes or
+// on-demand price needed to key it, so the caller can count and skip it.
+func parseRDSPriceProduct(ctx context.Context, priceList string) (key string, price float64, ok bool) {
+	var priceData AWSPriceData
+	if err := json.Unmarshal([]byte(priceList), &priceData); err != nil {
+		slog.ErrorContext(ctx, "error unmarshaling RDS price JSON", "error", err)
+		return "", 0, false
+	}
+
+	key, ok = priceKeyFromAttributes(priceData.Product)
+	if !ok {
+		return "", 0, false
+	}
+
+	price, err := priceFromTerms(ctx, priceData.Terms)
+	if err != nil {
+		return "", 0, false
+	}
+	return key, price, true
+}
+
+// priceKeyFromAttributes builds the pricing key from a product's attributes. It
+// returns ok=false when an attribute the key depends on is missing.
+func priceKeyFromAttributes(product *AWSProduct) (string, bool) {
+	if product == nil || product.Attributes == nil {
+		return "", false
+	}
+	a := product.Attributes
+	if a.RegionCode == "" || a.InstanceType == "" || a.DatabaseEngine == "" || a.DeploymentOption == "" || a.LocationType == "" {
+		return "", false
+	}
+	license := a.LicenseModel
+	if a.DatabaseEdition == "" {
+		// Open-source engines carry no edition; normalize their license to the
+		// same token the instance side uses so the key matches without either
+		// side depending on the raw licenseModel attribute string.
+		license = openSourceLicense
+	}
+	return createPricingKey(a.RegionCode, a.InstanceType, a.DatabaseEngine, a.DatabaseEdition, a.DeploymentOption, license, a.LocationType), true
 }

--- a/pkg/aws/rds/pricing_map.go
+++ b/pkg/aws/rds/pricing_map.go
@@ -30,6 +30,9 @@ type AWSProductAttributes struct {
 	DeploymentOption string `json:"deploymentOption"`
 	LicenseModel     string `json:"licenseModel"`
 	LocationType     string `json:"locationType"`
+	// Storage only disambiguates Aurora SKUs (Standard vs I/O-Optimized, which
+	// carry different instance-hour prices); see auroraStorageModeFromPricing.
+	Storage string `json:"storage"`
 }
 
 type AWSTerms struct {
@@ -155,5 +158,15 @@ func priceKeyFromAttributes(product *AWSProduct) (string, bool) {
 		// side depending on the raw licenseModel attribute string.
 		license = openSourceLicense
 	}
-	return createPricingKey(a.RegionCode, a.InstanceType, a.DatabaseEngine, a.DatabaseEdition, a.DeploymentOption, license, a.LocationType), true
+
+	storageMode := auroraStorageModeNA
+	if isAuroraEngine(a.DatabaseEngine) {
+		var ok bool
+		storageMode, ok = auroraStorageModeFromPricing(a.Storage)
+		if !ok {
+			return "", false
+		}
+	}
+
+	return createPricingKey(a.RegionCode, a.InstanceType, a.DatabaseEngine, a.DatabaseEdition, a.DeploymentOption, license, a.LocationType, storageMode), true
 }

--- a/pkg/aws/rds/pricing_map_test.go
+++ b/pkg/aws/rds/pricing_map_test.go
@@ -1,6 +1,7 @@
 package rds
 
 import (
+	"encoding/json"
 	"fmt"
 	"sync"
 	"testing"
@@ -8,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestValidateRDSPriceData(t *testing.T) {
+func TestPriceFromTerms(t *testing.T) {
 	ctx := t.Context()
 
 	tests := []struct {
@@ -151,7 +152,12 @@ func TestValidateRDSPriceData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			price, err := validateRDSPriceData(ctx, tt.priceList)
+			var data AWSPriceData
+			if err := json.Unmarshal([]byte(tt.priceList), &data); err != nil {
+				assert.True(t, tt.wantErr, "invalid JSON should be a wantErr case")
+				return
+			}
+			price, err := priceFromTerms(ctx, data.Terms)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -160,6 +166,45 @@ func TestValidateRDSPriceData(t *testing.T) {
 			assert.Equal(t, tt.want, price)
 		})
 	}
+}
+
+func TestParseRDSPriceProduct(t *testing.T) {
+	ctx := t.Context()
+
+	product := `{
+		"product": {
+			"attributes": {
+				"instanceType": "db.t3.medium",
+				"regionCode": "us-east-1",
+				"databaseEngine": "PostgreSQL",
+				"deploymentOption": "Single-AZ",
+				"locationType": "AWS Region"
+			}
+		},
+		"terms": {"OnDemand": {"t": {"priceDimensions": {"d": {"pricePerUnit": {"USD": "0.456"}}}}}}
+	}`
+
+	t.Run("valid product yields key and price", func(t *testing.T) {
+		key, price, ok := parseRDSPriceProduct(ctx, product)
+		assert.True(t, ok)
+		assert.Equal(t, 0.456, price)
+		assert.Equal(t, createPricingKey("us-east-1", "db.t3.medium", "PostgreSQL", "", "Single-AZ", "No license required", "AWS Region"), key)
+	})
+
+	t.Run("missing product attributes is skipped", func(t *testing.T) {
+		_, _, ok := parseRDSPriceProduct(ctx, `{"terms":{"OnDemand":{"t":{"priceDimensions":{"d":{"pricePerUnit":{"USD":"0.1"}}}}}}}`)
+		assert.False(t, ok)
+	})
+
+	t.Run("missing price is skipped", func(t *testing.T) {
+		_, _, ok := parseRDSPriceProduct(ctx, `{"product":{"attributes":{"instanceType":"db.t3.medium","regionCode":"us-east-1","databaseEngine":"PostgreSQL","deploymentOption":"Single-AZ","locationType":"AWS Region"}}}`)
+		assert.False(t, ok)
+	})
+
+	t.Run("invalid JSON is skipped", func(t *testing.T) {
+		_, _, ok := parseRDSPriceProduct(ctx, `{invalid`)
+		assert.False(t, ok)
+	})
 }
 
 func TestPricingMap_SetAndGet(t *testing.T) {

--- a/pkg/aws/rds/pricing_map_test.go
+++ b/pkg/aws/rds/pricing_map_test.go
@@ -188,7 +188,7 @@ func TestParseRDSPriceProduct(t *testing.T) {
 		key, price, ok := parseRDSPriceProduct(ctx, product)
 		assert.True(t, ok)
 		assert.Equal(t, 0.456, price)
-		assert.Equal(t, createPricingKey("us-east-1", "db.t3.medium", "PostgreSQL", "", "Single-AZ", "No license required", "AWS Region"), key)
+		assert.Equal(t, createPricingKey("us-east-1", "db.t3.medium", "PostgreSQL", "", "Single-AZ", "No license required", "AWS Region", auroraStorageModeNA), key)
 	})
 
 	t.Run("missing product attributes is skipped", func(t *testing.T) {
@@ -203,6 +203,55 @@ func TestParseRDSPriceProduct(t *testing.T) {
 
 	t.Run("invalid JSON is skipped", func(t *testing.T) {
 		_, _, ok := parseRDSPriceProduct(ctx, `{invalid`)
+		assert.False(t, ok)
+	})
+
+	auroraProduct := func(storage string) string {
+		return fmt.Sprintf(`{
+			"product": {
+				"attributes": {
+					"instanceType": "db.r6g.large",
+					"regionCode": "us-east-1",
+					"databaseEngine": "Aurora MySQL",
+					"deploymentOption": "Single-AZ",
+					"locationType": "AWS Region",
+					"storage": "%s"
+				}
+			},
+			"terms": {"OnDemand": {"t": {"priceDimensions": {"d": {"pricePerUnit": {"USD": "0.5"}}}}}}
+		}`, storage)
+	}
+
+	t.Run("aurora standard and I/O-optimized storage yield distinct keys", func(t *testing.T) {
+		standardKey, _, ok := parseRDSPriceProduct(ctx, auroraProduct("EBS Only"))
+		assert.True(t, ok)
+
+		ioOptimizedKey, _, ok := parseRDSPriceProduct(ctx, auroraProduct("Aurora IO Optimization Mode"))
+		assert.True(t, ok)
+
+		assert.NotEqual(t, standardKey, ioOptimizedKey)
+		assert.Equal(t, createPricingKey("us-east-1", "db.r6g.large", "Aurora MySQL", "", "Single-AZ", "No license required", "AWS Region", auroraStorageModeStandard), standardKey)
+		assert.Equal(t, createPricingKey("us-east-1", "db.r6g.large", "Aurora MySQL", "", "Single-AZ", "No license required", "AWS Region", auroraStorageModeIOOptimized), ioOptimizedKey)
+	})
+
+	t.Run("aurora with unrecognized storage is skipped", func(t *testing.T) {
+		_, _, ok := parseRDSPriceProduct(ctx, auroraProduct("Some New Storage Mode"))
+		assert.False(t, ok)
+	})
+
+	t.Run("aurora with missing storage is skipped", func(t *testing.T) {
+		_, _, ok := parseRDSPriceProduct(ctx, `{
+			"product": {
+				"attributes": {
+					"instanceType": "db.r6g.large",
+					"regionCode": "us-east-1",
+					"databaseEngine": "Aurora MySQL",
+					"deploymentOption": "Single-AZ",
+					"locationType": "AWS Region"
+				}
+			},
+			"terms": {"OnDemand": {"t": {"priceDimensions": {"d": {"pricePerUnit": {"USD": "0.5"}}}}}}
+		}`)
 		assert.False(t, ok)
 	})
 }

--- a/pkg/aws/rds/pricing_store.go
+++ b/pkg/aws/rds/pricing_store.go
@@ -19,6 +19,14 @@ import (
 // inventory. Mirrors GKE's PriceRefreshInterval.
 const defaultPricingRefreshInterval = 24 * time.Hour
 
+// defaultPricingRefreshRetryInterval is used instead of
+// defaultPricingRefreshInterval after a populate where at least one region's
+// pricing listing failed, so a persistent outage (bad IAM permissions, a
+// region-wide Pricing API failure) retries again soon rather than leaving the
+// store on stale or empty data for a full day. Mirrors the AKS VM price
+// store's adaptive-interval pattern (pkg/azure/aks/aks.go).
+const defaultPricingRefreshRetryInterval = 30 * time.Minute
+
 // pricingStore refreshes RDS pricing in the background and serves it to
 // Collect from memory, off the scrape path. It is independent of
 // instanceStore: pricing is listed in bulk per region from the Pricing API
@@ -40,10 +48,10 @@ type pricingStore struct {
 	initialPopulation     chan struct{}
 }
 
-// newPricingStore returns a store that begins warming immediately in the
-// background, independent of instanceStore.
-func newPricingStore(ctx context.Context, logger *slog.Logger, config *Config, populateErrors *prometheus.CounterVec) *pricingStore {
-	s := &pricingStore{
+// newPricingStore builds an unstarted store; call startPricingRefreshTicker to
+// begin warming it in the background, independent of instanceStore.
+func newPricingStore(logger *slog.Logger, config *Config, populateErrors *prometheus.CounterVec) *pricingStore {
+	return &pricingStore{
 		logger:            logger.With("store", "pricing"),
 		pricingClient:     config.Client,
 		regions:           config.Regions,
@@ -53,8 +61,37 @@ func newPricingStore(ctx context.Context, logger *slog.Logger, config *Config, p
 		prices:            newPricingMap(),
 		initialPopulation: make(chan struct{}),
 	}
-	go s.Populate(ctx)
-	return s
+}
+
+// startPricingRefreshTicker owns pricingStore's entire populate lifecycle,
+// including the first attempt, so it can size the wait before the next
+// attempt off that attempt's own outcome. After any populate where at least
+// one region's pricing listing failed, the next attempt runs after
+// defaultPricingRefreshRetryInterval instead of defaultPricingRefreshInterval.
+// Runs in its own goroutine and returns immediately, so a slow or failing
+// Pricing API never delays startup.
+func startPricingRefreshTicker(ctx context.Context, store *pricingStore) {
+	go func() {
+		interval := defaultPricingRefreshInterval
+		if !store.Populate(ctx) {
+			interval = defaultPricingRefreshRetryInterval
+		}
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				nextInterval := defaultPricingRefreshInterval
+				if !store.Populate(ctx) {
+					nextInterval = defaultPricingRefreshRetryInterval
+				}
+				ticker.Reset(nextInterval)
+			}
+		}
+	}()
 }
 
 // Done is closed once the first populate attempt finishes, successfully or not.
@@ -70,13 +107,17 @@ func (s *pricingStore) Get(key string) (float64, bool) {
 // Populate refreshes pricing for every region. It skips the tick if a
 // previous populate is still running, fans out under a bounded errgroup, and
 // logs, counts, and swallows per-region errors so one bad region never drops
-// its siblings.
-func (s *pricingStore) Populate(ctx context.Context) {
+// its siblings. It returns false if any region's pricing listing itself
+// failed (not merely an individual price failing to parse), so the caller can
+// retry sooner rather than waiting the full refresh interval; a skipped
+// (overlapping) populate returns true since nothing about the store's health
+// changed.
+func (s *pricingStore) Populate(ctx context.Context) bool {
 	// Drop overlapping populates: if a tick fires while the previous one is
 	// still running, avoid doubling API load.
 	if !s.populating.CompareAndSwap(false, true) {
 		s.logger.LogAttrs(ctx, slog.LevelInfo, "populate already in progress, skipping tick")
-		return
+		return true
 	}
 	defer s.populating.Store(false)
 
@@ -87,6 +128,9 @@ func (s *pricingStore) Populate(ctx context.Context) {
 	var eg errgroup.Group
 	eg.SetLimit(s.concurrency)
 
+	var succeeded atomic.Bool
+	succeeded.Store(true)
+
 	for _, region := range s.regions {
 		if ctx.Err() != nil {
 			break
@@ -96,16 +140,22 @@ func (s *pricingStore) Populate(ctx context.Context) {
 			if ctx.Err() != nil {
 				return nil
 			}
-			s.populateRegion(ctx, regionName)
+			if !s.populateRegion(ctx, regionName) {
+				succeeded.Store(false)
+			}
 			return nil // log and continue; don't drop sibling regions
 		})
 	}
 	eg.Wait()
+
+	return succeeded.Load()
 }
 
 // populateRegion refreshes a single region's pricing, bounded by a
 // per-region timeout so a hung listing call cannot wedge the background loop.
-func (s *pricingStore) populateRegion(ctx context.Context, regionName string) {
+// It returns false only when the listing call itself failed; a price that
+// fails to parse is counted and skipped but doesn't fail the region.
+func (s *pricingStore) populateRegion(ctx context.Context, regionName string) bool {
 	timeout := s.regionListTimeout
 	if timeout <= 0 {
 		timeout = defaultPopulateTimeout
@@ -119,7 +169,7 @@ func (s *pricingStore) populateRegion(ctx context.Context, regionName string) {
 			slog.String("region", regionName),
 			slog.String("error", err.Error()))
 		s.populateErrors.WithLabelValues("pricing", regionName, "list_prices").Inc()
-		return
+		return false
 	}
 
 	for _, product := range priceList {
@@ -130,4 +180,5 @@ func (s *pricingStore) populateRegion(ctx context.Context, regionName string) {
 		}
 		s.prices.Set(key, price)
 	}
+	return true
 }

--- a/pkg/aws/rds/pricing_store.go
+++ b/pkg/aws/rds/pricing_store.go
@@ -1,0 +1,133 @@
+package rds
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/grafana/cloudcost-exporter/pkg/aws/client"
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/sync/errgroup"
+)
+
+// defaultPricingRefreshInterval is the pricing store's refresh cadence.
+// Pricing is a stable, bulk per-region fetch from the Pricing API rather than
+// a per-instance lookup, so it doesn't need to refresh as often as instance
+// inventory. Mirrors GKE's PriceRefreshInterval.
+const defaultPricingRefreshInterval = 24 * time.Hour
+
+// pricingStore refreshes RDS pricing in the background and serves it to
+// Collect from memory, off the scrape path. It is independent of
+// instanceStore: pricing is listed in bulk per region from the Pricing API
+// and keyed by product attributes, not driven by the listed instances.
+// Collect joins the two stores by pricing key.
+type pricingStore struct {
+	logger            *slog.Logger
+	pricingClient     client.Client // shared across regions; the Pricing API takes a region name, not a per-region client
+	regions           []types.Region
+	regionListTimeout time.Duration
+	concurrency       int
+	populateErrors    *prometheus.CounterVec
+
+	prices *pricingMap
+
+	populating atomic.Bool
+
+	initialPopulationOnce sync.Once
+	initialPopulation     chan struct{}
+}
+
+// newPricingStore returns a store that begins warming immediately in the
+// background, independent of instanceStore.
+func newPricingStore(ctx context.Context, logger *slog.Logger, config *Config, populateErrors *prometheus.CounterVec) *pricingStore {
+	s := &pricingStore{
+		logger:            logger.With("store", "pricing"),
+		pricingClient:     config.Client,
+		regions:           config.Regions,
+		regionListTimeout: config.RegionListTimeout,
+		concurrency:       populateConcurrency,
+		populateErrors:    populateErrors,
+		prices:            newPricingMap(),
+		initialPopulation: make(chan struct{}),
+	}
+	go s.Populate(ctx)
+	return s
+}
+
+// Done is closed once the first populate attempt finishes, successfully or not.
+func (s *pricingStore) Done() <-chan struct{} {
+	return s.initialPopulation
+}
+
+// Get returns the cached on-demand hourly price for a pricing key.
+func (s *pricingStore) Get(key string) (float64, bool) {
+	return s.prices.Get(key)
+}
+
+// Populate refreshes pricing for every region. It skips the tick if a
+// previous populate is still running, fans out under a bounded errgroup, and
+// logs, counts, and swallows per-region errors so one bad region never drops
+// its siblings.
+func (s *pricingStore) Populate(ctx context.Context) {
+	// Drop overlapping populates: if a tick fires while the previous one is
+	// still running, avoid doubling API load.
+	if !s.populating.CompareAndSwap(false, true) {
+		s.logger.LogAttrs(ctx, slog.LevelInfo, "populate already in progress, skipping tick")
+		return
+	}
+	defer s.populating.Store(false)
+
+	defer s.initialPopulationOnce.Do(func() {
+		close(s.initialPopulation)
+	})
+
+	var eg errgroup.Group
+	eg.SetLimit(s.concurrency)
+
+	for _, region := range s.regions {
+		if ctx.Err() != nil {
+			break
+		}
+		regionName := *region.RegionName
+		eg.Go(func() error {
+			if ctx.Err() != nil {
+				return nil
+			}
+			s.populateRegion(ctx, regionName)
+			return nil // log and continue; don't drop sibling regions
+		})
+	}
+	eg.Wait()
+}
+
+// populateRegion refreshes a single region's pricing, bounded by a
+// per-region timeout so a hung listing call cannot wedge the background loop.
+func (s *pricingStore) populateRegion(ctx context.Context, regionName string) {
+	timeout := s.regionListTimeout
+	if timeout <= 0 {
+		timeout = defaultPopulateTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	priceList, err := s.pricingClient.ListRDSPrices(ctx, regionName)
+	if err != nil {
+		s.logger.LogAttrs(ctx, slog.LevelError, "error listing RDS prices",
+			slog.String("region", regionName),
+			slog.String("error", err.Error()))
+		s.populateErrors.WithLabelValues("pricing", regionName, "list_prices").Inc()
+		return
+	}
+
+	for _, product := range priceList {
+		key, price, ok := parseRDSPriceProduct(ctx, product)
+		if !ok {
+			s.populateErrors.WithLabelValues("pricing", regionName, "parse_pricing").Inc()
+			continue
+		}
+		s.prices.Set(key, price)
+	}
+}

--- a/pkg/aws/rds/pricing_store_test.go
+++ b/pkg/aws/rds/pricing_store_test.go
@@ -17,8 +17,8 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-// newTestPricingStore builds a store without the background goroutine the
-// production constructor starts, so tests can drive Populate synchronously.
+// newTestPricingStore builds a store without starting the production
+// adaptive-refresh goroutine, so tests can drive Populate synchronously.
 func newTestPricingStore(regions []types.Region, pricingClient client.Client) *pricingStore {
 	return &pricingStore{
 		logger:            slog.Default(),
@@ -45,7 +45,8 @@ func TestPricingStore_Populate_WarmsPricing(t *testing.T) {
 	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
 	store := newTestPricingStore(regions, pricingClient)
 
-	store.Populate(t.Context())
+	succeeded := store.Populate(t.Context())
+	assert.True(t, succeeded, "a populate with no region failures should report success")
 
 	price, ok := store.Get(warmKey)
 	assert.True(t, ok, "price should be warmed during populate")
@@ -171,7 +172,8 @@ func TestPricingStore_Populate_OverlapGuard(t *testing.T) {
 	// Simulate an in-flight populate.
 	require.True(t, store.populating.CompareAndSwap(false, true))
 
-	store.Populate(t.Context())
+	succeeded := store.Populate(t.Context())
+	assert.True(t, succeeded, "a skipped populate should not be treated as a failure needing a fast retry")
 
 	select {
 	case <-store.Done():
@@ -201,7 +203,8 @@ func TestPricingStore_Populate_ListPricesErrorCountsAndContinues(t *testing.T) {
 	}
 	store := newTestPricingStore(regions, pricingClient)
 
-	store.Populate(t.Context())
+	succeeded := store.Populate(t.Context())
+	assert.False(t, succeeded, "a region's listing failure should report the populate as not fully successful")
 
 	_, ok := store.Get(warmKey)
 	assert.True(t, ok, "healthy region's price should still be cached")
@@ -222,7 +225,8 @@ func TestPricingStore_Populate_ParseErrorCounts(t *testing.T) {
 	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
 	store := newTestPricingStore(regions, pricingClient)
 
-	store.Populate(t.Context())
+	succeeded := store.Populate(t.Context())
+	assert.True(t, succeeded, "a price that fails to parse should not fail the region: the listing call itself succeeded")
 
 	assert.Equal(t, 1.0, testutil.ToFloat64(store.populateErrors.WithLabelValues("pricing", "us-east-1", "parse_pricing")))
 }
@@ -302,4 +306,56 @@ func TestPricingStore_Populate_SlowRegionFailsFast(t *testing.T) {
 	assert.Less(t, elapsed, 5*time.Second, "slow region should not block the populate")
 	_, ok := store.Get(warmKey)
 	assert.True(t, ok, "healthy region's price should still be cached")
+}
+
+// TestNewPricingStore_DoesNotWarm verifies the constructor builds an inert
+// store: warming only begins once startPricingRefreshTicker is called.
+func TestNewPricingStore_DoesNotWarm(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	pricingClient := mock.NewMockClient(mockCtrl)
+	// No calls expected: construction alone must not warm the store.
+
+	config := &Config{
+		Client:  pricingClient,
+		Regions: []types.Region{{RegionName: aws.String("us-east-1")}},
+	}
+	store := newPricingStore(slog.Default(), config, newPopulateErrorsCounter())
+
+	select {
+	case <-store.Done():
+		t.Fatal("Done should not be closed before anything triggers a populate")
+	default:
+	}
+}
+
+// TestStartPricingRefreshTicker_RunsFirstPopulateImmediately verifies the
+// starter kicks off the first populate right away, without the caller
+// blocking on it.
+func TestStartPricingRefreshTicker_RunsFirstPopulateImmediately(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	pricingClient := mock.NewMockClient(mockCtrl)
+	expectPricing(pricingClient, "0.456")
+
+	config := &Config{
+		Client:  pricingClient,
+		Regions: []types.Region{{RegionName: aws.String("us-east-1")}},
+	}
+	store := newPricingStore(slog.Default(), config, newPopulateErrorsCounter())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startPricingRefreshTicker(ctx, store)
+
+	select {
+	case <-store.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("starter should trigger the first populate without the caller blocking on it")
+	}
+
+	_, ok := store.Get(warmKey)
+	assert.True(t, ok, "the first populate triggered by the starter should warm the store")
 }

--- a/pkg/aws/rds/pricing_store_test.go
+++ b/pkg/aws/rds/pricing_store_test.go
@@ -99,6 +99,36 @@ func TestPricingStore_Populate_Refresh(t *testing.T) {
 	assert.Equal(t, 0.789, price, "refresh should overwrite the cached price")
 }
 
+// TestPricingStore_Populate_FailedRefreshKeepsStalePrice verifies a region
+// that previously warmed successfully keeps serving its last-known-good price
+// when a later refresh for that region fails, rather than losing the price.
+func TestPricingStore_Populate_FailedRefreshKeepsStalePrice(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	pricingClient := mock.NewMockClient(mockCtrl)
+	gomock.InOrder(
+		pricingClient.EXPECT().ListRDSPrices(gomock.Any(), gomock.Any()).
+			Return([]string{postgresPrice("us-east-1", "0.456")}, nil).Times(1),
+		pricingClient.EXPECT().ListRDSPrices(gomock.Any(), gomock.Any()).
+			Return(nil, errors.New("boom")).Times(1),
+	)
+
+	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
+	store := newTestPricingStore(regions, pricingClient)
+
+	store.Populate(t.Context())
+	price, ok := store.Get(warmKey)
+	require.True(t, ok, "price should be warmed during the first populate")
+	assert.Equal(t, 0.456, price)
+
+	store.Populate(t.Context())
+	price, ok = store.Get(warmKey)
+	assert.True(t, ok, "a failed refresh should keep serving the last-known-good price")
+	assert.Equal(t, 0.456, price)
+	assert.Equal(t, 1.0, testutil.ToFloat64(store.populateErrors.WithLabelValues("pricing", "us-east-1", "list_prices")))
+}
+
 // TestPricingStore_Done_ClosesAfterPopulate verifies readiness is signalled
 // once the first populate attempt finishes.
 func TestPricingStore_Done_ClosesAfterPopulate(t *testing.T) {

--- a/pkg/aws/rds/pricing_store_test.go
+++ b/pkg/aws/rds/pricing_store_test.go
@@ -1,0 +1,275 @@
+package rds
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/grafana/cloudcost-exporter/pkg/aws/client"
+	mock "github.com/grafana/cloudcost-exporter/pkg/aws/client/mocks"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// newTestPricingStore builds a store without the background goroutine the
+// production constructor starts, so tests can drive Populate synchronously.
+func newTestPricingStore(regions []types.Region, pricingClient client.Client) *pricingStore {
+	return &pricingStore{
+		logger:            slog.Default(),
+		pricingClient:     pricingClient,
+		regions:           regions,
+		concurrency:       populateConcurrency,
+		populateErrors:    newPopulateErrorsCounter(),
+		prices:            newPricingMap(),
+		initialPopulation: make(chan struct{}),
+	}
+}
+
+// TestPricingStore_Populate_WarmsPricing verifies a populate fills the
+// pricing map off the scrape path.
+func TestPricingStore_Populate_WarmsPricing(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	pricingClient := mock.NewMockClient(mockCtrl)
+	pricingClient.EXPECT().ListRDSPrices(gomock.Any(), gomock.Any()).
+		Return([]string{postgresPrice("us-east-1", "0.456")}, nil).
+		Times(1)
+
+	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
+	store := newTestPricingStore(regions, pricingClient)
+
+	store.Populate(t.Context())
+
+	price, ok := store.Get(warmKey)
+	assert.True(t, ok, "price should be warmed during populate")
+	assert.Equal(t, 0.456, price)
+}
+
+// TestPricingStore_Populate_OneCallPerRegion verifies pricing is listed in
+// bulk exactly once per configured region per populate.
+func TestPricingStore_Populate_OneCallPerRegion(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	pricingClient := mock.NewMockClient(mockCtrl)
+	expectPricing(pricingClient, "0.456")
+
+	regions := []types.Region{
+		{RegionName: aws.String("us-east-1")},
+		{RegionName: aws.String("eu-west-1")},
+	}
+	store := newTestPricingStore(regions, pricingClient)
+
+	store.Populate(t.Context())
+
+	_, ok := store.Get(warmKey)
+	assert.True(t, ok)
+}
+
+// TestPricingStore_Populate_Refresh verifies a second populate re-lists
+// prices so the map tracks the latest rates.
+func TestPricingStore_Populate_Refresh(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	pricingClient := mock.NewMockClient(mockCtrl)
+	gomock.InOrder(
+		pricingClient.EXPECT().ListRDSPrices(gomock.Any(), gomock.Any()).
+			Return([]string{postgresPrice("us-east-1", "0.456")}, nil).Times(1),
+		pricingClient.EXPECT().ListRDSPrices(gomock.Any(), gomock.Any()).
+			Return([]string{postgresPrice("us-east-1", "0.789")}, nil).Times(1),
+	)
+
+	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
+	store := newTestPricingStore(regions, pricingClient)
+
+	store.Populate(t.Context())
+	price, _ := store.Get(warmKey)
+	assert.Equal(t, 0.456, price)
+
+	store.Populate(t.Context())
+	price, _ = store.Get(warmKey)
+	assert.Equal(t, 0.789, price, "refresh should overwrite the cached price")
+}
+
+// TestPricingStore_Done_ClosesAfterPopulate verifies readiness is signalled
+// once the first populate attempt finishes.
+func TestPricingStore_Done_ClosesAfterPopulate(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	pricingClient := mock.NewMockClient(mockCtrl)
+	expectPricing(pricingClient, "0.456")
+
+	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
+	store := newTestPricingStore(regions, pricingClient)
+
+	select {
+	case <-store.Done():
+		t.Fatal("Done should not be closed before the first populate")
+	default:
+	}
+
+	store.Populate(t.Context())
+
+	select {
+	case <-store.Done():
+	default:
+		t.Fatal("Done should be closed after the first populate")
+	}
+}
+
+// TestPricingStore_Populate_OverlapGuard verifies a populate is skipped while
+// another is still running, so a slow AWS API cannot double the load.
+func TestPricingStore_Populate_OverlapGuard(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	pricingClient := mock.NewMockClient(mockCtrl)
+	// No calls expected: the guard short-circuits before any listing.
+
+	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
+	store := newTestPricingStore(regions, pricingClient)
+
+	// Simulate an in-flight populate.
+	require.True(t, store.populating.CompareAndSwap(false, true))
+
+	store.Populate(t.Context())
+
+	select {
+	case <-store.Done():
+		t.Fatal("a skipped populate must not signal readiness")
+	default:
+	}
+}
+
+// TestPricingStore_Populate_ListPricesErrorCountsAndContinues verifies a
+// failing region is counted and skipped without dropping its healthy
+// siblings.
+func TestPricingStore_Populate_ListPricesErrorCountsAndContinues(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	pricingClient := mock.NewMockClient(mockCtrl)
+	pricingClient.EXPECT().ListRDSPrices(gomock.Any(), "us-east-1").
+		Return([]string{postgresPrice("us-east-1", "0.456")}, nil).
+		Times(1)
+	pricingClient.EXPECT().ListRDSPrices(gomock.Any(), "eu-west-1").
+		Return(nil, errors.New("boom")).
+		Times(1)
+
+	regions := []types.Region{
+		{RegionName: aws.String("us-east-1")},
+		{RegionName: aws.String("eu-west-1")},
+	}
+	store := newTestPricingStore(regions, pricingClient)
+
+	store.Populate(t.Context())
+
+	_, ok := store.Get(warmKey)
+	assert.True(t, ok, "healthy region's price should still be cached")
+	assert.Equal(t, 1.0, testutil.ToFloat64(store.populateErrors.WithLabelValues("pricing", "eu-west-1", "list_prices")))
+}
+
+// TestPricingStore_Populate_ParseErrorCounts verifies a product that fails to
+// parse into a pricing key is counted and skipped.
+func TestPricingStore_Populate_ParseErrorCounts(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	pricingClient := mock.NewMockClient(mockCtrl)
+	pricingClient.EXPECT().ListRDSPrices(gomock.Any(), gomock.Any()).
+		Return([]string{`{invalid`}, nil).
+		Times(1)
+
+	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
+	store := newTestPricingStore(regions, pricingClient)
+
+	store.Populate(t.Context())
+
+	assert.Equal(t, 1.0, testutil.ToFloat64(store.populateErrors.WithLabelValues("pricing", "us-east-1", "parse_pricing")))
+}
+
+// TestPricingStore_Populate_RegionListTimeout verifies the background listing
+// is always bounded: a positive RegionListTimeout is honoured, and a zero
+// value falls back to the internal safety ceiling rather than running
+// unbounded.
+func TestPricingStore_Populate_RegionListTimeout(t *testing.T) {
+	tests := []struct {
+		name              string
+		regionListTimeout time.Duration
+		wantMaxRemaining  time.Duration
+	}{
+		{name: "zero falls back to the safety ceiling", regionListTimeout: 0, wantMaxRemaining: defaultPopulateTimeout},
+		{name: "positive imposes a tighter deadline", regionListTimeout: 30 * time.Second, wantMaxRemaining: 30 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			var deadline time.Time
+			var hasDeadline bool
+			pricingClient := mock.NewMockClient(mockCtrl)
+			pricingClient.EXPECT().ListRDSPrices(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, _ string) ([]string, error) {
+					deadline, hasDeadline = ctx.Deadline()
+					return nil, nil
+				}).
+				Times(1)
+
+			regions := []types.Region{{RegionName: aws.String("us-east-1")}}
+			store := newTestPricingStore(regions, pricingClient)
+			store.regionListTimeout = tt.regionListTimeout
+
+			// Parent context carries no deadline, so any deadline observed comes
+			// from the per-region bound.
+			store.Populate(context.Background())
+			require.True(t, hasDeadline, "background listing must always be bounded")
+			assert.LessOrEqual(t, time.Until(deadline), tt.wantMaxRemaining)
+		})
+	}
+}
+
+// TestPricingStore_Populate_SlowRegionFailsFast verifies a region whose
+// listing hangs is bounded by regionListTimeout and does not block healthy
+// regions.
+func TestPricingStore_Populate_SlowRegionFailsFast(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	pricingClient := mock.NewMockClient(mockCtrl)
+	pricingClient.EXPECT().ListRDSPrices(gomock.Any(), "us-east-1").
+		Return([]string{postgresPrice("us-east-1", "0.456")}, nil).
+		Times(1)
+	// The slow region blocks until its timeout-bounded context is cancelled.
+	pricingClient.EXPECT().ListRDSPrices(gomock.Any(), "ap-southeast-7").
+		DoAndReturn(func(ctx context.Context, _ string) ([]string, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}).
+		Times(1)
+
+	regions := []types.Region{
+		{RegionName: aws.String("us-east-1")},
+		{RegionName: aws.String("ap-southeast-7")},
+	}
+	store := newTestPricingStore(regions, pricingClient)
+	store.regionListTimeout = 50 * time.Millisecond
+
+	start := time.Now()
+	store.Populate(t.Context())
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, 5*time.Second, "slow region should not block the populate")
+	_, ok := store.Get(warmKey)
+	assert.True(t, ok, "healthy region's price should still be cached")
+}

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -32,14 +31,13 @@ var (
 
 // Collector is a prometheus collector that collects metrics from AWS RDS clusters.
 type Collector struct {
-	regions           []types.Region
-	regionMap         map[string]client.Client
-	scrapeInterval    time.Duration
-	regionListTimeout time.Duration
-	Client            client.Client
-	pricingMap        *pricingMap
-	accountID         string
-	logger            *slog.Logger
+	regions        []types.Region
+	regionMap      map[string]client.Client
+	pricingMap     *pricingMap
+	store          *instanceStore
+	accountID      string
+	populateErrors *prometheus.CounterVec
+	logger         *slog.Logger
 }
 
 type Config struct {
@@ -55,123 +53,79 @@ const (
 	serviceName = "RDS"
 )
 
-// New creates an rds collector. A RegionListTimeout of 0 leaves each region's
-// DescribeDBInstances call bounded only by the shared collector context
-// (-collector-interval); a positive value caps it per region so a slow or
-// unreachable region fails fast instead of overrunning the scrape.
-func New(_ context.Context, config *Config, logger *slog.Logger) (*Collector, error) {
+// New creates an rds collector.
+//
+// Instance inventory and pricing are refreshed in the background on a ticker
+// rather than on the scrape path (see background-store-pattern.md). New()
+// kicks off the first populate immediately via the store constructor and
+// returns without blocking, so a slow AWS API never delays startup. Collect()
+// makes zero AWS calls and serves metrics from the warm store and pricing map.
+// A positive RegionListTimeout caps each region's background work; 0 falls back
+// to an internal safety ceiling so a slow region never wedges the refresh.
+func New(ctx context.Context, config *Config, logger *slog.Logger) (*Collector, error) {
+	logger = logger.With("collector", serviceName)
+	pm := newPricingMap()
+	populateErrors := newPopulateErrorsCounter()
+	store := newInstanceStore(ctx, logger, config, pm, populateErrors)
+
+	startRefreshTicker(ctx, config.ScrapeInterval, func() { store.Populate(ctx) })
+
 	return &Collector{
-		pricingMap:        newPricingMap(),
-		regions:           config.Regions,
-		regionMap:         config.RegionMap,
-		scrapeInterval:    config.ScrapeInterval,
-		regionListTimeout: config.RegionListTimeout,
-		Client:            config.Client,
-		accountID:         config.AccountID,
-		logger:            logger.With("collector", serviceName),
+		regions:        config.Regions,
+		regionMap:      config.RegionMap,
+		pricingMap:     pm,
+		store:          store,
+		accountID:      config.AccountID,
+		populateErrors: populateErrors,
+		logger:         logger,
 	}, nil
 }
 
-// Collect satisfies the provider.Collector interface.
+// Collect satisfies the provider.Collector interface. It makes no AWS calls:
+// instances come from the background store and prices from the pre-warmed
+// pricing map. A cold store (no populate finished yet) or a pricing miss emits
+// nothing for the affected instances and logs, rather than failing the scrape.
 func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
-	logger := c.logger
-	var instances = []rdsTypes.DBInstance{}
+	select {
+	case <-c.store.Done():
+	default:
+		c.logger.LogAttrs(ctx, slog.LevelInfo, "instance store not yet populated, skipping metrics")
+		return nil
+	}
 
-	// Fan out the per-region ListRDSInstances calls concurrently
-	numOfRegions := len(c.regions)
-	instanceCh := make(chan []rdsTypes.DBInstance, numOfRegions)
-
-	wg := sync.WaitGroup{}
 	for _, region := range c.regions {
-		regionName := *region.RegionName
-		regionClient, ok := c.regionMap[regionName]
-		if !ok {
-			logger.Error("no client found for region", "region", regionName)
-			continue
-		}
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			c.fetchInstancesData(ctx, regionClient, regionName, instanceCh)
-		}()
-	}
-
-	go func() {
-		wg.Wait()
-		close(instanceCh)
-	}()
-
-	for is := range instanceCh {
-		instances = append(instances, is...)
-	}
-
-	for _, instance := range instances {
-		// we need to get the region from the availability zone as there is no field for region
-		if instance.AvailabilityZone == nil {
-			// sometimes the availability zone is empty, possibly when an RDS instance is introduced or being removed, skipping them for the time being
-			logger.Warn("no availability zone found for RDS instance")
-			continue
-		}
-		var az = *instance.AvailabilityZone
-		var region = az[:len(az)-1]
-		depOption := multiOrSingleAZ(*instance.MultiAZ)
-		locationType := isOutpostsInstance(instance) // outposts locations have a different unit price
-		createPricingKey := createPricingKey(region, *instance.DBInstanceClass, *instance.Engine, depOption, locationType)
-
-		hourlyPrice, ok := c.pricingMap.Get(createPricingKey)
-
-		if !ok {
-			// Compute price without holding the lock
-			v, err := c.Client.GetRDSUnitData(ctx, *instance.DBInstanceClass, region, depOption, *instance.Engine, locationType)
-			if err != nil {
-				logger.Error("error listing rds prices", "error", err)
-				return err
-			}
-			if v == "" {
-				logger.Warn("no pricing data found for RDS instance, skipping", "instanceType", *instance.DBInstanceClass, "region", region, "engine", *instance.Engine)
+		for _, instance := range c.store.Get(*region.RegionName) {
+			// AWS can return partial instances (missing AZ, class, engine, or
+			// multi-AZ) mid create or delete; skip rather than deref a nil.
+			key, azRegion, ok := pricingKeyFor(instance)
+			if !ok {
+				c.logger.Warn("incomplete RDS instance, skipping")
 				continue
 			}
-			validatedPrice, err := validateRDSPriceData(ctx, v)
-			if err != nil {
-				logger.Error("error validating RDS price data", "error", err)
-				return err
+			if instance.DbiResourceId == nil || instance.DBInstanceArn == nil {
+				c.logger.Warn("RDS instance missing identifiers, skipping", "region", azRegion)
+				continue
 			}
-			c.pricingMap.Set(createPricingKey, validatedPrice)
-			hourlyPrice = validatedPrice
-		}
 
-		ch <- prometheus.MustNewConstMetric(
-			HourlyGaugeDesc,
-			prometheus.GaugeValue,
-			hourlyPrice,
-			c.accountID,
-			region,
-			*instance.DBInstanceClass,
-			*instance.DbiResourceId,
-			*instance.DBInstanceArn,
-		)
+			hourlyPrice, ok := c.pricingMap.Get(key)
+			if !ok {
+				c.logger.Warn("no pricing data found for RDS instance, skipping", "instanceType", *instance.DBInstanceClass, "region", azRegion, "engine", *instance.Engine)
+				continue
+			}
+
+			ch <- prometheus.MustNewConstMetric(
+				HourlyGaugeDesc,
+				prometheus.GaugeValue,
+				hourlyPrice,
+				c.accountID,
+				azRegion,
+				*instance.DBInstanceClass,
+				*instance.DbiResourceId,
+				*instance.DBInstanceArn,
+			)
+		}
 	}
 	return nil
-}
-
-// fetchInstancesData lists RDS instances for a single region, sending the
-// result to instanceCh. On failure it logs the error and returns.
-func (c *Collector) fetchInstancesData(ctx context.Context, regionClient client.Client, region string, instanceCh chan []rdsTypes.DBInstance) {
-	// A positive regionListTimeout caps this region's call; 0 leaves it bounded
-	// only by the parent collector context (backwards-compatible default).
-	if c.regionListTimeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, c.regionListTimeout)
-		defer cancel()
-	}
-
-	is, err := regionClient.ListRDSInstances(ctx)
-	if err != nil {
-		c.logger.Error("error listing RDS instances", "region", region, "error", err)
-		return
-	}
-	instanceCh <- is
 }
 
 func multiOrSingleAZ(multiAZ bool) string {
@@ -199,6 +153,24 @@ func createPricingKey(region, tier, engine, depOption, locationType string) stri
 	return fmt.Sprintf("%s-%s-%s-%s-%s", region, tier, engine, depOption, locationType)
 }
 
+// pricingKeyFor derives the pricing-map key and the region (from the instance's
+// availability zone) for an instance. It returns ok=false when a field the key
+// depends on is missing, which AWS can return while an instance is mid create
+// or delete. Callers must skip such instances rather than dereference the nils.
+func pricingKeyFor(instance rdsTypes.DBInstance) (key, region string, ok bool) {
+	if instance.AvailabilityZone == nil || instance.DBInstanceClass == nil || instance.Engine == nil || instance.MultiAZ == nil {
+		return "", "", false
+	}
+	az := *instance.AvailabilityZone
+	if az == "" {
+		return "", "", false
+	}
+	region = az[:len(az)-1]
+	depOption := multiOrSingleAZ(*instance.MultiAZ)
+	locationType := isOutpostsInstance(instance) // outposts locations have a different unit price
+	return createPricingKey(region, *instance.DBInstanceClass, *instance.Engine, depOption, locationType), region, true
+}
+
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
 	return nil
 }
@@ -212,5 +184,6 @@ func (c *Collector) Regions() []string {
 }
 
 func (c *Collector) Register(registry provider.Registry) error {
+	registry.MustRegister(c.populateErrors)
 	return nil
 }

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -56,10 +56,10 @@ const (
 // New creates an rds collector.
 //
 // Instance inventory and pricing are refreshed in the background on a ticker
-// rather than on the scrape path (see background-store-pattern.md). New()
-// kicks off the first populate immediately via the store constructor and
-// returns without blocking, so a slow AWS API never delays startup. Collect()
-// makes zero AWS calls and serves metrics from the warm store and pricing map.
+// rather than on the scrape path. New() kicks off the first populate immediately
+// via the store constructor and returns without blocking, so a slow AWS API
+// never delays startup. Collect() makes zero AWS calls and serves metrics from
+// the warm store and pricing map.
 // A positive RegionListTimeout caps each region's background work; 0 falls back
 // to an internal safety ceiling so a slow region never wedges the refresh.
 func New(ctx context.Context, config *Config, logger *slog.Logger) (*Collector, error) {
@@ -95,11 +95,13 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 
 	for _, region := range c.regions {
 		for _, instance := range c.store.Get(*region.RegionName) {
-			// AWS can return partial instances (missing AZ, class, engine, or
-			// multi-AZ) mid create or delete; skip rather than deref a nil.
+			// pricingKeyFor returns ok=false for a partial instance (AWS can
+			// return one missing its AZ, class, engine, or multi-AZ flag mid
+			// create or delete) or an engine we cannot map to a price; skip
+			// either rather than deref a nil.
 			key, azRegion, ok := pricingKeyFor(instance)
 			if !ok {
-				c.logger.Warn("incomplete RDS instance, skipping")
+				c.logger.Warn("cannot derive pricing key for RDS instance, skipping")
 				continue
 			}
 			if instance.DbiResourceId == nil || instance.DBInstanceArn == nil {
@@ -149,14 +151,61 @@ func isOutpostsInstance(instance rdsTypes.DBInstance) string {
 	return "AWS Region"
 }
 
-func createPricingKey(region, tier, engine, depOption, locationType string) string {
-	return fmt.Sprintf("%s-%s-%s-%s-%s", region, tier, engine, depOption, locationType)
+// engineAttributes maps an RDS instance Engine code to the AmazonRDS pricing
+// databaseEngine and databaseEdition attribute values that key its price. The
+// instance Engine field ("postgres", "oracle-ee") differs from the Pricing
+// API's display names ("PostgreSQL", "Oracle" plus edition "Enterprise"), so we
+// translate explicitly. Engines absent from this map cannot be priced and are
+// skipped by pricingKeyFor.
+//
+// VERIFY: the open-source rows (MySQL/MariaDB/PostgreSQL/Aurora) are confirmed,
+// but the Oracle and SQL Server databaseEdition strings are best-effort and
+// should be checked against a real GetProducts response before relying on their
+// prices.
+var engineAttributes = map[string]struct {
+	databaseEngine  string
+	databaseEdition string
+}{
+	"mysql":             {databaseEngine: "MySQL"},
+	"mariadb":           {databaseEngine: "MariaDB"},
+	"postgres":          {databaseEngine: "PostgreSQL"},
+	"aurora-mysql":      {databaseEngine: "Aurora MySQL"},
+	"aurora-postgresql": {databaseEngine: "Aurora PostgreSQL"},
+	"oracle-ee":         {databaseEngine: "Oracle", databaseEdition: "Enterprise"},
+	"oracle-ee-cdb":     {databaseEngine: "Oracle", databaseEdition: "Enterprise"},
+	"oracle-se2":        {databaseEngine: "Oracle", databaseEdition: "Standard Two"},
+	"oracle-se2-cdb":    {databaseEngine: "Oracle", databaseEdition: "Standard Two"},
+	"sqlserver-ee":      {databaseEngine: "SQL Server", databaseEdition: "Enterprise"},
+	"sqlserver-se":      {databaseEngine: "SQL Server", databaseEdition: "Standard"},
+	"sqlserver-web":     {databaseEngine: "SQL Server", databaseEdition: "Web"},
+	"sqlserver-ex":      {databaseEngine: "SQL Server", databaseEdition: "Express"},
+}
+
+// openSourceLicense is the pricing licenseModel attribute shared by every
+// open-source RDS engine, so those engines never depend on the instance's
+// LicenseModel field.
+const openSourceLicense = "No license required"
+
+// licenseModelAttributes maps an RDS instance LicenseModel to the pricing
+// licenseModel attribute value. Only the licensed engines (Oracle, SQL Server)
+// consult this map; see pricingKeyFor.
+//
+// VERIFY: the "License included" / "Bring your own license" strings are
+// best-effort and should be checked against a real GetProducts response.
+var licenseModelAttributes = map[string]string{
+	"license-included":       "License included",
+	"bring-your-own-license": "Bring your own license",
+}
+
+func createPricingKey(region, instanceType, databaseEngine, databaseEdition, depOption, licenseModel, locationType string) string {
+	return fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s", region, instanceType, databaseEngine, databaseEdition, depOption, licenseModel, locationType)
 }
 
 // pricingKeyFor derives the pricing-map key and the region (from the instance's
 // availability zone) for an instance. It returns ok=false when a field the key
-// depends on is missing, which AWS can return while an instance is mid create
-// or delete. Callers must skip such instances rather than dereference the nils.
+// depends on is missing (AWS can return partial instances mid create or delete)
+// or the engine is not in engineAttributes. Callers must skip such instances
+// rather than dereference the nils.
 func pricingKeyFor(instance rdsTypes.DBInstance) (key, region string, ok bool) {
 	if instance.AvailabilityZone == nil || instance.DBInstanceClass == nil || instance.Engine == nil || instance.MultiAZ == nil {
 		return "", "", false
@@ -166,9 +215,29 @@ func pricingKeyFor(instance rdsTypes.DBInstance) (key, region string, ok bool) {
 		return "", "", false
 	}
 	region = az[:len(az)-1]
+
+	engine, ok := engineAttributes[*instance.Engine]
+	if !ok {
+		return "", region, false
+	}
+
+	// Open-source engines all price under a single license; only the licensed
+	// engines (Oracle, SQL Server) key on the instance's LicenseModel.
+	license := openSourceLicense
+	if engine.databaseEdition != "" {
+		lm := ""
+		if instance.LicenseModel != nil {
+			lm = *instance.LicenseModel
+		}
+		license, ok = licenseModelAttributes[lm]
+		if !ok {
+			return "", region, false
+		}
+	}
+
 	depOption := multiOrSingleAZ(*instance.MultiAZ)
 	locationType := isOutpostsInstance(instance) // outposts locations have a different unit price
-	return createPricingKey(region, *instance.DBInstanceClass, *instance.Engine, depOption, locationType), region, true
+	return createPricingKey(region, *instance.DBInstanceClass, engine.databaseEngine, engine.databaseEdition, depOption, license, locationType), region, true
 }
 
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -33,8 +33,8 @@ var (
 type Collector struct {
 	regions        []types.Region
 	regionMap      map[string]client.Client
-	pricingMap     *pricingMap
-	store          *instanceStore
+	instanceStore  *instanceStore
+	pricingStore   *pricingStore
 	accountID      string
 	populateErrors *prometheus.CounterVec
 	logger         *slog.Logger
@@ -55,46 +55,68 @@ const (
 
 // New creates an rds collector.
 //
-// Instance inventory and pricing are refreshed in the background on a ticker
-// rather than on the scrape path. New() kicks off the first populate immediately
-// via the store constructor and returns without blocking, so a slow AWS API
-// never delays startup. Collect() makes zero AWS calls and serves metrics from
-// the warm store and pricing map.
-// A positive RegionListTimeout caps each region's background work; 0 falls back
-// to an internal safety ceiling so a slow region never wedges the refresh.
+// Instance inventory and pricing are refreshed independently in the
+// background, each on its own ticker, rather than on the scrape path. New()
+// kicks off both stores' first populate immediately and returns without
+// blocking, so a slow AWS API never delays startup. Collect() makes zero AWS
+// calls and serves metrics from the two warm stores, joined by pricing key.
+// A positive RegionListTimeout caps each region's background work for both
+// stores; 0 falls back to an internal safety ceiling so a slow region never
+// wedges either refresh.
 func New(ctx context.Context, config *Config, logger *slog.Logger) (*Collector, error) {
 	logger = logger.With("collector", serviceName)
-	pm := newPricingMap()
 	populateErrors := newPopulateErrorsCounter()
-	store := newInstanceStore(ctx, logger, config, pm, populateErrors)
 
-	startRefreshTicker(ctx, config.ScrapeInterval, func() { store.Populate(ctx) })
+	instanceStore := newInstanceStore(ctx, logger, config, populateErrors)
+	pricingStore := newPricingStore(ctx, logger, config, populateErrors)
+
+	startRefreshTicker(ctx, config.ScrapeInterval, func() { instanceStore.Populate(ctx) })
+	startRefreshTicker(ctx, defaultPricingRefreshInterval, func() { pricingStore.Populate(ctx) })
 
 	return &Collector{
 		regions:        config.Regions,
 		regionMap:      config.RegionMap,
-		pricingMap:     pm,
-		store:          store,
+		instanceStore:  instanceStore,
+		pricingStore:   pricingStore,
 		accountID:      config.AccountID,
 		populateErrors: populateErrors,
 		logger:         logger,
 	}, nil
 }
 
-// Collect satisfies the provider.Collector interface. It makes no AWS calls:
-// instances come from the background store and prices from the pre-warmed
-// pricing map. A cold store (no populate finished yet) or a pricing miss emits
-// nothing for the affected instances and logs, rather than failing the scrape.
-func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+// isDone reports whether ch has been closed.
+func isDone(ch <-chan struct{}) bool {
 	select {
-	case <-c.store.Done():
+	case <-ch:
+		return true
 	default:
+		return false
+	}
+}
+
+// Collect satisfies the provider.Collector interface. It makes no AWS calls:
+// instances come from the background instance store and prices from the
+// background pricing store. Either store not yet populated, or any
+// combination of the two, skips the scrape (no metrics, no error) rather than
+// failing it. A pricing miss for an individual instance is likewise skipped
+// with a log, not an error.
+func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	instancesReady := isDone(c.instanceStore.Done())
+	pricesReady := isDone(c.pricingStore.Done())
+	switch {
+	case !instancesReady && !pricesReady:
+		c.logger.LogAttrs(ctx, slog.LevelInfo, "instance and pricing stores not yet populated, skipping metrics")
+		return nil
+	case !instancesReady:
 		c.logger.LogAttrs(ctx, slog.LevelInfo, "instance store not yet populated, skipping metrics")
+		return nil
+	case !pricesReady:
+		c.logger.LogAttrs(ctx, slog.LevelInfo, "pricing store not yet populated, skipping metrics")
 		return nil
 	}
 
 	for _, region := range c.regions {
-		for _, instance := range c.store.Get(*region.RegionName) {
+		for _, instance := range c.instanceStore.Get(*region.RegionName) {
 			// pricingKeyFor returns ok=false for a partial instance (AWS can
 			// return one missing its AZ, class, engine, or multi-AZ flag mid
 			// create or delete) or an engine we cannot map to a price; skip
@@ -109,7 +131,7 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 				continue
 			}
 
-			hourlyPrice, ok := c.pricingMap.Get(key)
+			hourlyPrice, ok := c.pricingStore.Get(key)
 			if !ok {
 				c.logger.Warn("no pricing data found for RDS instance, skipping", "instanceType", *instance.DBInstanceClass, "region", azRegion, "engine", *instance.Engine)
 				continue
@@ -162,6 +184,10 @@ func isOutpostsInstance(instance rdsTypes.DBInstance) string {
 // but the Oracle and SQL Server databaseEdition strings are best-effort and
 // should be checked against a real GetProducts response before relying on their
 // prices.
+//
+// TODO: harden Aurora and multi-edition engine matching against a real
+// GetProducts response (e.g. Aurora Serverless v2 may need a distinct key
+// from provisioned Aurora); tracked as a follow-up issue.
 var engineAttributes = map[string]struct {
 	databaseEngine  string
 	databaseEdition string

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -185,9 +185,8 @@ func isOutpostsInstance(instance rdsTypes.DBInstance) string {
 // should be checked against a real GetProducts response before relying on their
 // prices.
 //
-// TODO: harden Aurora and multi-edition engine matching against a real
-// GetProducts response (e.g. Aurora Serverless v2 may need a distinct key
-// from provisioned Aurora); tracked as a follow-up issue.
+// TODO: harden Oracle and SQL Server databaseEdition/license matching against
+// a real GetProducts response; tracked as a follow-up issue (#1131).
 var engineAttributes = map[string]struct {
 	databaseEngine  string
 	databaseEdition string
@@ -223,8 +222,61 @@ var licenseModelAttributes = map[string]string{
 	"bring-your-own-license": "Bring your own license",
 }
 
-func createPricingKey(region, instanceType, databaseEngine, databaseEdition, depOption, licenseModel, locationType string) string {
-	return fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s", region, instanceType, databaseEngine, databaseEdition, depOption, licenseModel, locationType)
+// Aurora storage-mode tokens disambiguate the two Aurora SKUs (Standard vs
+// I/O-Optimized), which carry different instance-hour prices despite sharing
+// every other pricing attribute. auroraStorageModeNA is used by both sides of
+// the key for every non-Aurora engine, so the key is unaffected for them.
+const (
+	auroraStorageModeNA          = ""
+	auroraStorageModeStandard    = "Standard"
+	auroraStorageModeIOOptimized = "IOOptimized"
+)
+
+// isAuroraEngine reports whether a pricing databaseEngine attribute value
+// (also used as engineAttributes' databaseEngine) is one of the two Aurora
+// engines, the only engines whose instance-hour price depends on storage mode.
+func isAuroraEngine(databaseEngine string) bool {
+	return databaseEngine == "Aurora MySQL" || databaseEngine == "Aurora PostgreSQL"
+}
+
+// auroraStorageModeFromPricing normalizes the Pricing API's "storage"
+// attribute into a mode token for Aurora engines. ok=false when storage is
+// missing or doesn't match a known value, so the caller skips the row instead
+// of silently mis-keying it.
+func auroraStorageModeFromPricing(storage string) (mode string, ok bool) {
+	switch storage {
+	case "EBS Only":
+		return auroraStorageModeStandard, true
+	case "Aurora IO Optimization Mode":
+		return auroraStorageModeIOOptimized, true
+	default:
+		return "", false
+	}
+}
+
+// auroraStorageModeFromInstance normalizes a DB instance's StorageType into
+// the same mode token for Aurora engines.
+//
+// VERIFY: assumes DescribeDBInstances surfaces "aurora-iopt1" on Aurora
+// I/O-Optimized member instances, mirroring DBCluster.StorageType, rather than
+// only DescribeDBClusters exposing it. Confirm against a live Aurora
+// I/O-Optimized cluster before relying on this in production.
+func auroraStorageModeFromInstance(storageType *string) (mode string, ok bool) {
+	if storageType == nil {
+		return "", false
+	}
+	switch *storageType {
+	case "aurora":
+		return auroraStorageModeStandard, true
+	case "aurora-iopt1":
+		return auroraStorageModeIOOptimized, true
+	default:
+		return "", false
+	}
+}
+
+func createPricingKey(region, instanceType, databaseEngine, databaseEdition, depOption, licenseModel, locationType, storageMode string) string {
+	return fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s|%s", region, instanceType, databaseEngine, databaseEdition, depOption, licenseModel, locationType, storageMode)
 }
 
 // pricingKeyFor derives the pricing-map key and the region (from the instance's
@@ -261,9 +313,17 @@ func pricingKeyFor(instance rdsTypes.DBInstance) (key, region string, ok bool) {
 		}
 	}
 
+	storageMode := auroraStorageModeNA
+	if isAuroraEngine(engine.databaseEngine) {
+		storageMode, ok = auroraStorageModeFromInstance(instance.StorageType)
+		if !ok {
+			return "", region, false
+		}
+	}
+
 	depOption := multiOrSingleAZ(*instance.MultiAZ)
 	locationType := isOutpostsInstance(instance) // outposts locations have a different unit price
-	return createPricingKey(region, *instance.DBInstanceClass, engine.databaseEngine, engine.databaseEdition, depOption, license, locationType), region, true
+	return createPricingKey(region, *instance.DBInstanceClass, engine.databaseEngine, engine.databaseEdition, depOption, license, locationType, storageMode), region, true
 }
 
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {

--- a/pkg/aws/rds/rds.go
+++ b/pkg/aws/rds/rds.go
@@ -62,16 +62,19 @@ const (
 // calls and serves metrics from the two warm stores, joined by pricing key.
 // A positive RegionListTimeout caps each region's background work for both
 // stores; 0 falls back to an internal safety ceiling so a slow region never
-// wedges either refresh.
+// wedges either refresh. Pricing additionally retries sooner than its normal
+// refresh interval after any populate with a region failure, so a persistent
+// outage self-heals rather than leaving the store stale or empty for a full
+// day; see startPricingRefreshTicker.
 func New(ctx context.Context, config *Config, logger *slog.Logger) (*Collector, error) {
 	logger = logger.With("collector", serviceName)
 	populateErrors := newPopulateErrorsCounter()
 
 	instanceStore := newInstanceStore(ctx, logger, config, populateErrors)
-	pricingStore := newPricingStore(ctx, logger, config, populateErrors)
+	pricingStore := newPricingStore(logger, config, populateErrors)
 
 	startRefreshTicker(ctx, config.ScrapeInterval, func() { instanceStore.Populate(ctx) })
-	startRefreshTicker(ctx, defaultPricingRefreshInterval, func() { pricingStore.Populate(ctx) })
+	startPricingRefreshTicker(ctx, pricingStore)
 
 	return &Collector{
 		regions:        config.Regions,

--- a/pkg/aws/rds/rds_test.go
+++ b/pkg/aws/rds/rds_test.go
@@ -1,6 +1,8 @@
 package rds
 
 import (
+	"context"
+	"fmt"
 	"log/slog"
 	"testing"
 
@@ -15,19 +17,25 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-const validPriceJSON = `{
-	"terms": {
-		"OnDemand": {
-			"term1": {
-				"priceDimensions": {
-					"dim1": {
-						"pricePerUnit": {"USD": "0.456"}
-					}
-				}
-			}
-		}
-	}
-}`
+// rdsPriceProduct builds a Pricing API product JSON for the given attributes.
+func rdsPriceProduct(region, instanceType, databaseEngine, deploymentOption, locationType, usd string) string {
+	return fmt.Sprintf(`{"product":{"attributes":{"instanceType":%q,"regionCode":%q,"databaseEngine":%q,"deploymentOption":%q,"locationType":%q}},"terms":{"OnDemand":{"t":{"priceDimensions":{"d":{"pricePerUnit":{"USD":%q}}}}}}}`,
+		instanceType, region, databaseEngine, deploymentOption, locationType, usd)
+}
+
+// postgresPrice builds the price product that matches instanceFor's shape.
+func postgresPrice(region, usd string) string {
+	return rdsPriceProduct(region, "db.t3.medium", "PostgreSQL", "Single-AZ", "AWS Region", usd)
+}
+
+// expectPricing stubs ListRDSPrices to return a matching postgres price per
+// region, so a populate warms every instanceFor instance.
+func expectPricing(c *mock.MockClient, usd string) {
+	c.EXPECT().ListRDSPrices(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, region string) ([]string, error) {
+			return []string{postgresPrice(region, usd)}, nil
+		}).AnyTimes()
+}
 
 func TestIsOutpostsInstance(t *testing.T) {
 	tests := []struct {
@@ -196,8 +204,8 @@ func TestCollector_Collect_ServesFromWarmMap(t *testing.T) {
 		Times(1)
 
 	pricingClient := mock.NewMockClient(mockCtrl)
-	pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(validPriceJSON, nil).
+	pricingClient.EXPECT().ListRDSPrices(gomock.Any(), gomock.Any()).
+		Return([]string{postgresPrice("us-east-1", "0.456")}, nil).
 		Times(1)
 
 	pm := newPricingMap()
@@ -242,10 +250,10 @@ func TestCollector_Collect_PricingMiss(t *testing.T) {
 		Return([]rdsTypes.DBInstance{instanceFor("us-east-1", "db-1")}, nil).
 		Times(1)
 
-	// The pricing API returns no data, so the key never lands in the map.
+	// The pricing API returns no products, so the key never lands in the map.
 	pricingClient := mock.NewMockClient(mockCtrl)
-	pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return("", nil).
+	pricingClient.EXPECT().ListRDSPrices(gomock.Any(), gomock.Any()).
+		Return([]string{}, nil).
 		Times(1)
 
 	pm := newPricingMap()
@@ -295,9 +303,7 @@ func TestCollector_Collect_MultiRegion(t *testing.T) {
 
 	// One distinct pricing key per region.
 	pricingClient := mock.NewMockClient(mockCtrl)
-	pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(validPriceJSON, nil).
-		Times(len(regionNames))
+	expectPricing(pricingClient, "0.456")
 
 	pm := newPricingMap()
 	store := newTestStore(regions, regionMap, pricingClient, pm)

--- a/pkg/aws/rds/rds_test.go
+++ b/pkg/aws/rds/rds_test.go
@@ -1,10 +1,8 @@
 package rds
 
 import (
-	"context"
 	"log/slog"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -14,9 +12,22 @@ import (
 	"github.com/grafana/cloudcost-exporter/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
+
+const validPriceJSON = `{
+	"terms": {
+		"OnDemand": {
+			"term1": {
+				"priceDimensions": {
+					"dim1": {
+						"pricePerUnit": {"USD": "0.456"}
+					}
+				}
+			}
+		}
+	}
+}`
 
 func TestIsOutpostsInstance(t *testing.T) {
 	tests := []struct {
@@ -112,34 +123,161 @@ func TestMultiOrSingleAZ(t *testing.T) {
 	}
 }
 
-func TestCollector_Collect_MultiRegion(t *testing.T) {
-	const validPriceJSON = `{
-            "terms": {
-                "OnDemand": {
-                    "term1": {
-                        "priceDimensions": {
-                            "dim1": {
-                                "pricePerUnit": {"USD": "0.456"}
-                            }
-                        }
-                    }
-                }
-            }
-        }`
+func instanceFor(region, id string) rdsTypes.DBInstance {
+	return rdsTypes.DBInstance{
+		DBSubnetGroup:        &rdsTypes.DBSubnetGroup{},
+		AvailabilityZone:     aws.String(region + "a"),
+		DBInstanceClass:      aws.String("db.t3.medium"),
+		Engine:               aws.String("postgres"),
+		DBInstanceIdentifier: aws.String(id),
+		MultiAZ:              aws.Bool(false),
+		DbiResourceId:        aws.String(id),
+		DBInstanceArn:        aws.String("arn-" + id),
+	}
+}
 
-	instanceFor := func(region, id string) rdsTypes.DBInstance {
-		return rdsTypes.DBInstance{
-			DBSubnetGroup:        &rdsTypes.DBSubnetGroup{},
-			AvailabilityZone:     aws.String(region + "a"),
-			DBInstanceClass:      aws.String("db.t3.medium"),
-			Engine:               aws.String("postgres"),
-			DBInstanceIdentifier: aws.String(id),
-			MultiAZ:              aws.Bool(false),
-			DbiResourceId:        aws.String(id),
-			DBInstanceArn:        aws.String("arn-" + id),
-		}
+// collectRegions drains ch and returns the set of region labels seen.
+func collectRegions(t *testing.T, ch chan prometheus.Metric) map[string]bool {
+	t.Helper()
+	close(ch)
+	got := map[string]bool{}
+	for metric := range ch {
+		got[utils.ReadMetrics(metric).Labels["region"]] = true
+	}
+	return got
+}
+
+// TestCollector_Collect_ColdStart verifies that a scrape before the first
+// populate finishes emits no metrics and does not error.
+func TestCollector_Collect_ColdStart(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	regionClient := mock.NewMockClient(mockCtrl)
+	// No AWS calls expected: the store has not populated, so Collect returns early.
+
+	pm := newPricingMap()
+	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
+	regionMap := map[string]client.Client{"us-east-1": regionClient}
+	store := newTestStore(regions, regionMap, regionClient, pm)
+
+	c := &Collector{
+		regions:        regions,
+		regionMap:      regionMap,
+		pricingMap:     pm,
+		store:          store,
+		accountID:      "123456789012",
+		populateErrors: store.populateErrors,
+		logger:         slog.Default(),
 	}
 
+	ch := make(chan prometheus.Metric, 1)
+	err := c.Collect(t.Context(), ch)
+	assert.NoError(t, err)
+
+	select {
+	case <-ch:
+		t.Fatal("expected no metric before the store is populated")
+	default:
+	}
+}
+
+// TestCollector_Collect_ServesFromWarmMap verifies that once the store is
+// populated, Collect serves instances and prices from memory and makes zero
+// AWS calls. The gomock Times(1) expectations are consumed entirely by the
+// background populate; any call from Collect would exceed them and fail.
+func TestCollector_Collect_ServesFromWarmMap(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	regionClient := mock.NewMockClient(mockCtrl)
+	regionClient.EXPECT().ListRDSInstances(gomock.Any()).
+		Return([]rdsTypes.DBInstance{instanceFor("us-east-1", "db-1")}, nil).
+		Times(1)
+
+	pricingClient := mock.NewMockClient(mockCtrl)
+	pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(validPriceJSON, nil).
+		Times(1)
+
+	pm := newPricingMap()
+	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
+	regionMap := map[string]client.Client{"us-east-1": regionClient}
+	store := newTestStore(regions, regionMap, pricingClient, pm)
+	store.Populate(t.Context())
+
+	c := &Collector{
+		regions:        regions,
+		regionMap:      regionMap,
+		pricingMap:     pm,
+		store:          store,
+		accountID:      "123456789012",
+		populateErrors: store.populateErrors,
+		logger:         slog.Default(),
+	}
+
+	ch := make(chan prometheus.Metric, 1)
+	err := c.Collect(t.Context(), ch)
+	assert.NoError(t, err)
+
+	select {
+	case metric := <-ch:
+		result := utils.ReadMetrics(metric)
+		assert.Equal(t, "db.t3.medium", result.Labels["tier"])
+		assert.Equal(t, "db-1", result.Labels["id"])
+		assert.Equal(t, 0.456, result.Value)
+	default:
+		t.Fatal("expected a metric to be collected from the warm map")
+	}
+}
+
+// TestCollector_Collect_PricingMiss verifies that an instance whose price never
+// warmed is skipped with a log and does not fail the scrape.
+func TestCollector_Collect_PricingMiss(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	regionClient := mock.NewMockClient(mockCtrl)
+	regionClient.EXPECT().ListRDSInstances(gomock.Any()).
+		Return([]rdsTypes.DBInstance{instanceFor("us-east-1", "db-1")}, nil).
+		Times(1)
+
+	// The pricing API returns no data, so the key never lands in the map.
+	pricingClient := mock.NewMockClient(mockCtrl)
+	pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return("", nil).
+		Times(1)
+
+	pm := newPricingMap()
+	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
+	regionMap := map[string]client.Client{"us-east-1": regionClient}
+	store := newTestStore(regions, regionMap, pricingClient, pm)
+	store.Populate(t.Context())
+
+	c := &Collector{
+		regions:        regions,
+		regionMap:      regionMap,
+		pricingMap:     pm,
+		store:          store,
+		accountID:      "123456789012",
+		populateErrors: store.populateErrors,
+		logger:         slog.Default(),
+	}
+
+	ch := make(chan prometheus.Metric, 1)
+	err := c.Collect(t.Context(), ch)
+	assert.NoError(t, err)
+
+	select {
+	case <-ch:
+		t.Fatal("expected no metric when pricing is missing")
+	default:
+	}
+}
+
+// TestCollector_Collect_MultiRegion verifies instances from every region are
+// served from the warm store.
+func TestCollector_Collect_MultiRegion(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -155,299 +293,32 @@ func TestCollector_Collect_MultiRegion(t *testing.T) {
 		regionMap[region] = regionClient
 	}
 
-	// Pricing lookups go through the shared client; serve a valid price for any region.
+	// One distinct pricing key per region.
 	pricingClient := mock.NewMockClient(mockCtrl)
 	pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(validPriceJSON, nil).
-		AnyTimes()
+		Times(len(regionNames))
+
+	pm := newPricingMap()
+	store := newTestStore(regions, regionMap, pricingClient, pm)
+	store.Populate(t.Context())
 
 	c := &Collector{
-		pricingMap:        newPricingMap(),
-		regions:           regions,
-		regionMap:         regionMap,
-		scrapeInterval:    time.Minute,
-		regionListTimeout: time.Minute,
-		Client:            pricingClient,
-		accountID:         "123456789012",
-		logger:            slog.Default(),
+		regions:        regions,
+		regionMap:      regionMap,
+		pricingMap:     pm,
+		store:          store,
+		accountID:      "123456789012",
+		populateErrors: store.populateErrors,
+		logger:         slog.Default(),
 	}
 
 	ch := make(chan prometheus.Metric, len(regionNames))
 	err := c.Collect(t.Context(), ch)
 	assert.NoError(t, err)
-	close(ch)
 
-	gotRegions := map[string]bool{}
-	for metric := range ch {
-		gotRegions[utils.ReadMetrics(metric).Labels["region"]] = true
-	}
+	gotRegions := collectRegions(t, ch)
 	for _, region := range regionNames {
 		assert.True(t, gotRegions[region], "expected a metric for region %s", region)
-	}
-}
-
-// TestCollector_Collect_SlowRegionFailsFast verifies a region whose
-// ListRDSInstances hangs is bounded by regionListTimeout and does not block the
-// healthy regions or the overall Collect.
-func TestCollector_Collect_SlowRegionFailsFast(t *testing.T) {
-	const validPriceJSON = `{"terms":{"OnDemand":{"t":{"priceDimensions":{"d":{"pricePerUnit":{"USD":"0.456"}}}}}}}`
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	healthyInstance := rdsTypes.DBInstance{
-		DBSubnetGroup:        &rdsTypes.DBSubnetGroup{},
-		AvailabilityZone:     aws.String("us-east-1a"),
-		DBInstanceClass:      aws.String("db.t3.medium"),
-		Engine:               aws.String("postgres"),
-		DBInstanceIdentifier: aws.String("healthy-db"),
-		MultiAZ:              aws.Bool(false),
-		DbiResourceId:        aws.String("healthy-db"),
-		DBInstanceArn:        aws.String("arn-healthy"),
-	}
-
-	healthy := mock.NewMockClient(mockCtrl)
-	healthy.EXPECT().ListRDSInstances(gomock.Any()).
-		Return([]rdsTypes.DBInstance{healthyInstance}, nil).
-		Times(1)
-
-	// The slow region blocks until its (timeout-bounded) context is canceled,
-	// then returns the context error — mimicking an unreachable endpoint.
-	slow := mock.NewMockClient(mockCtrl)
-	slow.EXPECT().ListRDSInstances(gomock.Any()).
-		DoAndReturn(func(ctx context.Context) ([]rdsTypes.DBInstance, error) {
-			<-ctx.Done()
-			return nil, ctx.Err()
-		}).
-		Times(1)
-
-	pricingClient := mock.NewMockClient(mockCtrl)
-	pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(validPriceJSON, nil).
-		AnyTimes()
-
-	c := &Collector{
-		pricingMap: newPricingMap(),
-		regions: []types.Region{
-			{RegionName: aws.String("us-east-1")},
-			{RegionName: aws.String("ap-southeast-7")},
-		},
-		regionMap: map[string]client.Client{
-			"us-east-1":      healthy,
-			"ap-southeast-7": slow,
-		},
-		scrapeInterval:    time.Minute,
-		regionListTimeout: 50 * time.Millisecond,
-		Client:            pricingClient,
-		accountID:         "123456789012",
-		logger:            slog.Default(),
-	}
-
-	ch := make(chan prometheus.Metric, 2)
-	start := time.Now()
-	err := c.Collect(t.Context(), ch)
-	elapsed := time.Since(start)
-	assert.NoError(t, err)
-	close(ch)
-
-	// Collect returns shortly after the per-region timeout, not after the full
-	// collector budget; allow generous slack for CI scheduling.
-	assert.Less(t, elapsed, 5*time.Second, "slow region should not block Collect")
-
-	gotRegions := map[string]bool{}
-	for metric := range ch {
-		gotRegions[utils.ReadMetrics(metric).Labels["region"]] = true
-	}
-	assert.True(t, gotRegions["us-east-1"], "healthy region should still emit a metric")
-	assert.False(t, gotRegions["ap-southeast-7"], "slow region should be skipped, not block")
-}
-
-// TestCollector_Collect_RegionListTimeout verifies the wrap/no-wrap behavior:
-// a zero timeout leaves the region call bounded only by the parent context
-// (backwards-compatible default), while a positive timeout imposes a deadline.
-func TestCollector_Collect_RegionListTimeout(t *testing.T) {
-	tests := []struct {
-		name              string
-		regionListTimeout time.Duration
-		wantDeadline      bool
-	}{
-		{name: "zero disables per-region timeout", regionListTimeout: 0, wantDeadline: false},
-		{name: "positive imposes per-region timeout", regionListTimeout: 30 * time.Second, wantDeadline: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
-
-			var gotDeadline bool
-			regionClient := mock.NewMockClient(mockCtrl)
-			regionClient.EXPECT().ListRDSInstances(gomock.Any()).
-				DoAndReturn(func(ctx context.Context) ([]rdsTypes.DBInstance, error) {
-					_, gotDeadline = ctx.Deadline()
-					return nil, nil
-				}).
-				Times(1)
-
-			c := &Collector{
-				pricingMap:        newPricingMap(),
-				regions:           []types.Region{{RegionName: aws.String("us-east-1")}},
-				regionMap:         map[string]client.Client{"us-east-1": regionClient},
-				scrapeInterval:    time.Minute,
-				regionListTimeout: tt.regionListTimeout,
-				Client:            regionClient,
-				accountID:         "123456789012",
-				logger:            slog.Default(),
-			}
-
-			// Parent context carries no deadline, so any deadline observed by the
-			// region call comes from the per-region timeout.
-			ch := make(chan prometheus.Metric, 1)
-			require.NoError(t, c.Collect(context.Background(), ch))
-			assert.Equal(t, tt.wantDeadline, gotDeadline)
-		})
-	}
-}
-
-func TestCollector_Collect(t *testing.T) {
-	const cacheKey = "us-east-1-db.t3.medium-mysql-Single-AZ-AWS Outposts"
-	validPriceJSON := `{
-            "terms": {
-                "OnDemand": {
-                    "term1": {
-                        "priceDimensions": {
-                            "dim1": {
-                                "pricePerUnit": {"USD": "0.456"}
-                            }
-                        }
-                    }
-                }
-            }
-        }`
-	tests := []struct {
-		name                 string
-		ListRDSInstances     []rdsTypes.DBInstance
-		pricingKey           string
-		getRDSUnitDataRet    string
-		expectGetRDSUnitData bool
-		expectMetric         bool
-		initialCache         map[string]float64
-	}{
-		{
-			name: "cache hit - uses cached price",
-			ListRDSInstances: []rdsTypes.DBInstance{{
-				DBSubnetGroup: &rdsTypes.DBSubnetGroup{
-					Subnets: []rdsTypes.Subnet{
-						{
-							SubnetOutpost: &rdsTypes.Outpost{
-								Arn: aws.String("some-outpost-arn"),
-							},
-						},
-					},
-				},
-				AvailabilityZone:     aws.String("us-east-1a"),
-				DBInstanceClass:      aws.String("db.t3.medium"),
-				Engine:               aws.String("mysql"),
-				DBInstanceIdentifier: aws.String("test-db"),
-				MultiAZ:              aws.Bool(false),
-				DbiResourceId:        aws.String("test-db"),
-				DBInstanceArn:        aws.String("some-arn"),
-			}},
-			pricingKey:           cacheKey,
-			expectGetRDSUnitData: false,
-			expectMetric:         true,
-			initialCache:         map[string]float64{cacheKey: 0.123},
-		},
-		{
-			name: "cache miss - fetches price from API",
-			ListRDSInstances: []rdsTypes.DBInstance{{
-				DBSubnetGroup:        &rdsTypes.DBSubnetGroup{},
-				AvailabilityZone:     aws.String("us-east-1a"),
-				DBInstanceClass:      aws.String("db.t3.medium"),
-				Engine:               aws.String("postgres"),
-				DBInstanceIdentifier: aws.String("test-db-2"),
-				MultiAZ:              aws.Bool(false),
-				DbiResourceId:        aws.String("test-db-2"),
-				DBInstanceArn:        aws.String("some-arn-2"),
-			}},
-			pricingKey:           createPricingKey("us-east-1", "db.t3.medium", "postgres", "Single-AZ", "AWS Region"),
-			getRDSUnitDataRet:    validPriceJSON,
-			expectGetRDSUnitData: true,
-			expectMetric:         true,
-			initialCache:         map[string]float64{},
-		},
-		{
-			name: "no pricing data returned for instance - skips without error",
-			ListRDSInstances: []rdsTypes.DBInstance{{
-				DBSubnetGroup:        &rdsTypes.DBSubnetGroup{},
-				AvailabilityZone:     aws.String("us-east-1a"),
-				DBInstanceClass:      aws.String("db.t3.medium"),
-				Engine:               aws.String("aurora-postgresql"),
-				DBInstanceIdentifier: aws.String("test-db-3"),
-				MultiAZ:              aws.Bool(false),
-				DbiResourceId:        aws.String("test-db-3"),
-				DBInstanceArn:        aws.String("some-arn-3"),
-			}},
-			pricingKey:           createPricingKey("us-east-1", "db.t3.medium", "aurora-postgresql", "Single-AZ", "AWS Region"),
-			getRDSUnitDataRet:    "",
-			expectGetRDSUnitData: true,
-			expectMetric:         false,
-			initialCache:         map[string]float64{},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
-
-			mockClient := mock.NewMockClient(mockCtrl)
-			mockClient.EXPECT().ListRDSInstances(gomock.Any()).
-				Return(tt.ListRDSInstances, nil).
-				Times(1)
-
-			if tt.expectGetRDSUnitData {
-				mockClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(tt.getRDSUnitDataRet, nil).
-					Times(1)
-			}
-
-			c := &Collector{
-				pricingMap:        &pricingMap{pricingMap: tt.initialCache},
-				regions:           []types.Region{{RegionName: aws.String("us-east-1")}},
-				regionMap:         map[string]client.Client{"us-east-1": mockClient},
-				scrapeInterval:    time.Minute,
-				regionListTimeout: time.Minute,
-				Client:            mockClient,
-				accountID:         "123456789012",
-				logger:            slog.Default(),
-			}
-
-			ch := make(chan prometheus.Metric, 1)
-			err := c.Collect(t.Context(), ch)
-			assert.NoError(t, err)
-
-			if !tt.expectMetric {
-				select {
-				case <-ch:
-					t.Fatal("expected no metric to be collected")
-				default:
-				}
-				return
-			}
-
-			select {
-			case metric := <-ch:
-				metricResult := utils.ReadMetrics(metric)
-				close(ch)
-				labels := metricResult.Labels
-				hourlyPrice, _ := c.pricingMap.Get(tt.pricingKey)
-				assert.Equal(t, *tt.ListRDSInstances[0].DBInstanceClass, labels["tier"])
-				assert.Equal(t, *tt.ListRDSInstances[0].DbiResourceId, labels["id"])
-				assert.Equal(t, hourlyPrice, metricResult.Value)
-			default:
-				t.Fatal("expected a metric to be collected")
-			}
-		})
 	}
 }

--- a/pkg/aws/rds/rds_test.go
+++ b/pkg/aws/rds/rds_test.go
@@ -144,6 +144,69 @@ func instanceFor(region, id string) rdsTypes.DBInstance {
 	}
 }
 
+// TestPricingKeyFor_AuroraStorageMode verifies Aurora engines disambiguate
+// Standard vs I/O-Optimized storage in the pricing key, non-Aurora engines are
+// unaffected, and a missing or unrecognized Aurora StorageType is skipped
+// rather than silently mis-keyed.
+func TestPricingKeyFor_AuroraStorageMode(t *testing.T) {
+	auroraInstance := func(storageType *string) rdsTypes.DBInstance {
+		inst := instanceFor("us-east-1", "aurora-1")
+		inst.Engine = aws.String("aurora-mysql")
+		inst.StorageType = storageType
+		return inst
+	}
+
+	tests := []struct {
+		name   string
+		inst   rdsTypes.DBInstance
+		wantOK bool
+	}{
+		{
+			name:   "non-aurora engine ignores storage type",
+			inst:   instanceFor("us-east-1", "db-1"),
+			wantOK: true,
+		},
+		{
+			name:   "aurora standard storage",
+			inst:   auroraInstance(aws.String("aurora")),
+			wantOK: true,
+		},
+		{
+			name:   "aurora I/O-optimized storage",
+			inst:   auroraInstance(aws.String("aurora-iopt1")),
+			wantOK: true,
+		},
+		{
+			name:   "aurora with nil storage type is skipped",
+			inst:   auroraInstance(nil),
+			wantOK: false,
+		},
+		{
+			name:   "aurora with unrecognized storage type is skipped",
+			inst:   auroraInstance(aws.String("some-future-mode")),
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, ok := pricingKeyFor(tt.inst)
+			assert.Equal(t, tt.wantOK, ok)
+		})
+	}
+
+	t.Run("standard and I/O-optimized keys are distinct and match the pricing side", func(t *testing.T) {
+		standardKey, _, ok := pricingKeyFor(auroraInstance(aws.String("aurora")))
+		assert.True(t, ok)
+		ioOptimizedKey, _, ok := pricingKeyFor(auroraInstance(aws.String("aurora-iopt1")))
+		assert.True(t, ok)
+
+		assert.NotEqual(t, standardKey, ioOptimizedKey)
+		assert.Equal(t, createPricingKey("us-east-1", "db.t3.medium", "Aurora MySQL", "", "Single-AZ", "No license required", "AWS Region", auroraStorageModeStandard), standardKey)
+		assert.Equal(t, createPricingKey("us-east-1", "db.t3.medium", "Aurora MySQL", "", "Single-AZ", "No license required", "AWS Region", auroraStorageModeIOOptimized), ioOptimizedKey)
+	})
+}
+
 // collectRegions drains ch and returns the set of region labels seen.
 func collectRegions(t *testing.T, ch chan prometheus.Metric) map[string]bool {
 	t.Helper()

--- a/pkg/aws/rds/rds_test.go
+++ b/pkg/aws/rds/rds_test.go
@@ -155,27 +155,27 @@ func collectRegions(t *testing.T, ch chan prometheus.Metric) map[string]bool {
 	return got
 }
 
-// TestCollector_Collect_ColdStart verifies that a scrape before the first
-// populate finishes emits no metrics and does not error.
-func TestCollector_Collect_ColdStart(t *testing.T) {
+// TestCollector_Collect_ColdStart_NeitherReady verifies that a scrape before
+// either store has populated emits no metrics and does not error.
+func TestCollector_Collect_ColdStart_NeitherReady(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
 	regionClient := mock.NewMockClient(mockCtrl)
-	// No AWS calls expected: the store has not populated, so Collect returns early.
+	// No AWS calls expected: neither store has populated, so Collect returns early.
 
-	pm := newPricingMap()
 	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
 	regionMap := map[string]client.Client{"us-east-1": regionClient}
-	store := newTestStore(regions, regionMap, regionClient, pm)
+	instanceStore := newTestInstanceStore(regions, regionMap)
+	pricingStore := newTestPricingStore(regions, regionClient)
 
 	c := &Collector{
 		regions:        regions,
 		regionMap:      regionMap,
-		pricingMap:     pm,
-		store:          store,
+		instanceStore:  instanceStore,
+		pricingStore:   pricingStore,
 		accountID:      "123456789012",
-		populateErrors: store.populateErrors,
+		populateErrors: instanceStore.populateErrors,
 		logger:         slog.Default(),
 	}
 
@@ -185,7 +185,89 @@ func TestCollector_Collect_ColdStart(t *testing.T) {
 
 	select {
 	case <-ch:
-		t.Fatal("expected no metric before the store is populated")
+		t.Fatal("expected no metric before either store is populated")
+	default:
+	}
+}
+
+// TestCollector_Collect_ColdStart_InstancesReadyPricesNot verifies that a
+// scrape with a warm instance store but a cold pricing store still emits no
+// metrics and does not error.
+func TestCollector_Collect_ColdStart_InstancesReadyPricesNot(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	regionClient := mock.NewMockClient(mockCtrl)
+	regionClient.EXPECT().ListRDSInstances(gomock.Any()).
+		Return([]rdsTypes.DBInstance{instanceFor("us-east-1", "db-1")}, nil).
+		Times(1)
+	// No ListRDSPrices call expected: the pricing store never populates.
+	pricingClient := mock.NewMockClient(mockCtrl)
+
+	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
+	regionMap := map[string]client.Client{"us-east-1": regionClient}
+	instanceStore := newTestInstanceStore(regions, regionMap)
+	instanceStore.Populate(t.Context())
+	pricingStore := newTestPricingStore(regions, pricingClient)
+
+	c := &Collector{
+		regions:        regions,
+		regionMap:      regionMap,
+		instanceStore:  instanceStore,
+		pricingStore:   pricingStore,
+		accountID:      "123456789012",
+		populateErrors: instanceStore.populateErrors,
+		logger:         slog.Default(),
+	}
+
+	ch := make(chan prometheus.Metric, 1)
+	err := c.Collect(t.Context(), ch)
+	assert.NoError(t, err)
+
+	select {
+	case <-ch:
+		t.Fatal("expected no metric while the pricing store is cold")
+	default:
+	}
+}
+
+// TestCollector_Collect_ColdStart_PricesReadyInstancesNot verifies that a
+// scrape with a warm pricing store but a cold instance store still emits no
+// metrics and does not error.
+func TestCollector_Collect_ColdStart_PricesReadyInstancesNot(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	// No ListRDSInstances call expected: the instance store never populates.
+	regionClient := mock.NewMockClient(mockCtrl)
+	pricingClient := mock.NewMockClient(mockCtrl)
+	pricingClient.EXPECT().ListRDSPrices(gomock.Any(), gomock.Any()).
+		Return([]string{postgresPrice("us-east-1", "0.456")}, nil).
+		Times(1)
+
+	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
+	regionMap := map[string]client.Client{"us-east-1": regionClient}
+	instanceStore := newTestInstanceStore(regions, regionMap)
+	pricingStore := newTestPricingStore(regions, pricingClient)
+	pricingStore.Populate(t.Context())
+
+	c := &Collector{
+		regions:        regions,
+		regionMap:      regionMap,
+		instanceStore:  instanceStore,
+		pricingStore:   pricingStore,
+		accountID:      "123456789012",
+		populateErrors: instanceStore.populateErrors,
+		logger:         slog.Default(),
+	}
+
+	ch := make(chan prometheus.Metric, 1)
+	err := c.Collect(t.Context(), ch)
+	assert.NoError(t, err)
+
+	select {
+	case <-ch:
+		t.Fatal("expected no metric while the instance store is cold")
 	default:
 	}
 }
@@ -208,19 +290,20 @@ func TestCollector_Collect_ServesFromWarmMap(t *testing.T) {
 		Return([]string{postgresPrice("us-east-1", "0.456")}, nil).
 		Times(1)
 
-	pm := newPricingMap()
 	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
 	regionMap := map[string]client.Client{"us-east-1": regionClient}
-	store := newTestStore(regions, regionMap, pricingClient, pm)
-	store.Populate(t.Context())
+	instanceStore := newTestInstanceStore(regions, regionMap)
+	instanceStore.Populate(t.Context())
+	pricingStore := newTestPricingStore(regions, pricingClient)
+	pricingStore.Populate(t.Context())
 
 	c := &Collector{
 		regions:        regions,
 		regionMap:      regionMap,
-		pricingMap:     pm,
-		store:          store,
+		instanceStore:  instanceStore,
+		pricingStore:   pricingStore,
 		accountID:      "123456789012",
-		populateErrors: store.populateErrors,
+		populateErrors: instanceStore.populateErrors,
 		logger:         slog.Default(),
 	}
 
@@ -256,19 +339,20 @@ func TestCollector_Collect_PricingMiss(t *testing.T) {
 		Return([]string{}, nil).
 		Times(1)
 
-	pm := newPricingMap()
 	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
 	regionMap := map[string]client.Client{"us-east-1": regionClient}
-	store := newTestStore(regions, regionMap, pricingClient, pm)
-	store.Populate(t.Context())
+	instanceStore := newTestInstanceStore(regions, regionMap)
+	instanceStore.Populate(t.Context())
+	pricingStore := newTestPricingStore(regions, pricingClient)
+	pricingStore.Populate(t.Context())
 
 	c := &Collector{
 		regions:        regions,
 		regionMap:      regionMap,
-		pricingMap:     pm,
-		store:          store,
+		instanceStore:  instanceStore,
+		pricingStore:   pricingStore,
 		accountID:      "123456789012",
-		populateErrors: store.populateErrors,
+		populateErrors: instanceStore.populateErrors,
 		logger:         slog.Default(),
 	}
 
@@ -305,17 +389,18 @@ func TestCollector_Collect_MultiRegion(t *testing.T) {
 	pricingClient := mock.NewMockClient(mockCtrl)
 	expectPricing(pricingClient, "0.456")
 
-	pm := newPricingMap()
-	store := newTestStore(regions, regionMap, pricingClient, pm)
-	store.Populate(t.Context())
+	instanceStore := newTestInstanceStore(regions, regionMap)
+	instanceStore.Populate(t.Context())
+	pricingStore := newTestPricingStore(regions, pricingClient)
+	pricingStore.Populate(t.Context())
 
 	c := &Collector{
 		regions:        regions,
 		regionMap:      regionMap,
-		pricingMap:     pm,
-		store:          store,
+		instanceStore:  instanceStore,
+		pricingStore:   pricingStore,
 		accountID:      "123456789012",
-		populateErrors: store.populateErrors,
+		populateErrors: instanceStore.populateErrors,
 		logger:         slog.Default(),
 	}
 

--- a/pkg/aws/rds/store.go
+++ b/pkg/aws/rds/store.go
@@ -1,0 +1,238 @@
+package rds
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	cloudcost_exporter "github.com/grafana/cloudcost-exporter"
+	"github.com/grafana/cloudcost-exporter/pkg/aws/client"
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/sync/errgroup"
+)
+
+// populateConcurrency caps the number of regions refreshed in parallel per
+// populate. RDS is regional (one DescribeDBInstances call per region), so this
+// bounds in-flight listing plus the pricing lookups each region triggers.
+const populateConcurrency = 10
+
+// defaultPopulateTimeout caps a single region's background refresh (listing
+// plus pricing) when no RegionListTimeout is configured. On the scrape path the
+// collector interval bounded these calls; the background populate has no such
+// outer deadline, so without a ceiling a hung AWS call would keep Populate from
+// returning, leave the readiness channel open, and skip every future tick. This
+// ceiling guarantees the loop always makes progress.
+const defaultPopulateTimeout = 2 * time.Minute
+
+const defaultRefreshInterval = time.Hour
+
+func newPopulateErrorsCounter() *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: prometheus.BuildFQName(cloudcost_exporter.ExporterName, subsystem, "populate_errors_total"),
+			Help: "Total errors during background store population, by store, region, and operation.",
+		},
+		[]string{"store", "region", "operation"},
+	)
+}
+
+// startRefreshTicker drives a refresh loop until ctx is cancelled. It mirrors
+// the GKE background-store helper of the same name.
+func startRefreshTicker(ctx context.Context, interval time.Duration, run func()) {
+	if interval <= 0 {
+		interval = defaultRefreshInterval
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				run()
+			}
+		}
+	}()
+}
+
+// instanceStore refreshes RDS instance inventory and pricing in the background
+// and serves both to Collect from memory. Listing (the scrape average) and
+// pricing lookups (the cold-start p99 tail) both move off the scrape path.
+// Instances and prices are refreshed together because RDS prices are keyed by
+// attributes only known from the live instances, unlike EC2's bulk pricing.
+type instanceStore struct {
+	logger            *slog.Logger
+	regions           []types.Region
+	regionMap         map[string]client.Client
+	pricingClient     client.Client
+	pricingMap        *pricingMap
+	regionListTimeout time.Duration
+	concurrency       int
+	populateErrors    *prometheus.CounterVec
+
+	mu        sync.RWMutex
+	instances map[string][]rdsTypes.DBInstance // region -> instances
+
+	populating atomic.Bool
+
+	initialPopulationOnce sync.Once
+	initialPopulation     chan struct{}
+}
+
+// newInstanceStore returns a store that begins warming immediately in the
+// background. Warming at startup rather than on the first scrape closes the
+// cold-start pricing gap that drove the RDS p99.
+func newInstanceStore(ctx context.Context, logger *slog.Logger, config *Config, pm *pricingMap, populateErrors *prometheus.CounterVec) *instanceStore {
+	s := &instanceStore{
+		logger:            logger.With("store", "instances"),
+		regions:           config.Regions,
+		regionMap:         config.RegionMap,
+		pricingClient:     config.Client,
+		pricingMap:        pm,
+		regionListTimeout: config.RegionListTimeout,
+		concurrency:       populateConcurrency,
+		populateErrors:    populateErrors,
+		instances:         make(map[string][]rdsTypes.DBInstance),
+		initialPopulation: make(chan struct{}),
+	}
+	go s.Populate(ctx)
+	return s
+}
+
+// Done is closed once the first populate attempt finishes, successfully or not.
+func (s *instanceStore) Done() <-chan struct{} {
+	return s.initialPopulation
+}
+
+// Get returns the cached instances for a region.
+func (s *instanceStore) Get(region string) []rdsTypes.DBInstance {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.instances[region]
+}
+
+// Populate refreshes instance inventory and pricing for every region. It skips
+// the tick if a previous populate is still running, fans out under a bounded
+// errgroup, and logs, counts, and swallows per-region errors so one bad region
+// never drops its siblings.
+func (s *instanceStore) Populate(ctx context.Context) {
+	// Drop overlapping populates: if a tick fires while the previous one is
+	// still running (slow AWS / many regions), avoid doubling API load and the
+	// last-writer race on s.instances.
+	if !s.populating.CompareAndSwap(false, true) {
+		s.logger.LogAttrs(ctx, slog.LevelInfo, "populate already in progress, skipping tick")
+		return
+	}
+	defer s.populating.Store(false)
+
+	defer s.initialPopulationOnce.Do(func() {
+		close(s.initialPopulation)
+	})
+
+	var eg errgroup.Group
+	eg.SetLimit(s.concurrency)
+
+	for _, region := range s.regions {
+		if ctx.Err() != nil {
+			break
+		}
+		regionName := *region.RegionName
+		regionClient, ok := s.regionMap[regionName]
+		if !ok {
+			s.logger.LogAttrs(ctx, slog.LevelError, "no client found for region", slog.String("region", regionName))
+			s.populateErrors.WithLabelValues("instances", regionName, "lookup_client").Inc()
+			continue
+		}
+		eg.Go(func() error {
+			if ctx.Err() != nil {
+				return nil
+			}
+			s.populateRegion(ctx, regionName, regionClient)
+			return nil // log and continue; don't drop sibling regions
+		})
+	}
+	eg.Wait()
+}
+
+// populateRegion lists a single region's instances and warms their prices.
+func (s *instanceStore) populateRegion(ctx context.Context, regionName string, regionClient client.Client) {
+	// Bound every AWS call for this region. A configured RegionListTimeout wins
+	// so operators can fail slow regions fast; otherwise a safety ceiling keeps
+	// a hung listing or pricing call from wedging the background loop.
+	timeout := s.regionListTimeout
+	if timeout <= 0 {
+		timeout = defaultPopulateTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	instances, err := regionClient.ListRDSInstances(ctx)
+	if err != nil {
+		s.logger.LogAttrs(ctx, slog.LevelError, "error listing RDS instances",
+			slog.String("region", regionName),
+			slog.String("error", err.Error()))
+		s.populateErrors.WithLabelValues("instances", regionName, "list_instances").Inc()
+		return
+	}
+
+	s.mu.Lock()
+	s.instances[regionName] = instances
+	s.mu.Unlock()
+
+	s.warmPricing(ctx, regionName, instances)
+}
+
+// warmPricing fetches a price for each distinct pricing key among the region's
+// instances and writes it to the shared pricing map, so Collect never issues a
+// pricing call. Keys already fetched this pass are skipped to collapse the
+// serialized fan-in that caused the cold-start p99.
+func (s *instanceStore) warmPricing(ctx context.Context, regionName string, instances []rdsTypes.DBInstance) {
+	seen := make(map[string]struct{})
+	for _, instance := range instances {
+		key, region, ok := pricingKeyFor(instance)
+		if !ok {
+			// AWS can return partial instances mid create or delete; skip them
+			// rather than panic in this background goroutine.
+			continue
+		}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		depOption := multiOrSingleAZ(*instance.MultiAZ)
+		locationType := isOutpostsInstance(instance)
+		v, err := s.pricingClient.GetRDSUnitData(ctx, *instance.DBInstanceClass, region, depOption, *instance.Engine, locationType)
+		if err != nil {
+			s.logger.LogAttrs(ctx, slog.LevelError, "error fetching RDS price",
+				slog.String("region", region),
+				slog.String("instanceType", *instance.DBInstanceClass),
+				slog.String("engine", *instance.Engine),
+				slog.String("error", err.Error()))
+			s.populateErrors.WithLabelValues("instances", regionName, "get_pricing").Inc()
+			continue
+		}
+		if v == "" {
+			s.logger.LogAttrs(ctx, slog.LevelWarn, "no pricing data found for RDS instance, skipping",
+				slog.String("region", region),
+				slog.String("instanceType", *instance.DBInstanceClass),
+				slog.String("engine", *instance.Engine))
+			continue
+		}
+		price, err := validateRDSPriceData(ctx, v)
+		if err != nil {
+			s.logger.LogAttrs(ctx, slog.LevelError, "error validating RDS price data",
+				slog.String("region", region),
+				slog.String("instanceType", *instance.DBInstanceClass),
+				slog.String("error", err.Error()))
+			s.populateErrors.WithLabelValues("instances", regionName, "validate_pricing").Inc()
+			continue
+		}
+		s.pricingMap.Set(key, price)
+	}
+}

--- a/pkg/aws/rds/store.go
+++ b/pkg/aws/rds/store.go
@@ -63,8 +63,9 @@ func startRefreshTicker(ctx context.Context, interval time.Duration, run func())
 // instanceStore refreshes RDS instance inventory and pricing in the background
 // and serves both to Collect from memory. Listing (the scrape average) and
 // pricing lookups (the cold-start p99 tail) both move off the scrape path.
-// Instances and prices are refreshed together because RDS prices are keyed by
-// attributes only known from the live instances, unlike EC2's bulk pricing.
+// Inventory and pricing are refreshed independently: prices are listed in bulk
+// from the Pricing API and keyed by product attributes, then joined to instances
+// by pricing key at Collect.
 type instanceStore struct {
 	logger            *slog.Logger
 	regions           []types.Region
@@ -159,7 +160,10 @@ func (s *instanceStore) Populate(ctx context.Context) {
 	eg.Wait()
 }
 
-// populateRegion lists a single region's instances and warms their prices.
+// populateRegion refreshes a single region's instance inventory and pricing.
+// The two are independent: pricing is listed in bulk from the Pricing API and
+// keyed by product attributes, not driven by the listed instances. Collect
+// joins them by pricing key.
 func (s *instanceStore) populateRegion(ctx context.Context, regionName string, regionClient client.Client) {
 	// Bound every AWS call for this region. A configured RegionListTimeout wins
 	// so operators can fail slow regions fast; otherwise a safety ceiling keeps
@@ -171,6 +175,12 @@ func (s *instanceStore) populateRegion(ctx context.Context, regionName string, r
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
+	s.populateInstances(ctx, regionName, regionClient)
+	s.populatePricing(ctx, regionName)
+}
+
+// populateInstances lists a region's instances and caches them.
+func (s *instanceStore) populateInstances(ctx context.Context, regionName string, regionClient client.Client) {
 	instances, err := regionClient.ListRDSInstances(ctx)
 	if err != nil {
 		s.logger.LogAttrs(ctx, slog.LevelError, "error listing RDS instances",
@@ -183,54 +193,26 @@ func (s *instanceStore) populateRegion(ctx context.Context, regionName string, r
 	s.mu.Lock()
 	s.instances[regionName] = instances
 	s.mu.Unlock()
-
-	s.warmPricing(ctx, regionName, instances)
 }
 
-// warmPricing fetches a price for each distinct pricing key among the region's
-// instances and writes it to the shared pricing map, so Collect never issues a
-// pricing call. Keys already fetched this pass are skipped to collapse the
-// serialized fan-in that caused the cold-start p99.
-func (s *instanceStore) warmPricing(ctx context.Context, regionName string, instances []rdsTypes.DBInstance) {
-	seen := make(map[string]struct{})
-	for _, instance := range instances {
-		key, region, ok := pricingKeyFor(instance)
-		if !ok {
-			// AWS can return partial instances mid create or delete; skip them
-			// rather than panic in this background goroutine.
-			continue
-		}
-		if _, dup := seen[key]; dup {
-			continue
-		}
-		seen[key] = struct{}{}
+// populatePricing lists every RDS Database Instance price in a region and writes
+// each keyed price to the shared pricing map, so Collect never issues a pricing
+// call. It goes through the dedicated pricing client and lists prices in bulk,
+// keeping pricing independent of the instance inventory.
+func (s *instanceStore) populatePricing(ctx context.Context, regionName string) {
+	priceList, err := s.pricingClient.ListRDSPrices(ctx, regionName)
+	if err != nil {
+		s.logger.LogAttrs(ctx, slog.LevelError, "error listing RDS prices",
+			slog.String("region", regionName),
+			slog.String("error", err.Error()))
+		s.populateErrors.WithLabelValues("instances", regionName, "list_prices").Inc()
+		return
+	}
 
-		depOption := multiOrSingleAZ(*instance.MultiAZ)
-		locationType := isOutpostsInstance(instance)
-		v, err := s.pricingClient.GetRDSUnitData(ctx, *instance.DBInstanceClass, region, depOption, *instance.Engine, locationType)
-		if err != nil {
-			s.logger.LogAttrs(ctx, slog.LevelError, "error fetching RDS price",
-				slog.String("region", region),
-				slog.String("instanceType", *instance.DBInstanceClass),
-				slog.String("engine", *instance.Engine),
-				slog.String("error", err.Error()))
-			s.populateErrors.WithLabelValues("instances", regionName, "get_pricing").Inc()
-			continue
-		}
-		if v == "" {
-			s.logger.LogAttrs(ctx, slog.LevelWarn, "no pricing data found for RDS instance, skipping",
-				slog.String("region", region),
-				slog.String("instanceType", *instance.DBInstanceClass),
-				slog.String("engine", *instance.Engine))
-			continue
-		}
-		price, err := validateRDSPriceData(ctx, v)
-		if err != nil {
-			s.logger.LogAttrs(ctx, slog.LevelError, "error validating RDS price data",
-				slog.String("region", region),
-				slog.String("instanceType", *instance.DBInstanceClass),
-				slog.String("error", err.Error()))
-			s.populateErrors.WithLabelValues("instances", regionName, "validate_pricing").Inc()
+	for _, product := range priceList {
+		key, price, ok := parseRDSPriceProduct(ctx, product)
+		if !ok {
+			s.populateErrors.WithLabelValues("instances", regionName, "parse_pricing").Inc()
 			continue
 		}
 		s.pricingMap.Set(key, price)

--- a/pkg/aws/rds/store.go
+++ b/pkg/aws/rds/store.go
@@ -16,16 +16,17 @@ import (
 )
 
 // populateConcurrency caps the number of regions refreshed in parallel per
-// populate. RDS is regional (one DescribeDBInstances call per region), so this
-// bounds in-flight listing plus the pricing lookups each region triggers.
+// populate. RDS is regional (one DescribeDBInstances or GetProducts call per
+// region), so this bounds in-flight AWS calls for both the instance and
+// pricing stores.
 const populateConcurrency = 10
 
-// defaultPopulateTimeout caps a single region's background refresh (listing
-// plus pricing) when no RegionListTimeout is configured. On the scrape path the
-// collector interval bounded these calls; the background populate has no such
-// outer deadline, so without a ceiling a hung AWS call would keep Populate from
-// returning, leave the readiness channel open, and skip every future tick. This
-// ceiling guarantees the loop always makes progress.
+// defaultPopulateTimeout caps a single region's background refresh when no
+// RegionListTimeout is configured. On the scrape path the collector interval
+// bounded these calls; the background populate has no such outer deadline, so
+// without a ceiling a hung AWS call would keep Populate from returning, leave
+// the readiness channel open, and skip every future tick. This ceiling
+// guarantees the loop always makes progress.
 const defaultPopulateTimeout = 2 * time.Minute
 
 const defaultRefreshInterval = time.Hour
@@ -60,18 +61,14 @@ func startRefreshTicker(ctx context.Context, interval time.Duration, run func())
 	}()
 }
 
-// instanceStore refreshes RDS instance inventory and pricing in the background
-// and serves both to Collect from memory. Listing (the scrape average) and
-// pricing lookups (the cold-start p99 tail) both move off the scrape path.
-// Inventory and pricing are refreshed independently: prices are listed in bulk
-// from the Pricing API and keyed by product attributes, then joined to instances
-// by pricing key at Collect.
+// instanceStore refreshes RDS instance inventory in the background and serves
+// it to Collect from memory, off the scrape path. It knows nothing about
+// pricing: pricing is refreshed independently by pricingStore and joined to
+// instances by pricing key at Collect.
 type instanceStore struct {
 	logger            *slog.Logger
 	regions           []types.Region
 	regionMap         map[string]client.Client
-	pricingClient     client.Client
-	pricingMap        *pricingMap
 	regionListTimeout time.Duration
 	concurrency       int
 	populateErrors    *prometheus.CounterVec
@@ -87,14 +84,12 @@ type instanceStore struct {
 
 // newInstanceStore returns a store that begins warming immediately in the
 // background. Warming at startup rather than on the first scrape closes the
-// cold-start pricing gap that drove the RDS p99.
-func newInstanceStore(ctx context.Context, logger *slog.Logger, config *Config, pm *pricingMap, populateErrors *prometheus.CounterVec) *instanceStore {
+// cold-start gap that drove the RDS p99.
+func newInstanceStore(ctx context.Context, logger *slog.Logger, config *Config, populateErrors *prometheus.CounterVec) *instanceStore {
 	s := &instanceStore{
 		logger:            logger.With("store", "instances"),
 		regions:           config.Regions,
 		regionMap:         config.RegionMap,
-		pricingClient:     config.Client,
-		pricingMap:        pm,
 		regionListTimeout: config.RegionListTimeout,
 		concurrency:       populateConcurrency,
 		populateErrors:    populateErrors,
@@ -117,10 +112,10 @@ func (s *instanceStore) Get(region string) []rdsTypes.DBInstance {
 	return s.instances[region]
 }
 
-// Populate refreshes instance inventory and pricing for every region. It skips
-// the tick if a previous populate is still running, fans out under a bounded
-// errgroup, and logs, counts, and swallows per-region errors so one bad region
-// never drops its siblings.
+// Populate refreshes instance inventory for every region. It skips the tick
+// if a previous populate is still running, fans out under a bounded errgroup,
+// and logs, counts, and swallows per-region errors so one bad region never
+// drops its siblings.
 func (s *instanceStore) Populate(ctx context.Context) {
 	// Drop overlapping populates: if a tick fires while the previous one is
 	// still running (slow AWS / many regions), avoid doubling API load and the
@@ -160,14 +155,12 @@ func (s *instanceStore) Populate(ctx context.Context) {
 	eg.Wait()
 }
 
-// populateRegion refreshes a single region's instance inventory and pricing.
-// The two are independent: pricing is listed in bulk from the Pricing API and
-// keyed by product attributes, not driven by the listed instances. Collect
-// joins them by pricing key.
+// populateRegion refreshes a single region's instance inventory, bounded by a
+// per-region timeout so a hung listing call cannot wedge the background loop.
 func (s *instanceStore) populateRegion(ctx context.Context, regionName string, regionClient client.Client) {
-	// Bound every AWS call for this region. A configured RegionListTimeout wins
+	// Bound the AWS call for this region. A configured RegionListTimeout wins
 	// so operators can fail slow regions fast; otherwise a safety ceiling keeps
-	// a hung listing or pricing call from wedging the background loop.
+	// a hung listing call from wedging the background loop.
 	timeout := s.regionListTimeout
 	if timeout <= 0 {
 		timeout = defaultPopulateTimeout
@@ -176,7 +169,6 @@ func (s *instanceStore) populateRegion(ctx context.Context, regionName string, r
 	defer cancel()
 
 	s.populateInstances(ctx, regionName, regionClient)
-	s.populatePricing(ctx, regionName)
 }
 
 // populateInstances lists a region's instances and caches them.
@@ -193,28 +185,4 @@ func (s *instanceStore) populateInstances(ctx context.Context, regionName string
 	s.mu.Lock()
 	s.instances[regionName] = instances
 	s.mu.Unlock()
-}
-
-// populatePricing lists every RDS Database Instance price in a region and writes
-// each keyed price to the shared pricing map, so Collect never issues a pricing
-// call. It goes through the dedicated pricing client and lists prices in bulk,
-// keeping pricing independent of the instance inventory.
-func (s *instanceStore) populatePricing(ctx context.Context, regionName string) {
-	priceList, err := s.pricingClient.ListRDSPrices(ctx, regionName)
-	if err != nil {
-		s.logger.LogAttrs(ctx, slog.LevelError, "error listing RDS prices",
-			slog.String("region", regionName),
-			slog.String("error", err.Error()))
-		s.populateErrors.WithLabelValues("instances", regionName, "list_prices").Inc()
-		return
-	}
-
-	for _, product := range priceList {
-		key, price, ok := parseRDSPriceProduct(ctx, product)
-		if !ok {
-			s.populateErrors.WithLabelValues("instances", regionName, "parse_pricing").Inc()
-			continue
-		}
-		s.pricingMap.Set(key, price)
-	}
 }

--- a/pkg/aws/rds/store_test.go
+++ b/pkg/aws/rds/store_test.go
@@ -18,6 +18,9 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+// warmKey is the pricing key produced by both instanceFor and postgresPrice.
+var warmKey = createPricingKey("us-east-1", "db.t3.medium", "PostgreSQL", "", "Single-AZ", "No license required", "AWS Region")
+
 // newTestStore builds a store without the background goroutine the production
 // constructor starts, so tests can drive Populate synchronously.
 func newTestStore(regions []types.Region, regionMap map[string]client.Client, pricingClient client.Client, pm *pricingMap) *instanceStore {
@@ -46,8 +49,8 @@ func TestStore_Populate_WarmsInstancesAndPricing(t *testing.T) {
 		Times(1)
 
 	pricingClient := mock.NewMockClient(mockCtrl)
-	pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(validPriceJSON, nil).
+	pricingClient.EXPECT().ListRDSPrices(gomock.Any(), gomock.Any()).
+		Return([]string{postgresPrice("us-east-1", "0.456")}, nil).
 		Times(1)
 
 	pm := newPricingMap()
@@ -58,14 +61,14 @@ func TestStore_Populate_WarmsInstancesAndPricing(t *testing.T) {
 	store.Populate(t.Context())
 
 	assert.Len(t, store.Get("us-east-1"), 1)
-	price, ok := pm.Get(createPricingKey("us-east-1", "db.t3.medium", "postgres", "Single-AZ", "AWS Region"))
+	price, ok := pm.Get(warmKey)
 	assert.True(t, ok, "price should be warmed during populate")
 	assert.Equal(t, 0.456, price)
 }
 
-// TestStore_Populate_DedupesPricingKeys verifies instances sharing a pricing
-// key trigger a single pricing call per populate.
-func TestStore_Populate_DedupesPricingKeys(t *testing.T) {
+// TestStore_Populate_PricingListedOncePerRegion verifies pricing is listed in
+// bulk once per region, independent of how many instances the region has.
+func TestStore_Populate_PricingListedOncePerRegion(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -78,9 +81,9 @@ func TestStore_Populate_DedupesPricingKeys(t *testing.T) {
 		Times(1)
 
 	pricingClient := mock.NewMockClient(mockCtrl)
-	pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(validPriceJSON, nil).
-		Times(1) // both instances share one key
+	pricingClient.EXPECT().ListRDSPrices(gomock.Any(), gomock.Any()).
+		Return([]string{postgresPrice("us-east-1", "0.456")}, nil).
+		Times(1) // one bulk price list regardless of instance count
 
 	pm := newPricingMap()
 	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
@@ -91,13 +94,11 @@ func TestStore_Populate_DedupesPricingKeys(t *testing.T) {
 	assert.Len(t, store.Get("us-east-1"), 2)
 }
 
-// TestStore_Populate_Refresh verifies a second populate re-fetches prices so
-// the map tracks the latest rates.
+// TestStore_Populate_Refresh verifies a second populate re-lists prices so the
+// map tracks the latest rates.
 func TestStore_Populate_Refresh(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
-
-	updatedPriceJSON := `{"terms":{"OnDemand":{"t":{"priceDimensions":{"d":{"pricePerUnit":{"USD":"0.789"}}}}}}}`
 
 	regionClient := mock.NewMockClient(mockCtrl)
 	regionClient.EXPECT().ListRDSInstances(gomock.Any()).
@@ -106,10 +107,10 @@ func TestStore_Populate_Refresh(t *testing.T) {
 
 	pricingClient := mock.NewMockClient(mockCtrl)
 	gomock.InOrder(
-		pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(validPriceJSON, nil).Times(1),
-		pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(updatedPriceJSON, nil).Times(1),
+		pricingClient.EXPECT().ListRDSPrices(gomock.Any(), gomock.Any()).
+			Return([]string{postgresPrice("us-east-1", "0.456")}, nil).Times(1),
+		pricingClient.EXPECT().ListRDSPrices(gomock.Any(), gomock.Any()).
+			Return([]string{postgresPrice("us-east-1", "0.789")}, nil).Times(1),
 	)
 
 	pm := newPricingMap()
@@ -117,14 +118,12 @@ func TestStore_Populate_Refresh(t *testing.T) {
 	regionMap := map[string]client.Client{"us-east-1": regionClient}
 	store := newTestStore(regions, regionMap, pricingClient, pm)
 
-	key := createPricingKey("us-east-1", "db.t3.medium", "postgres", "Single-AZ", "AWS Region")
-
 	store.Populate(t.Context())
-	price, _ := pm.Get(key)
+	price, _ := pm.Get(warmKey)
 	assert.Equal(t, 0.456, price)
 
 	store.Populate(t.Context())
-	price, _ = pm.Get(key)
+	price, _ = pm.Get(warmKey)
 	assert.Equal(t, 0.789, price, "refresh should overwrite the cached price")
 }
 
@@ -139,8 +138,7 @@ func TestStore_Done_ClosesAfterPopulate(t *testing.T) {
 		Return([]rdsTypes.DBInstance{instanceFor("us-east-1", "db-1")}, nil).
 		Times(1)
 	pricingClient := mock.NewMockClient(mockCtrl)
-	pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(validPriceJSON, nil).AnyTimes()
+	expectPricing(pricingClient, "0.456")
 
 	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
 	regionMap := map[string]client.Client{"us-east-1": regionClient}
@@ -203,9 +201,7 @@ func TestStore_Populate_ListErrorCountsAndContinues(t *testing.T) {
 		Times(1)
 
 	pricingClient := mock.NewMockClient(mockCtrl)
-	pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(validPriceJSON, nil).
-		Times(1) // only the healthy region reaches pricing
+	expectPricing(pricingClient, "0.456")
 
 	regions := []types.Region{
 		{RegionName: aws.String("us-east-1")},
@@ -265,6 +261,9 @@ func TestStore_Populate_RegionListTimeout(t *testing.T) {
 					return nil, nil
 				}).
 				Times(1)
+			regionClient.EXPECT().ListRDSPrices(gomock.Any(), gomock.Any()).
+				Return(nil, nil).
+				AnyTimes()
 
 			regions := []types.Region{{RegionName: aws.String("us-east-1")}}
 			regionMap := map[string]client.Client{"us-east-1": regionClient}
@@ -301,9 +300,7 @@ func TestStore_Populate_SlowRegionFailsFast(t *testing.T) {
 		Times(1)
 
 	pricingClient := mock.NewMockClient(mockCtrl)
-	pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(validPriceJSON, nil).
-		AnyTimes()
+	expectPricing(pricingClient, "0.456")
 
 	regions := []types.Region{
 		{RegionName: aws.String("us-east-1")},

--- a/pkg/aws/rds/store_test.go
+++ b/pkg/aws/rds/store_test.go
@@ -1,0 +1,326 @@
+package rds
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	"github.com/grafana/cloudcost-exporter/pkg/aws/client"
+	mock "github.com/grafana/cloudcost-exporter/pkg/aws/client/mocks"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// newTestStore builds a store without the background goroutine the production
+// constructor starts, so tests can drive Populate synchronously.
+func newTestStore(regions []types.Region, regionMap map[string]client.Client, pricingClient client.Client, pm *pricingMap) *instanceStore {
+	return &instanceStore{
+		logger:            slog.Default(),
+		regions:           regions,
+		regionMap:         regionMap,
+		pricingClient:     pricingClient,
+		pricingMap:        pm,
+		concurrency:       populateConcurrency,
+		populateErrors:    newPopulateErrorsCounter(),
+		instances:         make(map[string][]rdsTypes.DBInstance),
+		initialPopulation: make(chan struct{}),
+	}
+}
+
+// TestStore_Populate_WarmsInstancesAndPricing verifies a populate caches the
+// region's instances and fills the pricing map off the scrape path.
+func TestStore_Populate_WarmsInstancesAndPricing(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	regionClient := mock.NewMockClient(mockCtrl)
+	regionClient.EXPECT().ListRDSInstances(gomock.Any()).
+		Return([]rdsTypes.DBInstance{instanceFor("us-east-1", "db-1")}, nil).
+		Times(1)
+
+	pricingClient := mock.NewMockClient(mockCtrl)
+	pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(validPriceJSON, nil).
+		Times(1)
+
+	pm := newPricingMap()
+	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
+	regionMap := map[string]client.Client{"us-east-1": regionClient}
+	store := newTestStore(regions, regionMap, pricingClient, pm)
+
+	store.Populate(t.Context())
+
+	assert.Len(t, store.Get("us-east-1"), 1)
+	price, ok := pm.Get(createPricingKey("us-east-1", "db.t3.medium", "postgres", "Single-AZ", "AWS Region"))
+	assert.True(t, ok, "price should be warmed during populate")
+	assert.Equal(t, 0.456, price)
+}
+
+// TestStore_Populate_DedupesPricingKeys verifies instances sharing a pricing
+// key trigger a single pricing call per populate.
+func TestStore_Populate_DedupesPricingKeys(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	regionClient := mock.NewMockClient(mockCtrl)
+	regionClient.EXPECT().ListRDSInstances(gomock.Any()).
+		Return([]rdsTypes.DBInstance{
+			instanceFor("us-east-1", "db-1"),
+			instanceFor("us-east-1", "db-2"),
+		}, nil).
+		Times(1)
+
+	pricingClient := mock.NewMockClient(mockCtrl)
+	pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(validPriceJSON, nil).
+		Times(1) // both instances share one key
+
+	pm := newPricingMap()
+	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
+	regionMap := map[string]client.Client{"us-east-1": regionClient}
+	store := newTestStore(regions, regionMap, pricingClient, pm)
+
+	store.Populate(t.Context())
+	assert.Len(t, store.Get("us-east-1"), 2)
+}
+
+// TestStore_Populate_Refresh verifies a second populate re-fetches prices so
+// the map tracks the latest rates.
+func TestStore_Populate_Refresh(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	updatedPriceJSON := `{"terms":{"OnDemand":{"t":{"priceDimensions":{"d":{"pricePerUnit":{"USD":"0.789"}}}}}}}`
+
+	regionClient := mock.NewMockClient(mockCtrl)
+	regionClient.EXPECT().ListRDSInstances(gomock.Any()).
+		Return([]rdsTypes.DBInstance{instanceFor("us-east-1", "db-1")}, nil).
+		Times(2)
+
+	pricingClient := mock.NewMockClient(mockCtrl)
+	gomock.InOrder(
+		pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(validPriceJSON, nil).Times(1),
+		pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(updatedPriceJSON, nil).Times(1),
+	)
+
+	pm := newPricingMap()
+	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
+	regionMap := map[string]client.Client{"us-east-1": regionClient}
+	store := newTestStore(regions, regionMap, pricingClient, pm)
+
+	key := createPricingKey("us-east-1", "db.t3.medium", "postgres", "Single-AZ", "AWS Region")
+
+	store.Populate(t.Context())
+	price, _ := pm.Get(key)
+	assert.Equal(t, 0.456, price)
+
+	store.Populate(t.Context())
+	price, _ = pm.Get(key)
+	assert.Equal(t, 0.789, price, "refresh should overwrite the cached price")
+}
+
+// TestStore_Done_ClosesAfterPopulate verifies readiness is signalled once the
+// first populate attempt finishes.
+func TestStore_Done_ClosesAfterPopulate(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	regionClient := mock.NewMockClient(mockCtrl)
+	regionClient.EXPECT().ListRDSInstances(gomock.Any()).
+		Return([]rdsTypes.DBInstance{instanceFor("us-east-1", "db-1")}, nil).
+		Times(1)
+	pricingClient := mock.NewMockClient(mockCtrl)
+	pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(validPriceJSON, nil).AnyTimes()
+
+	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
+	regionMap := map[string]client.Client{"us-east-1": regionClient}
+	store := newTestStore(regions, regionMap, pricingClient, newPricingMap())
+
+	select {
+	case <-store.Done():
+		t.Fatal("Done should not be closed before the first populate")
+	default:
+	}
+
+	store.Populate(t.Context())
+
+	select {
+	case <-store.Done():
+	default:
+		t.Fatal("Done should be closed after the first populate")
+	}
+}
+
+// TestStore_Populate_OverlapGuard verifies a populate is skipped while another
+// is still running, so a slow AWS API cannot double the load.
+func TestStore_Populate_OverlapGuard(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	regionClient := mock.NewMockClient(mockCtrl)
+	// No calls expected: the guard short-circuits before any listing.
+
+	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
+	regionMap := map[string]client.Client{"us-east-1": regionClient}
+	store := newTestStore(regions, regionMap, regionClient, newPricingMap())
+
+	// Simulate an in-flight populate.
+	require.True(t, store.populating.CompareAndSwap(false, true))
+
+	store.Populate(t.Context())
+
+	select {
+	case <-store.Done():
+		t.Fatal("a skipped populate must not signal readiness")
+	default:
+	}
+}
+
+// TestStore_Populate_ListErrorCountsAndContinues verifies a failing region is
+// counted and skipped without dropping its healthy siblings.
+func TestStore_Populate_ListErrorCountsAndContinues(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	healthy := mock.NewMockClient(mockCtrl)
+	healthy.EXPECT().ListRDSInstances(gomock.Any()).
+		Return([]rdsTypes.DBInstance{instanceFor("us-east-1", "healthy")}, nil).
+		Times(1)
+
+	broken := mock.NewMockClient(mockCtrl)
+	broken.EXPECT().ListRDSInstances(gomock.Any()).
+		Return(nil, errors.New("boom")).
+		Times(1)
+
+	pricingClient := mock.NewMockClient(mockCtrl)
+	pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(validPriceJSON, nil).
+		Times(1) // only the healthy region reaches pricing
+
+	regions := []types.Region{
+		{RegionName: aws.String("us-east-1")},
+		{RegionName: aws.String("eu-west-1")},
+	}
+	regionMap := map[string]client.Client{
+		"us-east-1": healthy,
+		"eu-west-1": broken,
+	}
+	store := newTestStore(regions, regionMap, pricingClient, newPricingMap())
+
+	store.Populate(t.Context())
+
+	assert.Len(t, store.Get("us-east-1"), 1, "healthy region should still be cached")
+	assert.Empty(t, store.Get("eu-west-1"), "failed region should have no cached instances")
+	assert.Equal(t, 1.0, testutil.ToFloat64(store.populateErrors.WithLabelValues("instances", "eu-west-1", "list_instances")))
+}
+
+// TestStore_Populate_MissingClientCounts verifies a region without a client is
+// counted and skipped.
+func TestStore_Populate_MissingClientCounts(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
+	store := newTestStore(regions, map[string]client.Client{}, nil, newPricingMap())
+
+	store.Populate(t.Context())
+
+	assert.Equal(t, 1.0, testutil.ToFloat64(store.populateErrors.WithLabelValues("instances", "us-east-1", "lookup_client")))
+}
+
+// TestStore_Populate_RegionListTimeout verifies the background listing is
+// always bounded: a positive RegionListTimeout is honoured, and a zero value
+// falls back to the internal safety ceiling rather than running unbounded.
+func TestStore_Populate_RegionListTimeout(t *testing.T) {
+	tests := []struct {
+		name              string
+		regionListTimeout time.Duration
+		wantMaxRemaining  time.Duration
+	}{
+		{name: "zero falls back to the safety ceiling", regionListTimeout: 0, wantMaxRemaining: defaultPopulateTimeout},
+		{name: "positive imposes a tighter deadline", regionListTimeout: 30 * time.Second, wantMaxRemaining: 30 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			var deadline time.Time
+			var hasDeadline bool
+			regionClient := mock.NewMockClient(mockCtrl)
+			regionClient.EXPECT().ListRDSInstances(gomock.Any()).
+				DoAndReturn(func(ctx context.Context) ([]rdsTypes.DBInstance, error) {
+					deadline, hasDeadline = ctx.Deadline()
+					return nil, nil
+				}).
+				Times(1)
+
+			regions := []types.Region{{RegionName: aws.String("us-east-1")}}
+			regionMap := map[string]client.Client{"us-east-1": regionClient}
+			store := newTestStore(regions, regionMap, regionClient, newPricingMap())
+			store.regionListTimeout = tt.regionListTimeout
+
+			// Parent context carries no deadline, so any deadline observed comes
+			// from the per-region bound.
+			store.Populate(context.Background())
+			require.True(t, hasDeadline, "background listing must always be bounded")
+			assert.LessOrEqual(t, time.Until(deadline), tt.wantMaxRemaining)
+		})
+	}
+}
+
+// TestStore_Populate_SlowRegionFailsFast verifies a region whose listing hangs
+// is bounded by regionListTimeout and does not block healthy regions.
+func TestStore_Populate_SlowRegionFailsFast(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	healthy := mock.NewMockClient(mockCtrl)
+	healthy.EXPECT().ListRDSInstances(gomock.Any()).
+		Return([]rdsTypes.DBInstance{instanceFor("us-east-1", "healthy")}, nil).
+		Times(1)
+
+	// The slow region blocks until its timeout-bounded context is cancelled.
+	slow := mock.NewMockClient(mockCtrl)
+	slow.EXPECT().ListRDSInstances(gomock.Any()).
+		DoAndReturn(func(ctx context.Context) ([]rdsTypes.DBInstance, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}).
+		Times(1)
+
+	pricingClient := mock.NewMockClient(mockCtrl)
+	pricingClient.EXPECT().GetRDSUnitData(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(validPriceJSON, nil).
+		AnyTimes()
+
+	regions := []types.Region{
+		{RegionName: aws.String("us-east-1")},
+		{RegionName: aws.String("ap-southeast-7")},
+	}
+	regionMap := map[string]client.Client{
+		"us-east-1":      healthy,
+		"ap-southeast-7": slow,
+	}
+	store := newTestStore(regions, regionMap, pricingClient, newPricingMap())
+	store.regionListTimeout = 50 * time.Millisecond
+
+	start := time.Now()
+	store.Populate(t.Context())
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, 5*time.Second, "slow region should not block the populate")
+	assert.Len(t, store.Get("us-east-1"), 1, "healthy region should still be cached")
+	assert.Empty(t, store.Get("ap-southeast-7"), "slow region should be skipped")
+}

--- a/pkg/aws/rds/store_test.go
+++ b/pkg/aws/rds/store_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 // warmKey is the pricing key produced by both instanceFor and postgresPrice.
-var warmKey = createPricingKey("us-east-1", "db.t3.medium", "PostgreSQL", "", "Single-AZ", "No license required", "AWS Region")
+var warmKey = createPricingKey("us-east-1", "db.t3.medium", "PostgreSQL", "", "Single-AZ", "No license required", "AWS Region", auroraStorageModeNA)
 
 // newTestInstanceStore builds a store without the background goroutine the
 // production constructor starts, so tests can drive Populate synchronously.

--- a/pkg/aws/rds/store_test.go
+++ b/pkg/aws/rds/store_test.go
@@ -80,6 +80,34 @@ func TestInstanceStore_Populate_Refresh(t *testing.T) {
 	assert.Len(t, store.Get("us-east-1"), 2, "refresh should overwrite the cached inventory")
 }
 
+// TestInstanceStore_Populate_FailedRefreshKeepsStaleData verifies a region
+// that previously warmed successfully keeps serving its last-known-good
+// inventory when a later refresh for that region fails, rather than going
+// empty.
+func TestInstanceStore_Populate_FailedRefreshKeepsStaleData(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	regionClient := mock.NewMockClient(mockCtrl)
+	gomock.InOrder(
+		regionClient.EXPECT().ListRDSInstances(gomock.Any()).
+			Return([]rdsTypes.DBInstance{instanceFor("us-east-1", "db-1")}, nil).Times(1),
+		regionClient.EXPECT().ListRDSInstances(gomock.Any()).
+			Return(nil, errors.New("boom")).Times(1),
+	)
+
+	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
+	regionMap := map[string]client.Client{"us-east-1": regionClient}
+	store := newTestInstanceStore(regions, regionMap)
+
+	store.Populate(t.Context())
+	assert.Len(t, store.Get("us-east-1"), 1, "region should warm on the first populate")
+
+	store.Populate(t.Context())
+	assert.Len(t, store.Get("us-east-1"), 1, "a failed refresh should keep serving the last-known-good inventory")
+	assert.Equal(t, 1.0, testutil.ToFloat64(store.populateErrors.WithLabelValues("instances", "us-east-1", "list_instances")))
+}
+
 // TestInstanceStore_Done_ClosesAfterPopulate verifies readiness is signalled
 // once the first populate attempt finishes.
 func TestInstanceStore_Done_ClosesAfterPopulate(t *testing.T) {

--- a/pkg/aws/rds/store_test.go
+++ b/pkg/aws/rds/store_test.go
@@ -21,15 +21,13 @@ import (
 // warmKey is the pricing key produced by both instanceFor and postgresPrice.
 var warmKey = createPricingKey("us-east-1", "db.t3.medium", "PostgreSQL", "", "Single-AZ", "No license required", "AWS Region")
 
-// newTestStore builds a store without the background goroutine the production
-// constructor starts, so tests can drive Populate synchronously.
-func newTestStore(regions []types.Region, regionMap map[string]client.Client, pricingClient client.Client, pm *pricingMap) *instanceStore {
+// newTestInstanceStore builds a store without the background goroutine the
+// production constructor starts, so tests can drive Populate synchronously.
+func newTestInstanceStore(regions []types.Region, regionMap map[string]client.Client) *instanceStore {
 	return &instanceStore{
 		logger:            slog.Default(),
 		regions:           regions,
 		regionMap:         regionMap,
-		pricingClient:     pricingClient,
-		pricingMap:        pm,
 		concurrency:       populateConcurrency,
 		populateErrors:    newPopulateErrorsCounter(),
 		instances:         make(map[string][]rdsTypes.DBInstance),
@@ -37,9 +35,9 @@ func newTestStore(regions []types.Region, regionMap map[string]client.Client, pr
 	}
 }
 
-// TestStore_Populate_WarmsInstancesAndPricing verifies a populate caches the
-// region's instances and fills the pricing map off the scrape path.
-func TestStore_Populate_WarmsInstancesAndPricing(t *testing.T) {
+// TestInstanceStore_Populate_WarmsInstances verifies a populate caches the
+// region's instances off the scrape path.
+func TestInstanceStore_Populate_WarmsInstances(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -48,88 +46,43 @@ func TestStore_Populate_WarmsInstancesAndPricing(t *testing.T) {
 		Return([]rdsTypes.DBInstance{instanceFor("us-east-1", "db-1")}, nil).
 		Times(1)
 
-	pricingClient := mock.NewMockClient(mockCtrl)
-	pricingClient.EXPECT().ListRDSPrices(gomock.Any(), gomock.Any()).
-		Return([]string{postgresPrice("us-east-1", "0.456")}, nil).
-		Times(1)
-
-	pm := newPricingMap()
 	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
 	regionMap := map[string]client.Client{"us-east-1": regionClient}
-	store := newTestStore(regions, regionMap, pricingClient, pm)
+	store := newTestInstanceStore(regions, regionMap)
 
 	store.Populate(t.Context())
 
 	assert.Len(t, store.Get("us-east-1"), 1)
-	price, ok := pm.Get(warmKey)
-	assert.True(t, ok, "price should be warmed during populate")
-	assert.Equal(t, 0.456, price)
 }
 
-// TestStore_Populate_PricingListedOncePerRegion verifies pricing is listed in
-// bulk once per region, independent of how many instances the region has.
-func TestStore_Populate_PricingListedOncePerRegion(t *testing.T) {
+// TestInstanceStore_Populate_Refresh verifies a second populate re-lists
+// instances so the cache tracks the latest inventory.
+func TestInstanceStore_Populate_Refresh(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
 	regionClient := mock.NewMockClient(mockCtrl)
-	regionClient.EXPECT().ListRDSInstances(gomock.Any()).
-		Return([]rdsTypes.DBInstance{
-			instanceFor("us-east-1", "db-1"),
-			instanceFor("us-east-1", "db-2"),
-		}, nil).
-		Times(1)
-
-	pricingClient := mock.NewMockClient(mockCtrl)
-	pricingClient.EXPECT().ListRDSPrices(gomock.Any(), gomock.Any()).
-		Return([]string{postgresPrice("us-east-1", "0.456")}, nil).
-		Times(1) // one bulk price list regardless of instance count
-
-	pm := newPricingMap()
-	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
-	regionMap := map[string]client.Client{"us-east-1": regionClient}
-	store := newTestStore(regions, regionMap, pricingClient, pm)
-
-	store.Populate(t.Context())
-	assert.Len(t, store.Get("us-east-1"), 2)
-}
-
-// TestStore_Populate_Refresh verifies a second populate re-lists prices so the
-// map tracks the latest rates.
-func TestStore_Populate_Refresh(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	regionClient := mock.NewMockClient(mockCtrl)
-	regionClient.EXPECT().ListRDSInstances(gomock.Any()).
-		Return([]rdsTypes.DBInstance{instanceFor("us-east-1", "db-1")}, nil).
-		Times(2)
-
-	pricingClient := mock.NewMockClient(mockCtrl)
 	gomock.InOrder(
-		pricingClient.EXPECT().ListRDSPrices(gomock.Any(), gomock.Any()).
-			Return([]string{postgresPrice("us-east-1", "0.456")}, nil).Times(1),
-		pricingClient.EXPECT().ListRDSPrices(gomock.Any(), gomock.Any()).
-			Return([]string{postgresPrice("us-east-1", "0.789")}, nil).Times(1),
+		regionClient.EXPECT().ListRDSInstances(gomock.Any()).
+			Return([]rdsTypes.DBInstance{instanceFor("us-east-1", "db-1")}, nil).Times(1),
+		regionClient.EXPECT().ListRDSInstances(gomock.Any()).
+			Return([]rdsTypes.DBInstance{instanceFor("us-east-1", "db-1"), instanceFor("us-east-1", "db-2")}, nil).Times(1),
 	)
 
-	pm := newPricingMap()
 	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
 	regionMap := map[string]client.Client{"us-east-1": regionClient}
-	store := newTestStore(regions, regionMap, pricingClient, pm)
+	store := newTestInstanceStore(regions, regionMap)
 
 	store.Populate(t.Context())
-	price, _ := pm.Get(warmKey)
-	assert.Equal(t, 0.456, price)
+	assert.Len(t, store.Get("us-east-1"), 1)
 
 	store.Populate(t.Context())
-	price, _ = pm.Get(warmKey)
-	assert.Equal(t, 0.789, price, "refresh should overwrite the cached price")
+	assert.Len(t, store.Get("us-east-1"), 2, "refresh should overwrite the cached inventory")
 }
 
-// TestStore_Done_ClosesAfterPopulate verifies readiness is signalled once the
-// first populate attempt finishes.
-func TestStore_Done_ClosesAfterPopulate(t *testing.T) {
+// TestInstanceStore_Done_ClosesAfterPopulate verifies readiness is signalled
+// once the first populate attempt finishes.
+func TestInstanceStore_Done_ClosesAfterPopulate(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -137,12 +90,10 @@ func TestStore_Done_ClosesAfterPopulate(t *testing.T) {
 	regionClient.EXPECT().ListRDSInstances(gomock.Any()).
 		Return([]rdsTypes.DBInstance{instanceFor("us-east-1", "db-1")}, nil).
 		Times(1)
-	pricingClient := mock.NewMockClient(mockCtrl)
-	expectPricing(pricingClient, "0.456")
 
 	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
 	regionMap := map[string]client.Client{"us-east-1": regionClient}
-	store := newTestStore(regions, regionMap, pricingClient, newPricingMap())
+	store := newTestInstanceStore(regions, regionMap)
 
 	select {
 	case <-store.Done():
@@ -159,9 +110,9 @@ func TestStore_Done_ClosesAfterPopulate(t *testing.T) {
 	}
 }
 
-// TestStore_Populate_OverlapGuard verifies a populate is skipped while another
-// is still running, so a slow AWS API cannot double the load.
-func TestStore_Populate_OverlapGuard(t *testing.T) {
+// TestInstanceStore_Populate_OverlapGuard verifies a populate is skipped while
+// another is still running, so a slow AWS API cannot double the load.
+func TestInstanceStore_Populate_OverlapGuard(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -170,7 +121,7 @@ func TestStore_Populate_OverlapGuard(t *testing.T) {
 
 	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
 	regionMap := map[string]client.Client{"us-east-1": regionClient}
-	store := newTestStore(regions, regionMap, regionClient, newPricingMap())
+	store := newTestInstanceStore(regions, regionMap)
 
 	// Simulate an in-flight populate.
 	require.True(t, store.populating.CompareAndSwap(false, true))
@@ -184,9 +135,9 @@ func TestStore_Populate_OverlapGuard(t *testing.T) {
 	}
 }
 
-// TestStore_Populate_ListErrorCountsAndContinues verifies a failing region is
-// counted and skipped without dropping its healthy siblings.
-func TestStore_Populate_ListErrorCountsAndContinues(t *testing.T) {
+// TestInstanceStore_Populate_ListErrorCountsAndContinues verifies a failing
+// region is counted and skipped without dropping its healthy siblings.
+func TestInstanceStore_Populate_ListErrorCountsAndContinues(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -200,9 +151,6 @@ func TestStore_Populate_ListErrorCountsAndContinues(t *testing.T) {
 		Return(nil, errors.New("boom")).
 		Times(1)
 
-	pricingClient := mock.NewMockClient(mockCtrl)
-	expectPricing(pricingClient, "0.456")
-
 	regions := []types.Region{
 		{RegionName: aws.String("us-east-1")},
 		{RegionName: aws.String("eu-west-1")},
@@ -211,7 +159,7 @@ func TestStore_Populate_ListErrorCountsAndContinues(t *testing.T) {
 		"us-east-1": healthy,
 		"eu-west-1": broken,
 	}
-	store := newTestStore(regions, regionMap, pricingClient, newPricingMap())
+	store := newTestInstanceStore(regions, regionMap)
 
 	store.Populate(t.Context())
 
@@ -220,24 +168,22 @@ func TestStore_Populate_ListErrorCountsAndContinues(t *testing.T) {
 	assert.Equal(t, 1.0, testutil.ToFloat64(store.populateErrors.WithLabelValues("instances", "eu-west-1", "list_instances")))
 }
 
-// TestStore_Populate_MissingClientCounts verifies a region without a client is
-// counted and skipped.
-func TestStore_Populate_MissingClientCounts(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
+// TestInstanceStore_Populate_MissingClientCounts verifies a region without a
+// client is counted and skipped.
+func TestInstanceStore_Populate_MissingClientCounts(t *testing.T) {
 	regions := []types.Region{{RegionName: aws.String("us-east-1")}}
-	store := newTestStore(regions, map[string]client.Client{}, nil, newPricingMap())
+	store := newTestInstanceStore(regions, map[string]client.Client{})
 
 	store.Populate(t.Context())
 
 	assert.Equal(t, 1.0, testutil.ToFloat64(store.populateErrors.WithLabelValues("instances", "us-east-1", "lookup_client")))
 }
 
-// TestStore_Populate_RegionListTimeout verifies the background listing is
-// always bounded: a positive RegionListTimeout is honoured, and a zero value
-// falls back to the internal safety ceiling rather than running unbounded.
-func TestStore_Populate_RegionListTimeout(t *testing.T) {
+// TestInstanceStore_Populate_RegionListTimeout verifies the background
+// listing is always bounded: a positive RegionListTimeout is honoured, and a
+// zero value falls back to the internal safety ceiling rather than running
+// unbounded.
+func TestInstanceStore_Populate_RegionListTimeout(t *testing.T) {
 	tests := []struct {
 		name              string
 		regionListTimeout time.Duration
@@ -261,13 +207,10 @@ func TestStore_Populate_RegionListTimeout(t *testing.T) {
 					return nil, nil
 				}).
 				Times(1)
-			regionClient.EXPECT().ListRDSPrices(gomock.Any(), gomock.Any()).
-				Return(nil, nil).
-				AnyTimes()
 
 			regions := []types.Region{{RegionName: aws.String("us-east-1")}}
 			regionMap := map[string]client.Client{"us-east-1": regionClient}
-			store := newTestStore(regions, regionMap, regionClient, newPricingMap())
+			store := newTestInstanceStore(regions, regionMap)
 			store.regionListTimeout = tt.regionListTimeout
 
 			// Parent context carries no deadline, so any deadline observed comes
@@ -279,9 +222,10 @@ func TestStore_Populate_RegionListTimeout(t *testing.T) {
 	}
 }
 
-// TestStore_Populate_SlowRegionFailsFast verifies a region whose listing hangs
-// is bounded by regionListTimeout and does not block healthy regions.
-func TestStore_Populate_SlowRegionFailsFast(t *testing.T) {
+// TestInstanceStore_Populate_SlowRegionFailsFast verifies a region whose
+// listing hangs is bounded by regionListTimeout and does not block healthy
+// regions.
+func TestInstanceStore_Populate_SlowRegionFailsFast(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -299,9 +243,6 @@ func TestStore_Populate_SlowRegionFailsFast(t *testing.T) {
 		}).
 		Times(1)
 
-	pricingClient := mock.NewMockClient(mockCtrl)
-	expectPricing(pricingClient, "0.456")
-
 	regions := []types.Region{
 		{RegionName: aws.String("us-east-1")},
 		{RegionName: aws.String("ap-southeast-7")},
@@ -310,7 +251,7 @@ func TestStore_Populate_SlowRegionFailsFast(t *testing.T) {
 		"us-east-1":      healthy,
 		"ap-southeast-7": slow,
 	}
-	store := newTestStore(regions, regionMap, pricingClient, newPricingMap())
+	store := newTestInstanceStore(regions, regionMap)
 	store.regionListTimeout = 50 * time.Millisecond
 
 	start := time.Now()

--- a/pkg/aws/vpc/vpc_test.go
+++ b/pkg/aws/vpc/vpc_test.go
@@ -98,9 +98,9 @@ func (m *MockClient) ListRDSInstances(ctx context.Context) ([]rdsTypes.DBInstanc
 	return args.Get(0).([]rdsTypes.DBInstance), args.Error(1)
 }
 
-func (m *MockClient) GetRDSUnitData(ctx context.Context, instType, region, deploymentOption, engineCode, isOutpost string) (string, error) {
-	args := m.Called(ctx, instType, region, deploymentOption, engineCode, isOutpost)
-	return args.Get(0).(string), args.Error(1)
+func (m *MockClient) ListRDSPrices(ctx context.Context, region string) ([]string, error) {
+	args := m.Called(ctx, region)
+	return args.Get(0).([]string), args.Error(1)
 }
 
 func (m *MockClient) ListMSKClusters(ctx context.Context) ([]msktypes.Cluster, error) {


### PR DESCRIPTION
## Summary

Moves AWS RDS pricing and instance listing off the Prometheus scrape path into two fully independent background stores, collapsing the collector's p99.

Part of #1107. Closes #1108.

## Problem

`aws_rds` was the fleet's worst p99 offender (p99 ~42.55s, avg ~4.48s). `Collect()` filled the pricing map lazily: on a cache miss it made a blocking `GetProducts` call per instance, one at a time, inside the scrape loop. In steady state the map is warm and a scrape is just the concurrent listing (~4.5s). After a pod restart, or when many new instance shapes appear, the map is cold and a scrape issues a serialized fan-in of pricing calls, which is the p99 tail. Every other AWS collector already moves pricing off the scrape path; RDS was the outlier.

## Change

Apply the background-store pattern (the GKE `node_store`/`pricing_map` shape) to RDS, with instance listing and pricing fully decoupled per review feedback:

- `instanceStore` refreshes `DescribeDBInstances` inventory per region on a ticker (`--scrape-interval`), starting at process startup.
- `pricingStore` independently refreshes RDS pricing on its own fixed 24 hour ticker. It lists every RDS Database Instance price in a region in bulk (`GetProducts`) rather than per instance, and keys each price by product attributes (instance type, engine, edition, deployment option, license, location type, and for Aurora, storage mode). It has no dependency on `instanceStore` and vice versa.
- `Collect()` joins an instance to its price by that key. It makes zero AWS calls, checks each store's readiness independently, and skips the whole scrape (no metrics, no error) if either is still cold, covering every not-ready combination (neither, instances-only, pricing-only). A pricing miss for an individual instance is skipped with a log rather than failing the scrape.

This addresses both the p99 (cold pricing fan-in leaves the scrape path) and the average (listing leaves the scrape path), and lets pricing and inventory refresh on cadences that fit how often each actually changes.

### Bounding and safety

Each store's per-region background work is wrapped in its own timeout. A positive `--aws.rds.region-timeout` is honoured by both stores as the operator's fail-fast budget; `0` (the default) falls back to an internal 2 minute ceiling per store. On the old scrape-path code, `0` was implicitly bounded by the collector interval. The background populate has no such outer deadline, so the ceiling guarantees a hung AWS call can never wedge either refresh, leave its readiness channel open, and skip every future tick.

Partial instances (AWS can return an instance missing its AZ, class, engine, or multi-AZ flag mid create or delete) are skipped rather than dereferenced, so a partial record cannot panic the background goroutine.

### Observability

Operational counter `cloudcost_exporter_aws_rds_populate_errors_total`, labeled `store` (`instances` or `pricing`), `region`, `operation`, surfaces populate failures. Instance-side operations are `lookup_client`, `list_instances`; pricing-side operations are `list_prices`, `parse_pricing`. Populate failures become missing metrics plus a bumped counter, not scrape errors, so alerting on this counter is recommended.

## Tradeoffs

- Cached inventory is stale by up to `--scrape-interval`; cached pricing by up to 24 hours.
- No metrics emit until both stores complete their first refresh. Since the two stores populate concurrently rather than sequentially, this cold-start gap is bounded by the slower of the two, not their sum.
- Multi-edition engine (Oracle, SQL Server) pricing-key attributes are best-effort and untested against a live Pricing API response; tracked separately in #1131.
- Aurora's pricing key additionally disambiguates Standard vs I/O-Optimized storage (they carry different instance-hour prices and previously collided on one key, closes #1134). This relies on `DBInstance.StorageType` surfacing `aurora-iopt1` at the instance level, which needs confirming against a live Aurora I/O-Optimized cluster before merge; flagged with a `VERIFY:` comment on `auroraStorageModeFromInstance` in `pkg/aws/rds/rds.go`.

## Testing

- `go test ./...` passes.
- `instanceStore`: warms instance inventory; a refresh overwrites the cache; readiness is signalled once; the overlap guard skips a concurrent populate; a failing or client-less region is counted and skipped without dropping its siblings; the per-region timeout is applied (configured value and the default ceiling).
- `pricingStore`: warms pricing; prices are listed once per region regardless of instance count; a refresh overwrites cached prices; readiness is signalled once; the overlap guard skips a concurrent populate; list and parse errors are counted under `store="pricing"` and skipped without dropping siblings; the per-region timeout is applied (configured value and the default ceiling).
- `Collector.Collect`: cold-start for every not-ready combination (neither store warm, instances-only, pricing-only) emits nothing and does not error; a warm `Collect` serves every instance from both stores and makes zero AWS calls; a pricing miss for one instance is skipped without failing the scrape; multi-region instances are all emitted.
- Aurora storage mode: Standard and I/O-Optimized produce distinct pricing keys on both the Pricing API attribute side and the instance `StorageType` side, and a missing or unrecognized value on either side is skipped rather than mis-keyed.

## Verification

- `make generate && make test`.
- Run locally against a profile with RDS instances and confirm both stores populate at startup (not during `Collect`) and metrics emit once both complete their first refresh.
- Re-run the #1107 reproduction queries after deploy to confirm `aws_rds` drops out of the p99 tail.

## Docs

`docs/metrics/aws/rds.md` documents the operational metric's `store` label values, the two independent refresh intervals, and the cold-start behavior.

