### PR TITLE
feat(gcp): add standalone GCE compute collector

### DIFF
--- a/cmd/exporter/config/config.go
+++ b/cmd/exporter/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 			Services                 StringSliceFlag
 			ExperimentalServices     StringSliceFlag
 			GKEZoneConcurrency       int
+			GCEZoneConcurrency       int
 			VertexFamilyFilter       string
 		}
 		Azure struct {

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -98,6 +98,7 @@ func providerFlags(fs *flag.FlagSet, cfg *config.Config) {
 	flag.StringVar(&cfg.Providers.Azure.SubscriptionID, "azure.subscription-id", "", "Azure subscription ID to pull data from.")
 	flag.IntVar(&cfg.Providers.GCP.DefaultGCSDiscount, "gcp.default-discount", 19, "GCP default discount")
 	flag.IntVar(&cfg.Providers.GCP.GKEZoneConcurrency, "gcp.gke.zone-concurrency", 10, "Cap on concurrent API calls per background store populate (node and disk store).")
+	flag.IntVar(&cfg.Providers.GCP.GCEZoneConcurrency, "gcp.gce.zone-concurrency", 10, "Cap on concurrent API calls per background store populate (node store and machine-type lookups).")
 }
 
 // operationalFlags is a helper method that is responsible for setting up the flags that are used to configure the operational aspects of the application.
@@ -291,6 +292,7 @@ func selectProviderWith(
 			ExperimentalServices: strings.Split(cfg.Providers.GCP.ExperimentalServices.String(), ","),
 			CollectorTimeout:     collectorTimeout,
 			GKEZoneConcurrency:   cfg.Providers.GCP.GKEZoneConcurrency,
+			GCEZoneConcurrency:   cfg.Providers.GCP.GCEZoneConcurrency,
 			VertexFamilyFilter:   cfg.Providers.GCP.VertexFamilyFilter,
 		})
 

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -16,6 +16,7 @@ Each bullet shows the human-readable name, the flag value to pass via `-{provide
 ## GCP Services
 
 - **[GKE](./gcp/gke.md)** (`GKE`): Google Kubernetes Engine clusters
+- **[GCE](./gcp/gce.md)** (`GCE`): Standalone Google Compute Engine VMs (excludes GKE-managed nodes)
 - **[GCS](./gcp/gcs.md)** (`GCS`): Google Cloud Storage buckets
 - **[Cloud SQL](./gcp/cloudsql.md)** (`SQL`): Managed database instances
 - **[Managed Kafka](./gcp/managedkafka.md)** (`MANAGEDKAFKA`, alias: `KAFKA`): Managed Service for Apache Kafka clusters

--- a/docs/metrics/gcp/gce.md
+++ b/docs/metrics/gcp/gce.md
@@ -1,0 +1,30 @@
+# GCE Compute Metrics
+
+| Metric name                                          | Metric type | Description                                                                                                                | Labels                                                                                                                                                                                                                                                                                                        |
+|-------------------------------------------------------|-------------|-----------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| cloudcost_exporter_gcp_gce_populate_errors_total       | Counter     | Total errors during background store population. | `store`=&lt;nodes\|machine_types&gt; <br/> `project`=&lt;GCP project&gt; <br/> `operation`=&lt;get_zones\|list_instances\|get_machine_type&gt; |
+| cloudcost_gcp_gce_instance_cpu_usd_per_core_hour       | Gauge       | The processing cost of a standalone GCE Instance in USD/(core*h)                                                            | `instance`=&lt;name of the compute instance&gt; <br/> `region`=&lt;GCP region code&gt; <br/> `family`=&lt;broader compute family (n1, n2, c3 ...)&gt; <br/> `machine_type`=&lt;specific machine type, e.g.: n2-standard-2&gt; <br/> `project`=&lt;GCP project, where the instance is provisioned&gt; <br/> `price_tier`=&lt;spot\|ondemand&gt; |
+| cloudcost_gcp_gce_instance_memory_usd_per_gib_hour     | Gauge       | The memory cost of a standalone GCE Instance in USD/(GiB*h)                                                                 | Same labels as above.                                                                                                                                                                                                                                                                                          |
+| cloudcost_gcp_gce_instance_total_usd_per_hour          | Gauge       | The total hourly cost of a standalone GCE Instance in USD/h. Absent for an instance whose machine type spec hasn't resolved yet; the cpu/memory metrics are unaffected. | Same labels as above.                                                                                                                                                                                                                                                                                          |
+
+## What counts as a GCE instance here
+
+This collector only emits metrics for Compute Engine instances that are **not** part of a GKE cluster (no `goog-k8s-cluster-name` label). GKE-managed nodes are priced exclusively by the `gcp_gke_*` metrics documented in [gke.md](./gke.md). This split means a node's cost is never counted twice: running both `GKE` and `GCE` for the same project is safe, each instance shows up in exactly one collector's output.
+
+## Collection model
+
+Instance inventory and pricing are collected by background goroutines and cached in memory, the same architecture as the GKE collector. Each scrape reads from those caches, so scrape duration doesn't depend on GCP API latency.
+
+- **Node inventory** refreshes every 5 minutes (`Compute.Zones.List` per project, `Instances.List` per zone). This is a separate, independent store from any concurrently running `GKE` collector's own node store, so enabling both `GKE` and `GCE` for the same project duplicates these API calls. That's a known, accepted tradeoff, not a bug: it mirrors the existing duplication between GKE's own node and disk stores.
+- **Machine type specs** (vCPU count, memory) needed for the total cost metric are resolved per `(project, zone, machine_type)` via `Compute.MachineTypes.Get`, cached indefinitely since a machine type's spec never changes for a given zone. The cache warms on the same 5-minute cadence as node inventory. A lookup failure (transient API error, or a key not yet warmed) only suppresses `instance_total_usd_per_hour` for that instance; the cpu/memory rate metrics don't depend on it and are unaffected.
+- **Pricing** refreshes on its own interval via the Cloud Billing Catalog API, same source as GKE's.
+
+Per-zone API calls within a project are issued in parallel, capped at 10 concurrent in-flight calls by default. Override with the `--gcp.gce.zone-concurrency` flag; the value applies to both the node store and the machine-type cache warm.
+
+### Staleness and partial-failure behaviour
+
+- Instance metrics may be up to 5 minutes stale.
+- The first scrape after startup emits no metrics until the node store completes its initial populate. The collector logs `node store not yet populated, skipping instance metrics` and continues.
+- If `GetZones` fails for a project, that project's existing node cache is preserved.
+- If a zone-level call fails (partial or total), the cache entry for that zone is left untouched; a subsequent successful populate refreshes it. Failures are logged and counted in `cloudcost_exporter_gcp_gce_populate_errors_total`.
+- An instance on a machine type with no matching SKU in the pricing map (an unpriced or unrecognized machine type) is skipped entirely, no metrics are emitted for it, and the error is logged.

--- a/pkg/google/client/client.go
+++ b/pkg/google/client/client.go
@@ -21,7 +21,7 @@ type Client interface {
 	GetZones(project string) ([]*compute.Zone, error)
 	GetRegions(project string) ([]*compute.Region, error)
 	ListInstancesInZone(projectId, zone string) ([]*MachineSpec, error)
-	GetMachineType(project, zone, machineType string) (*compute.MachineType, error)
+	GetMachineType(ctx context.Context, project, zone, machineType string) (*compute.MachineType, error)
 	ListDisks(ctx context.Context, project string, zone string) ([]*compute.Disk, error)
 	ListForwardingRules(ctx context.Context, project string, region string) ([]*compute.ForwardingRule, error)
 	ListSQLInstances(ctx context.Context, project string) ([]*sqladmin.DatabaseInstance, error)

--- a/pkg/google/client/client.go
+++ b/pkg/google/client/client.go
@@ -21,6 +21,7 @@ type Client interface {
 	GetZones(project string) ([]*compute.Zone, error)
 	GetRegions(project string) ([]*compute.Region, error)
 	ListInstancesInZone(projectId, zone string) ([]*MachineSpec, error)
+	GetMachineType(project, zone, machineType string) (*compute.MachineType, error)
 	ListDisks(ctx context.Context, project string, zone string) ([]*compute.Disk, error)
 	ListForwardingRules(ctx context.Context, project string, region string) ([]*compute.ForwardingRule, error)
 	ListSQLInstances(ctx context.Context, project string) ([]*sqladmin.DatabaseInstance, error)

--- a/pkg/google/client/client_mock.go
+++ b/pkg/google/client/client_mock.go
@@ -73,8 +73,8 @@ func (c *Mock) ListInstancesInZone(projectId, zone string) ([]*MachineSpec, erro
 	return c.compute.listInstancesInZone(projectId, zone)
 }
 
-func (c *Mock) GetMachineType(projectId, zone, machineType string) (*compute.MachineType, error) {
-	return c.compute.getMachineType(projectId, zone, machineType)
+func (c *Mock) GetMachineType(ctx context.Context, projectId, zone, machineType string) (*compute.MachineType, error) {
+	return c.compute.getMachineType(ctx, projectId, zone, machineType)
 }
 
 func (c *Mock) ListDisks(ctx context.Context, projectId string, zone string) ([]*compute.Disk, error) {

--- a/pkg/google/client/client_mock.go
+++ b/pkg/google/client/client_mock.go
@@ -73,6 +73,10 @@ func (c *Mock) ListInstancesInZone(projectId, zone string) ([]*MachineSpec, erro
 	return c.compute.listInstancesInZone(projectId, zone)
 }
 
+func (c *Mock) GetMachineType(projectId, zone, machineType string) (*compute.MachineType, error) {
+	return c.compute.getMachineType(projectId, zone, machineType)
+}
+
 func (c *Mock) ListDisks(ctx context.Context, projectId string, zone string) ([]*compute.Disk, error) {
 	return c.compute.listDisks(ctx, projectId, zone)
 }

--- a/pkg/google/client/compute.go
+++ b/pkg/google/client/compute.go
@@ -64,8 +64,8 @@ func (c *Compute) listInstancesInZone(projectId, zone string) ([]*MachineSpec, e
 // getMachineType returns the machine type spec (vCPU count, memory) for a
 // (project, zone, machineType) tuple. The spec is immutable for a given
 // zone, so callers should cache the result.
-func (c *Compute) getMachineType(project, zone, machineType string) (*compute.MachineType, error) {
-	return c.computeService.MachineTypes.Get(project, zone, machineType).Do()
+func (c *Compute) getMachineType(ctx context.Context, project, zone, machineType string) (*compute.MachineType, error) {
+	return c.computeService.MachineTypes.Get(project, zone, machineType).Context(ctx).Do()
 }
 
 // listDisks will list all disks in a given zone and return a slice of compute.Disk

--- a/pkg/google/client/compute.go
+++ b/pkg/google/client/compute.go
@@ -61,6 +61,13 @@ func (c *Compute) listInstancesInZone(projectId, zone string) ([]*MachineSpec, e
 	return allInstances, nil
 }
 
+// getMachineType returns the machine type spec (vCPU count, memory) for a
+// (project, zone, machineType) tuple. The spec is immutable for a given
+// zone, so callers should cache the result.
+func (c *Compute) getMachineType(project, zone, machineType string) (*compute.MachineType, error) {
+	return c.computeService.MachineTypes.Get(project, zone, machineType).Do()
+}
+
 // listDisks will list all disks in a given zone and return a slice of compute.Disk
 func (c *Compute) listDisks(ctx context.Context, project string, zone string) ([]*compute.Disk, error) {
 	var disks []*compute.Disk

--- a/pkg/google/client/gcp_client.go
+++ b/pkg/google/client/gcp_client.go
@@ -130,8 +130,8 @@ func (c *GCPClient) ListInstancesInZone(projectId, zone string) ([]*MachineSpec,
 	return c.compute.listInstancesInZone(projectId, zone)
 }
 
-func (c *GCPClient) GetMachineType(projectId, zone, machineType string) (*computev1.MachineType, error) {
-	return c.compute.getMachineType(projectId, zone, machineType)
+func (c *GCPClient) GetMachineType(ctx context.Context, projectId, zone, machineType string) (*computev1.MachineType, error) {
+	return c.compute.getMachineType(ctx, projectId, zone, machineType)
 }
 
 func (c *GCPClient) ListDisks(ctx context.Context, projectId string, zone string) ([]*computev1.Disk, error) {

--- a/pkg/google/client/gcp_client.go
+++ b/pkg/google/client/gcp_client.go
@@ -130,6 +130,10 @@ func (c *GCPClient) ListInstancesInZone(projectId, zone string) ([]*MachineSpec,
 	return c.compute.listInstancesInZone(projectId, zone)
 }
 
+func (c *GCPClient) GetMachineType(projectId, zone, machineType string) (*computev1.MachineType, error) {
+	return c.compute.getMachineType(projectId, zone, machineType)
+}
+
 func (c *GCPClient) ListDisks(ctx context.Context, projectId string, zone string) ([]*computev1.Disk, error) {
 	return c.compute.listDisks(ctx, projectId, zone)
 }

--- a/pkg/google/client/regions_test.go
+++ b/pkg/google/client/regions_test.go
@@ -61,7 +61,7 @@ func (c *regionsStubClient) GetProjectBillingAccount(_ context.Context, _ string
 func (c *regionsStubClient) ListInstancesInZone(_, _ string) ([]*MachineSpec, error) {
 	panic("not implemented")
 }
-func (c *regionsStubClient) GetMachineType(_, _, _ string) (*compute.MachineType, error) {
+func (c *regionsStubClient) GetMachineType(_ context.Context, _, _, _ string) (*compute.MachineType, error) {
 	panic("not implemented")
 }
 func (c *regionsStubClient) ListDisks(_ context.Context, _, _ string) ([]*compute.Disk, error) {

--- a/pkg/google/client/regions_test.go
+++ b/pkg/google/client/regions_test.go
@@ -61,6 +61,9 @@ func (c *regionsStubClient) GetProjectBillingAccount(_ context.Context, _ string
 func (c *regionsStubClient) ListInstancesInZone(_, _ string) ([]*MachineSpec, error) {
 	panic("not implemented")
 }
+func (c *regionsStubClient) GetMachineType(_, _, _ string) (*compute.MachineType, error) {
+	panic("not implemented")
+}
 func (c *regionsStubClient) ListDisks(_ context.Context, _, _ string) ([]*compute.Disk, error) {
 	panic("not implemented")
 }

--- a/pkg/google/gce/gce.go
+++ b/pkg/google/gce/gce.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/cloudcost-exporter/pkg/google/client"
 	"github.com/grafana/cloudcost-exporter/pkg/google/gke"
+	"github.com/grafana/cloudcost-exporter/pkg/google/storeutil"
 	"github.com/grafana/cloudcost-exporter/pkg/utils"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -24,16 +25,6 @@ const (
 	// widening gke's exported surface just for this.
 	nodeRefreshInterval = 5 * time.Minute
 )
-
-func newPopulateErrorsCounter() *prometheus.CounterVec {
-	return prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: prometheus.BuildFQName(cloudcostexporter.ExporterName, subsystem, "populate_errors_total"),
-			Help: "Total errors during background store population, by store, project, and operation.",
-		},
-		[]string{"store", "project", "operation"},
-	)
-}
 
 var (
 	gceInstanceCPUHourlyCostDesc = utils.GenerateDesc(
@@ -140,16 +131,16 @@ func New(ctx context.Context, config *Config, logger *slog.Logger, gcpClient cli
 	projects := strings.Split(config.Projects, ",")
 	regions := client.RegionsFromZonesForProjects(gcpClient, projects, logger)
 
-	populateErrors := newPopulateErrorsCounter()
+	populateErrors := storeutil.NewPopulateErrorsCounter(subsystem)
 	nodeStore := gke.NewNodeStore(ctx, logger, gcpClient, projects, config.ZoneConcurrency, populateErrors)
 	machineTypes := newMachineTypeCache(gcpClient, populateErrors, config.ZoneConcurrency, logger)
 
-	startRefreshTicker(ctx, gke.PriceRefreshInterval, func() {
+	storeutil.StartRefreshTicker(ctx, gke.PriceRefreshInterval, func() {
 		if err := pm.Populate(ctx); err != nil {
 			logger.Error(err.Error())
 		}
 	})
-	startRefreshTicker(ctx, nodeRefreshInterval, func() {
+	storeutil.StartRefreshTicker(ctx, nodeRefreshInterval, func() {
 		nodeStore.Populate(ctx)
 		machineTypes.warm(ctx, nodeStore, projects)
 	})
@@ -172,21 +163,6 @@ func New(ctx context.Context, config *Config, logger *slog.Logger, gcpClient cli
 		machineTypes:   machineTypes,
 		populateErrors: populateErrors,
 	}, nil
-}
-
-func startRefreshTicker(ctx context.Context, interval time.Duration, run func()) {
-	go func() {
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				run()
-			}
-		}
-	}()
 }
 
 func (c *Collector) Regions() []string {

--- a/pkg/google/gce/gce.go
+++ b/pkg/google/gce/gce.go
@@ -2,14 +2,18 @@ package gce
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/grafana/cloudcost-exporter/pkg/google/client"
 	"github.com/grafana/cloudcost-exporter/pkg/google/gke"
 	"github.com/grafana/cloudcost-exporter/pkg/google/storeutil"
 	"github.com/grafana/cloudcost-exporter/pkg/utils"
+
+	dto "github.com/prometheus/client_model/go"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -66,6 +70,41 @@ type Collector struct {
 	machineTypes   *machineTypeCache
 	logger         *slog.Logger
 	populateErrors *prometheus.CounterVec
+
+	// errMu guards lastNodeStorePopulateErrors, which lets Collect detect
+	// whether the node store reported new populate errors since the previous
+	// scrape without gke.NodeStore needing to expose its own error state.
+	errMu                       sync.Mutex
+	lastNodeStorePopulateErrors float64
+}
+
+// sumPopulateErrorsByStore returns the current total across all label
+// combinations of populateErrors whose "store" label matches store, read via
+// its Collector interface rather than an exported total. Machine-type lookup
+// misses (store "machine_types") are an expected, per-instance data gap
+// already handled by skipping just the total-cost metric, so callers scope
+// this to "nodes" to only flag genuine project/zone/instance listing outages.
+func sumPopulateErrorsByStore(cv *prometheus.CounterVec, store string) float64 {
+	metricCh := make(chan prometheus.Metric)
+	go func() {
+		cv.Collect(metricCh)
+		close(metricCh)
+	}()
+
+	var total float64
+	var m dto.Metric
+	for metric := range metricCh {
+		if err := metric.Write(&m); err != nil {
+			continue
+		}
+		for _, lp := range m.GetLabel() {
+			if lp.GetName() == "store" && lp.GetValue() == store {
+				total += m.GetCounter().GetValue()
+				break
+			}
+		}
+	}
+	return total
 }
 
 func (c *Collector) Register(r provider.Registry) error {
@@ -117,6 +156,15 @@ func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) er
 	c.logger.LogAttrs(ctx, slog.LevelInfo, "metrics collected",
 		slog.Duration("duration", time.Since(now)),
 		slog.Int64("instances_emitted", instanceCount))
+
+	total := sumPopulateErrorsByStore(c.populateErrors, "nodes")
+	c.errMu.Lock()
+	hasNewPopulateErrors := total > c.lastNodeStorePopulateErrors
+	c.lastNodeStorePopulateErrors = total
+	c.errMu.Unlock()
+	if hasNewPopulateErrors {
+		return fmt.Errorf("node store population reported errors since the last scrape; see cloudcost_exporter_gcp_gce_populate_errors_total")
+	}
 	return nil
 }
 

--- a/pkg/google/gce/gce.go
+++ b/pkg/google/gce/gce.go
@@ -1,0 +1,205 @@
+package gce
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/grafana/cloudcost-exporter/pkg/google/client"
+	"github.com/grafana/cloudcost-exporter/pkg/google/gke"
+	"github.com/grafana/cloudcost-exporter/pkg/utils"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	cloudcostexporter "github.com/grafana/cloudcost-exporter"
+	"github.com/grafana/cloudcost-exporter/pkg/provider"
+)
+
+const (
+	subsystem = "gcp_gce"
+
+	// nodeRefreshInterval mirrors gke's own node-store refresh cadence. gke's
+	// equivalent constant is unexported, so it's duplicated here rather than
+	// widening gke's exported surface just for this.
+	nodeRefreshInterval = 5 * time.Minute
+)
+
+func newPopulateErrorsCounter() *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: prometheus.BuildFQName(cloudcostexporter.ExporterName, subsystem, "populate_errors_total"),
+			Help: "Total errors during background store population, by store, project, and operation.",
+		},
+		[]string{"store", "project", "operation"},
+	)
+}
+
+var (
+	gceInstanceCPUHourlyCostDesc = utils.GenerateDesc(
+		cloudcostexporter.MetricPrefix,
+		subsystem,
+		utils.InstanceCPUCostSuffix,
+		"The CPU cost of a standalone GCE Instance in USD/(core*h)",
+		[]string{"instance", "region", "family", "machine_type", "project", "price_tier"},
+	)
+	gceInstanceMemoryHourlyCostDesc = utils.GenerateDesc(
+		cloudcostexporter.MetricPrefix,
+		subsystem,
+		utils.InstanceMemoryCostSuffix,
+		"The memory cost of a standalone GCE Instance in USD/(GiB*h)",
+		[]string{"instance", "region", "family", "machine_type", "project", "price_tier"},
+	)
+	gceInstanceTotalHourlyCostDesc = utils.GenerateDesc(
+		cloudcostexporter.MetricPrefix,
+		subsystem,
+		utils.InstanceTotalCostSuffix,
+		"The total cost of a standalone GCE Instance in USD/h. Absent for an instance whose machine type spec hasn't been resolved yet.",
+		[]string{"instance", "region", "family", "machine_type", "project", "price_tier"},
+	)
+)
+
+type Config struct {
+	Projects       string
+	ScrapeInterval time.Duration
+	// ZoneConcurrency caps zone-level goroutines per project during a scrape.
+	// Falls back to gke.DefaultZoneCollectConcurrency.
+	ZoneConcurrency int
+}
+
+type Collector struct {
+	projects       []string
+	regions        []string
+	pricingMap     *gke.PricingMap
+	nodeStore      *gke.NodeStore
+	machineTypes   *machineTypeCache
+	logger         *slog.Logger
+	populateErrors *prometheus.CounterVec
+}
+
+func (c *Collector) Register(r provider.Registry) error {
+	r.MustRegister(c.populateErrors)
+	return nil
+}
+
+func (c *Collector) Collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	now := time.Now()
+	var instanceCount int64
+
+	select {
+	case <-c.nodeStore.Done():
+		for _, project := range c.projects {
+			for _, instance := range c.nodeStore.GetNodes(project) {
+				if instance.GetClusterName() != "" {
+					// GKE-managed node: priced by the gcp_gke collector instead, so cost is
+					// never double-counted between gcp_gke_* and gcp_gce_* metrics.
+					continue
+				}
+				cpuCost, ramCost, err := c.pricingMap.GetCostOfInstance(instance)
+				if err != nil {
+					c.logger.LogAttrs(ctx, slog.LevelError, err.Error(),
+						slog.String("machine_type", instance.MachineType),
+						slog.String("region", instance.Region),
+						slog.String("project", project))
+					continue
+				}
+				labelValues := []string{instance.Instance, instance.Region, instance.Family, instance.MachineType, project, instance.PriceTier}
+				ch <- prometheus.MustNewConstMetric(gceInstanceCPUHourlyCostDesc, prometheus.GaugeValue, cpuCost, labelValues...)
+				ch <- prometheus.MustNewConstMetric(gceInstanceMemoryHourlyCostDesc, prometheus.GaugeValue, ramCost, labelValues...)
+
+				if spec, ok := c.machineTypes.get(project, instance.Zone, instance.MachineType); ok {
+					total := cpuCost*float64(spec.VCPU) + ramCost*spec.MemoryGiB
+					ch <- prometheus.MustNewConstMetric(gceInstanceTotalHourlyCostDesc, prometheus.GaugeValue, total, labelValues...)
+				} else {
+					c.logger.LogAttrs(ctx, slog.LevelDebug, "machine type spec not cached, skipping total cost metric",
+						slog.String("machine_type", instance.MachineType),
+						slog.String("zone", instance.Zone),
+						slog.String("project", project))
+				}
+				instanceCount++
+			}
+		}
+	default:
+		c.logger.LogAttrs(ctx, slog.LevelInfo, "node store not yet populated, skipping instance metrics")
+	}
+
+	c.logger.LogAttrs(ctx, slog.LevelInfo, "metrics collected",
+		slog.Duration("duration", time.Since(now)),
+		slog.Int64("instances_emitted", instanceCount))
+	return nil
+}
+
+func New(ctx context.Context, config *Config, logger *slog.Logger, gcpClient client.Client) (*Collector, error) {
+	logger = logger.With("collector", "gce")
+
+	pm, err := gke.NewPricingMap(ctx, gcpClient)
+	if err != nil {
+		return nil, err
+	}
+
+	projects := strings.Split(config.Projects, ",")
+	regions := client.RegionsFromZonesForProjects(gcpClient, projects, logger)
+
+	populateErrors := newPopulateErrorsCounter()
+	nodeStore := gke.NewNodeStore(ctx, logger, gcpClient, projects, config.ZoneConcurrency, populateErrors)
+	machineTypes := newMachineTypeCache(gcpClient, populateErrors, config.ZoneConcurrency, logger)
+
+	startRefreshTicker(ctx, gke.PriceRefreshInterval, func() {
+		if err := pm.Populate(ctx); err != nil {
+			logger.Error(err.Error())
+		}
+	})
+	startRefreshTicker(ctx, nodeRefreshInterval, func() {
+		nodeStore.Populate(ctx)
+		machineTypes.warm(ctx, nodeStore, projects)
+	})
+	// Warm the machine-type cache right after the node store's own initial populate
+	// completes, rather than waiting for the first nodeRefreshInterval tick.
+	go func() {
+		select {
+		case <-nodeStore.Done():
+			machineTypes.warm(ctx, nodeStore, projects)
+		case <-ctx.Done():
+		}
+	}()
+
+	return &Collector{
+		projects:       projects,
+		regions:        regions,
+		logger:         logger,
+		pricingMap:     pm,
+		nodeStore:      nodeStore,
+		machineTypes:   machineTypes,
+		populateErrors: populateErrors,
+	}, nil
+}
+
+func startRefreshTicker(ctx context.Context, interval time.Duration, run func()) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				run()
+			}
+		}
+	}()
+}
+
+func (c *Collector) Regions() []string {
+	return c.regions
+}
+
+func (c *Collector) Name() string {
+	return subsystem
+}
+
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) error {
+	ch <- gceInstanceCPUHourlyCostDesc
+	ch <- gceInstanceMemoryHourlyCostDesc
+	ch <- gceInstanceTotalHourlyCostDesc
+	return nil
+}

--- a/pkg/google/gce/gce_test.go
+++ b/pkg/google/gce/gce_test.go
@@ -1,0 +1,272 @@
+package gce
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	billingv1 "cloud.google.com/go/billing/apiv1"
+	"cloud.google.com/go/billing/apiv1/billingpb"
+	"github.com/grafana/cloudcost-exporter/pkg/google/client"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	computev1 "google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/grafana/cloudcost-exporter/pkg/utils"
+)
+
+var logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+// standaloneInstances mixes a GKE-labeled node in with standalone VMs, including
+// one on an unpriced machine type, matching the fixture gke_test.go uses for the
+// same "unpriced machine type" case (see grafana/cloudcost-exporter#335).
+func standaloneInstances() []*computev1.Instance {
+	return []*computev1.Instance{
+		{
+			Name:        "gke-node",
+			MachineType: "abc/n1-slim",
+			Zone:        "testing/us-central1-a",
+			Scheduling:  &computev1.Scheduling{ProvisioningModel: "test"},
+			Labels:      map[string]string{client.GkeClusterLabel: "test"},
+		},
+		{
+			Name:        "standalone-n1",
+			MachineType: "abc/n1-slim",
+			Zone:        "testing/us-central1-a",
+			Scheduling:  &computev1.Scheduling{ProvisioningModel: "test"},
+		},
+		{
+			Name:        "standalone-n1-spot",
+			MachineType: "abc/n1-slim",
+			Zone:        "testing/us-central1-a",
+			Scheduling:  &computev1.Scheduling{ProvisioningModel: "SPOT"},
+		},
+		{
+			// No SKU exists for this machine type in the fake billing fixture below,
+			// mirroring gke_test.go's unpriced-machine-type case: the instance is
+			// skipped entirely, not just its total metric.
+			Name:        "standalone-n8",
+			MachineType: "abc/n8-slim",
+			Zone:        "testing/us-central1-a",
+			Scheduling:  &computev1.Scheduling{ProvisioningModel: "test"},
+		},
+	}
+}
+
+func computeHandler(serveMachineType bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var buf interface{}
+		switch r.URL.Path {
+		case "/projects/testing/zones/us-central1-a/instances":
+			buf = &computev1.InstanceList{Items: standaloneInstances()}
+		case "/projects/testing/zones":
+			buf = &computev1.ZoneList{Items: []*computev1.Zone{{Name: "us-central1-a"}}}
+		case "/projects/testing/zones/us-central1-a/machineTypes/n1-slim":
+			if !serveMachineType {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			buf = &computev1.MachineType{GuestCpus: 2, MemoryMb: 4096}
+		default:
+			// e.g. the unpriced "n8-slim" machine type: no fixture data for it,
+			// same as a real API 404 for an unrecognized machine type.
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(buf)
+	}
+}
+
+func TestCollector_Collect(t *testing.T) {
+	tests := map[string]struct {
+		config          *Config
+		testServer      *httptest.Server
+		expectedMetrics []*utils.MetricResult
+	}{
+		"Handle http error": {
+			config: &Config{Projects: "testing"},
+			testServer: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			})),
+			expectedMetrics: []*utils.MetricResult{},
+		},
+		"Excludes GKE nodes, prices standalone VMs, skips unpriced machine types": {
+			config:     &Config{Projects: "testing"},
+			testServer: httptest.NewServer(computeHandler(true)),
+			expectedMetrics: []*utils.MetricResult{
+				{
+					FqName: "cloudcost_gcp_gce_instance_cpu_usd_per_core_hour",
+					Labels: map[string]string{
+						"family": "n1", "instance": "standalone-n1", "machine_type": "n1-slim",
+						"price_tier": "ondemand", "project": "testing", "region": "us-central1",
+					},
+					Value: 1, MetricType: prometheus.GaugeValue,
+				},
+				{
+					FqName: "cloudcost_gcp_gce_instance_memory_usd_per_gib_hour",
+					Labels: map[string]string{
+						"family": "n1", "instance": "standalone-n1", "machine_type": "n1-slim",
+						"price_tier": "ondemand", "project": "testing", "region": "us-central1",
+					},
+					Value: 1, MetricType: prometheus.GaugeValue,
+				},
+				{
+					FqName: "cloudcost_gcp_gce_instance_total_usd_per_hour",
+					Labels: map[string]string{
+						"family": "n1", "instance": "standalone-n1", "machine_type": "n1-slim",
+						"price_tier": "ondemand", "project": "testing", "region": "us-central1",
+					},
+					Value: 6, MetricType: prometheus.GaugeValue,
+				},
+				{
+					FqName: "cloudcost_gcp_gce_instance_cpu_usd_per_core_hour",
+					Labels: map[string]string{
+						"family": "n1", "instance": "standalone-n1-spot", "machine_type": "n1-slim",
+						"price_tier": "spot", "project": "testing", "region": "us-central1",
+					},
+					Value: 1, MetricType: prometheus.GaugeValue,
+				},
+				{
+					FqName: "cloudcost_gcp_gce_instance_memory_usd_per_gib_hour",
+					Labels: map[string]string{
+						"family": "n1", "instance": "standalone-n1-spot", "machine_type": "n1-slim",
+						"price_tier": "spot", "project": "testing", "region": "us-central1",
+					},
+					Value: 1, MetricType: prometheus.GaugeValue,
+				},
+				{
+					FqName: "cloudcost_gcp_gce_instance_total_usd_per_hour",
+					Labels: map[string]string{
+						"family": "n1", "instance": "standalone-n1-spot", "machine_type": "n1-slim",
+						"price_tier": "spot", "project": "testing", "region": "us-central1",
+					},
+					Value: 6, MetricType: prometheus.GaugeValue,
+				},
+			},
+		},
+		"Machine type lookup failure suppresses only the total metric": {
+			config:     &Config{Projects: "testing"},
+			testServer: httptest.NewServer(computeHandler(false)),
+			expectedMetrics: []*utils.MetricResult{
+				{
+					FqName: "cloudcost_gcp_gce_instance_cpu_usd_per_core_hour",
+					Labels: map[string]string{
+						"family": "n1", "instance": "standalone-n1", "machine_type": "n1-slim",
+						"price_tier": "ondemand", "project": "testing", "region": "us-central1",
+					},
+					Value: 1, MetricType: prometheus.GaugeValue,
+				},
+				{
+					FqName: "cloudcost_gcp_gce_instance_memory_usd_per_gib_hour",
+					Labels: map[string]string{
+						"family": "n1", "instance": "standalone-n1", "machine_type": "n1-slim",
+						"price_tier": "ondemand", "project": "testing", "region": "us-central1",
+					},
+					Value: 1, MetricType: prometheus.GaugeValue,
+				},
+				{
+					FqName: "cloudcost_gcp_gce_instance_cpu_usd_per_core_hour",
+					Labels: map[string]string{
+						"family": "n1", "instance": "standalone-n1-spot", "machine_type": "n1-slim",
+						"price_tier": "spot", "project": "testing", "region": "us-central1",
+					},
+					Value: 1, MetricType: prometheus.GaugeValue,
+				},
+				{
+					FqName: "cloudcost_gcp_gce_instance_memory_usd_per_gib_hour",
+					Labels: map[string]string{
+						"family": "n1", "instance": "standalone-n1-spot", "machine_type": "n1-slim",
+						"price_tier": "spot", "project": "testing", "region": "us-central1",
+					},
+					Value: 1, MetricType: prometheus.GaugeValue,
+				},
+			},
+		},
+		"Empty node store emits no metrics": {
+			config: &Config{Projects: "testing"},
+			testServer: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var buf interface{}
+				switch r.URL.Path {
+				case "/projects/testing/zones/us-central1-a/instances":
+					buf = &computev1.InstanceList{}
+				case "/projects/testing/zones":
+					buf = &computev1.ZoneList{Items: []*computev1.Zone{{Name: "us-central1-a"}}}
+				}
+				_ = json.NewEncoder(w).Encode(buf)
+			})),
+			expectedMetrics: []*utils.MetricResult{},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			computeService, err := computev1.NewService(t.Context(), option.WithoutAuthentication(), option.WithEndpoint(test.testServer.URL))
+			require.NoError(t, err)
+			l, err := net.Listen("tcp", "localhost:0")
+			require.NoError(t, err)
+			gsrv := grpc.NewServer()
+			defer gsrv.Stop()
+			billingpb.RegisterCloudCatalogServer(gsrv, &client.FakeCloudCatalogServer{})
+			go func() {
+				_ = gsrv.Serve(l)
+			}()
+
+			cloudCatalogClient, err := billingv1.NewCloudCatalogClient(t.Context(),
+				option.WithEndpoint(l.Addr().String()),
+				option.WithoutAuthentication(),
+				option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+			)
+			require.NoError(t, err)
+
+			gcpClient := client.NewMock("testing", 0, nil, nil, cloudCatalogClient, computeService, nil, nil)
+			collector, err := New(t.Context(), test.config, logger, gcpClient)
+			require.NoError(t, err)
+			require.NotNil(t, collector)
+
+			// Wait for the background stores to complete their initial population
+			// before collecting, same convention as gke's test suite.
+			<-collector.nodeStore.Done()
+			<-collector.machineTypes.Done()
+
+			ch := make(chan prometheus.Metric)
+			go func() {
+				require.NoError(t, collector.Collect(t.Context(), ch))
+				close(ch)
+			}()
+
+			var metrics []*utils.MetricResult
+			for metric := range ch {
+				metrics = append(metrics, utils.ReadMetrics(metric))
+			}
+			if len(metrics) == 0 {
+				return
+			}
+			assert.ElementsMatch(t, metrics, test.expectedMetrics)
+		})
+	}
+}
+
+func TestCollector_Name(t *testing.T) {
+	c := &Collector{}
+	assert.Equal(t, "gcp_gce", c.Name())
+}
+
+func TestCollector_Describe(t *testing.T) {
+	c := &Collector{}
+	ch := make(chan *prometheus.Desc, 3)
+	require.NoError(t, c.Describe(ch))
+	close(ch)
+	var descs []*prometheus.Desc
+	for d := range ch {
+		descs = append(descs, d)
+	}
+	assert.Len(t, descs, 3)
+}

--- a/pkg/google/gce/gce_test.go
+++ b/pkg/google/gce/gce_test.go
@@ -90,6 +90,7 @@ func TestCollector_Collect(t *testing.T) {
 		config          *Config
 		testServer      *httptest.Server
 		expectedMetrics []*utils.MetricResult
+		expectErr       bool
 	}{
 		"Handle http error": {
 			config: &Config{Projects: "testing"},
@@ -97,6 +98,7 @@ func TestCollector_Collect(t *testing.T) {
 				w.WriteHeader(http.StatusInternalServerError)
 			})),
 			expectedMetrics: []*utils.MetricResult{},
+			expectErr:       true,
 		},
 		"Excludes GKE nodes, prices standalone VMs, skips unpriced machine types": {
 			config:     &Config{Projects: "testing"},
@@ -238,7 +240,12 @@ func TestCollector_Collect(t *testing.T) {
 
 			ch := make(chan prometheus.Metric)
 			go func() {
-				require.NoError(t, collector.Collect(t.Context(), ch))
+				collectErr := collector.Collect(t.Context(), ch)
+				if test.expectErr {
+					assert.Error(t, collectErr)
+				} else {
+					assert.NoError(t, collectErr)
+				}
 				close(ch)
 			}()
 

--- a/pkg/google/gce/machine_type_cache.go
+++ b/pkg/google/gce/machine_type_cache.go
@@ -1,0 +1,134 @@
+package gce
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/grafana/cloudcost-exporter/pkg/google/client"
+	"github.com/grafana/cloudcost-exporter/pkg/google/gke"
+)
+
+// errNilMachineType guards against a client returning a nil *compute.MachineType
+// alongside a nil error, which would otherwise panic on field access below.
+var errNilMachineType = errors.New("machine type response was nil")
+
+// machineTypeSpec is the subset of a GCE machine type's spec needed to turn
+// per-core/per-GiB rates into a total hourly cost.
+type machineTypeSpec struct {
+	VCPU      int64
+	MemoryGiB float64
+}
+
+// machineTypeCache resolves (project, zone, machine type) tuples to their vCPU/memory
+// spec, warmed in the background so Collect never makes a live GCP call. A machine
+// type's spec is immutable for a given zone, so entries are cached indefinitely; a
+// fetch failure just leaves the key uncached for the next warm to retry.
+type machineTypeCache struct {
+	gcpClient      client.Client
+	populateErrors *prometheus.CounterVec
+	concurrency    int
+	logger         *slog.Logger
+
+	mu    sync.RWMutex
+	specs map[string]machineTypeSpec
+
+	initialWarmOnce sync.Once
+	initialWarm     chan struct{}
+}
+
+func newMachineTypeCache(gcpClient client.Client, populateErrors *prometheus.CounterVec, concurrency int, logger *slog.Logger) *machineTypeCache {
+	if concurrency <= 0 {
+		concurrency = gke.DefaultZoneCollectConcurrency
+	}
+	return &machineTypeCache{
+		gcpClient:      gcpClient,
+		populateErrors: populateErrors,
+		concurrency:    concurrency,
+		logger:         logger.With("store", "machine_types"),
+		specs:          make(map[string]machineTypeSpec),
+		initialWarm:    make(chan struct{}),
+	}
+}
+
+// Done closes once the first call to warm has finished, mirroring
+// gke.NodeStore.Done(). It doesn't guarantee every key resolved, only that
+// the initial attempt completed, same semantics as the node store.
+func (c *machineTypeCache) Done() <-chan struct{} {
+	return c.initialWarm
+}
+
+func machineTypeCacheKey(project, zone, machineType string) string {
+	return project + "/" + zone + "/" + machineType
+}
+
+// get returns the cached spec for a machine type, if resolved.
+func (c *machineTypeCache) get(project, zone, machineType string) (machineTypeSpec, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	spec, ok := c.specs[machineTypeCacheKey(project, zone, machineType)]
+	return spec, ok
+}
+
+type machineTypeKey struct {
+	project, zone, machineType string
+}
+
+// warm fetches specs for any (project, zone, machine type) tuple present in nodeStore
+// that isn't already cached, capped at c.concurrency in-flight calls.
+func (c *machineTypeCache) warm(ctx context.Context, nodeStore *gke.NodeStore, projects []string) {
+	defer c.initialWarmOnce.Do(func() { close(c.initialWarm) })
+
+	seen := make(map[machineTypeKey]struct{})
+	var missing []machineTypeKey
+	for _, project := range projects {
+		for _, instance := range nodeStore.GetNodes(project) {
+			k := machineTypeKey{project, instance.Zone, instance.MachineType}
+			if _, ok := seen[k]; ok {
+				continue
+			}
+			seen[k] = struct{}{}
+			if _, cached := c.get(k.project, k.zone, k.machineType); !cached {
+				missing = append(missing, k)
+			}
+		}
+	}
+
+	var eg errgroup.Group
+	eg.SetLimit(c.concurrency)
+	for _, k := range missing {
+		if ctx.Err() != nil {
+			break
+		}
+		eg.Go(func() error {
+			if ctx.Err() != nil {
+				return nil
+			}
+			mt, err := c.gcpClient.GetMachineType(k.project, k.zone, k.machineType)
+			if err == nil && mt == nil {
+				err = errNilMachineType
+			}
+			if err != nil {
+				c.logger.LogAttrs(ctx, slog.LevelError, "failed to get machine type",
+					slog.String("project", k.project),
+					slog.String("zone", k.zone),
+					slog.String("machine_type", k.machineType),
+					slog.String("error", err.Error()))
+				c.populateErrors.WithLabelValues("machine_types", k.project, "get_machine_type").Inc()
+				return nil
+			}
+			c.mu.Lock()
+			c.specs[machineTypeCacheKey(k.project, k.zone, k.machineType)] = machineTypeSpec{
+				VCPU:      mt.GuestCpus,
+				MemoryGiB: float64(mt.MemoryMb) / 1024,
+			}
+			c.mu.Unlock()
+			return nil
+		})
+	}
+	eg.Wait()
+}

--- a/pkg/google/gce/machine_type_cache.go
+++ b/pkg/google/gce/machine_type_cache.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sync/errgroup"
@@ -16,6 +17,11 @@ import (
 // errNilMachineType guards against a client returning a nil *compute.MachineType
 // alongside a nil error, which would otherwise panic on field access below.
 var errNilMachineType = errors.New("machine type response was nil")
+
+// errIncompleteMachineType guards against a client returning a *compute.MachineType
+// with a non-positive vCPU or memory value, which would otherwise be cached as a
+// valid spec and silently zero out part of the total cost metric.
+var errIncompleteMachineType = errors.New("machine type response has non-positive vCPU or memory")
 
 // machineTypeSpec is the subset of a GCE machine type's spec needed to turn
 // per-core/per-GiB rates into a total hourly cost.
@@ -35,7 +41,9 @@ type machineTypeCache struct {
 	logger         *slog.Logger
 
 	mu    sync.RWMutex
-	specs map[string]machineTypeSpec
+	specs map[machineTypeKey]machineTypeSpec
+
+	warming atomic.Bool
 
 	initialWarmOnce sync.Once
 	initialWarm     chan struct{}
@@ -50,7 +58,7 @@ func newMachineTypeCache(gcpClient client.Client, populateErrors *prometheus.Cou
 		populateErrors: populateErrors,
 		concurrency:    concurrency,
 		logger:         logger.With("store", "machine_types"),
-		specs:          make(map[string]machineTypeSpec),
+		specs:          make(map[machineTypeKey]machineTypeSpec),
 		initialWarm:    make(chan struct{}),
 	}
 }
@@ -62,25 +70,30 @@ func (c *machineTypeCache) Done() <-chan struct{} {
 	return c.initialWarm
 }
 
-func machineTypeCacheKey(project, zone, machineType string) string {
-	return project + "/" + zone + "/" + machineType
+type machineTypeKey struct {
+	project, zone, machineType string
 }
 
 // get returns the cached spec for a machine type, if resolved.
 func (c *machineTypeCache) get(project, zone, machineType string) (machineTypeSpec, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	spec, ok := c.specs[machineTypeCacheKey(project, zone, machineType)]
+	spec, ok := c.specs[machineTypeKey{project, zone, machineType}]
 	return spec, ok
 }
 
-type machineTypeKey struct {
-	project, zone, machineType string
-}
-
 // warm fetches specs for any (project, zone, machine type) tuple present in nodeStore
-// that isn't already cached, capped at c.concurrency in-flight calls.
+// that isn't already cached, capped at c.concurrency in-flight calls. Concurrent calls
+// to warm are dropped: if a tick fires while a previous warm is still running, running
+// a second pass would only duplicate in-flight GetMachineType calls against the same
+// missing set.
 func (c *machineTypeCache) warm(ctx context.Context, nodeStore *gke.NodeStore, projects []string) {
+	if !c.warming.CompareAndSwap(false, true) {
+		c.logger.LogAttrs(ctx, slog.LevelInfo, "warm already in progress, skipping tick")
+		return
+	}
+	defer c.warming.Store(false)
+
 	defer c.initialWarmOnce.Do(func() { close(c.initialWarm) })
 
 	seen := make(map[machineTypeKey]struct{})
@@ -108,9 +121,12 @@ func (c *machineTypeCache) warm(ctx context.Context, nodeStore *gke.NodeStore, p
 			if ctx.Err() != nil {
 				return nil
 			}
-			mt, err := c.gcpClient.GetMachineType(k.project, k.zone, k.machineType)
+			mt, err := c.gcpClient.GetMachineType(ctx, k.project, k.zone, k.machineType)
 			if err == nil && mt == nil {
 				err = errNilMachineType
+			}
+			if err == nil && (mt.GuestCpus <= 0 || mt.MemoryMb <= 0) {
+				err = errIncompleteMachineType
 			}
 			if err != nil {
 				c.logger.LogAttrs(ctx, slog.LevelError, "failed to get machine type",
@@ -122,7 +138,7 @@ func (c *machineTypeCache) warm(ctx context.Context, nodeStore *gke.NodeStore, p
 				return nil
 			}
 			c.mu.Lock()
-			c.specs[machineTypeCacheKey(k.project, k.zone, k.machineType)] = machineTypeSpec{
+			c.specs[k] = machineTypeSpec{
 				VCPU:      mt.GuestCpus,
 				MemoryGiB: float64(mt.MemoryMb) / 1024,
 			}

--- a/pkg/google/gce/machine_type_cache_test.go
+++ b/pkg/google/gce/machine_type_cache_test.go
@@ -1,6 +1,7 @@
 package gce
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"os"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/grafana/cloudcost-exporter/pkg/google/client"
 	"github.com/grafana/cloudcost-exporter/pkg/google/gke"
+	"github.com/grafana/cloudcost-exporter/pkg/google/storeutil"
 )
 
 var cacheTestLogger = slog.New(slog.NewTextHandler(os.Stdout, nil))
@@ -45,7 +47,7 @@ func newTestNodeStore(t *testing.T, instances []*computev1.Instance) *gke.NodeSt
 		zones:     []*computev1.Zone{{Name: "us-central1-a"}},
 		instances: instances,
 	}
-	populateErrors := newPopulateErrorsCounter()
+	populateErrors := storeutil.NewPopulateErrorsCounter(subsystem)
 	ns := gke.NewNodeStore(t.Context(), cacheTestLogger, fakeClient, []string{"testing"}, 5, populateErrors)
 	<-ns.Done()
 	return ns
@@ -58,21 +60,21 @@ type fakeMachineTypeClient struct {
 	client.Client
 
 	mu                 sync.Mutex
-	failuresRemaining  map[string]int
-	calls              map[string]int
+	failuresRemaining  map[machineTypeKey]int
+	calls              map[machineTypeKey]int
 	currentConcurrency int
 	peakConcurrency    int
 }
 
-func newFakeMachineTypeClient(failuresRemaining map[string]int) *fakeMachineTypeClient {
+func newFakeMachineTypeClient(failuresRemaining map[machineTypeKey]int) *fakeMachineTypeClient {
 	return &fakeMachineTypeClient{
 		failuresRemaining: failuresRemaining,
-		calls:             map[string]int{},
+		calls:             map[machineTypeKey]int{},
 	}
 }
 
-func (f *fakeMachineTypeClient) GetMachineType(project, zone, machineType string) (*computev1.MachineType, error) {
-	key := machineTypeCacheKey(project, zone, machineType)
+func (f *fakeMachineTypeClient) GetMachineType(_ context.Context, project, zone, machineType string) (*computev1.MachineType, error) {
+	key := machineTypeKey{project, zone, machineType}
 
 	f.mu.Lock()
 	f.calls[key]++
@@ -99,7 +101,7 @@ func (f *fakeMachineTypeClient) GetMachineType(project, zone, machineType string
 }
 
 func newTestCache(gcpClient client.Client, concurrency int) *machineTypeCache {
-	return newMachineTypeCache(gcpClient, newPopulateErrorsCounter(), concurrency, cacheTestLogger)
+	return newMachineTypeCache(gcpClient, storeutil.NewPopulateErrorsCounter(subsystem), concurrency, cacheTestLogger)
 }
 
 func TestMachineTypeCache_GetHitMiss(t *testing.T) {
@@ -109,7 +111,7 @@ func TestMachineTypeCache_GetHitMiss(t *testing.T) {
 	assert.False(t, ok, "expected a miss before warming")
 
 	cache.mu.Lock()
-	cache.specs[machineTypeCacheKey("proj", "us-central1-a", "n1-standard-1")] = machineTypeSpec{VCPU: 1, MemoryGiB: 3.75}
+	cache.specs[machineTypeKey{"proj", "us-central1-a", "n1-standard-1"}] = machineTypeSpec{VCPU: 1, MemoryGiB: 3.75}
 	cache.mu.Unlock()
 
 	spec, ok := cache.get("proj", "us-central1-a", "n1-standard-1")
@@ -148,8 +150,8 @@ func TestMachineTypeCache_Warm_RetriesPreviouslyFailedKeys(t *testing.T) {
 		{Name: "a", MachineType: "abc/n1-slim", Zone: "testing/us-central1-a", Scheduling: &computev1.Scheduling{}},
 	}
 	nodeStore := newTestNodeStore(t, instances)
-	key := machineTypeCacheKey("testing", "us-central1-a", "n1-slim")
-	gcpClient := newFakeMachineTypeClient(map[string]int{key: 1}) // fails once, then succeeds
+	key := machineTypeKey{"testing", "us-central1-a", "n1-slim"}
+	gcpClient := newFakeMachineTypeClient(map[machineTypeKey]int{key: 1}) // fails once, then succeeds
 	cache := newTestCache(gcpClient, 5)
 
 	cache.warm(t.Context(), nodeStore, []string{"testing"})
@@ -186,7 +188,7 @@ func TestMachineTypeCache_Warm_RespectsConcurrencyLimit(t *testing.T) {
 }
 
 func TestCollector_Register(t *testing.T) {
-	c := &Collector{populateErrors: newPopulateErrorsCounter()}
+	c := &Collector{populateErrors: storeutil.NewPopulateErrorsCounter(subsystem)}
 	registry := prometheus.NewRegistry()
 	require.NoError(t, c.Register(registry))
 }

--- a/pkg/google/gce/machine_type_cache_test.go
+++ b/pkg/google/gce/machine_type_cache_test.go
@@ -1,0 +1,192 @@
+package gce
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	computev1 "google.golang.org/api/compute/v1"
+
+	"github.com/grafana/cloudcost-exporter/pkg/google/client"
+	"github.com/grafana/cloudcost-exporter/pkg/google/gke"
+)
+
+var cacheTestLogger = slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+// fakeNodeStoreClient provides a fixed set of zones/instances so a real
+// gke.NodeStore can be populated without hitting a live GCP API.
+type fakeNodeStoreClient struct {
+	client.Client
+	zones     []*computev1.Zone
+	instances []*computev1.Instance
+}
+
+func (f *fakeNodeStoreClient) GetZones(string) ([]*computev1.Zone, error) {
+	return f.zones, nil
+}
+
+func (f *fakeNodeStoreClient) ListInstancesInZone(string, string) ([]*client.MachineSpec, error) {
+	specs := make([]*client.MachineSpec, len(f.instances))
+	for i, inst := range f.instances {
+		specs[i] = client.NewMachineSpec(inst)
+	}
+	return specs, nil
+}
+
+func newTestNodeStore(t *testing.T, instances []*computev1.Instance) *gke.NodeStore {
+	t.Helper()
+	fakeClient := &fakeNodeStoreClient{
+		zones:     []*computev1.Zone{{Name: "us-central1-a"}},
+		instances: instances,
+	}
+	populateErrors := newPopulateErrorsCounter()
+	ns := gke.NewNodeStore(t.Context(), cacheTestLogger, fakeClient, []string{"testing"}, 5, populateErrors)
+	<-ns.Done()
+	return ns
+}
+
+// fakeMachineTypeClient controls GetMachineType behavior per (project, zone,
+// machineType) key: configurable failure count before success, plus
+// concurrency tracking.
+type fakeMachineTypeClient struct {
+	client.Client
+
+	mu                 sync.Mutex
+	failuresRemaining  map[string]int
+	calls              map[string]int
+	currentConcurrency int
+	peakConcurrency    int
+}
+
+func newFakeMachineTypeClient(failuresRemaining map[string]int) *fakeMachineTypeClient {
+	return &fakeMachineTypeClient{
+		failuresRemaining: failuresRemaining,
+		calls:             map[string]int{},
+	}
+}
+
+func (f *fakeMachineTypeClient) GetMachineType(project, zone, machineType string) (*computev1.MachineType, error) {
+	key := machineTypeCacheKey(project, zone, machineType)
+
+	f.mu.Lock()
+	f.calls[key]++
+	f.currentConcurrency++
+	if f.currentConcurrency > f.peakConcurrency {
+		f.peakConcurrency = f.currentConcurrency
+	}
+	f.mu.Unlock()
+
+	time.Sleep(5 * time.Millisecond)
+
+	f.mu.Lock()
+	f.currentConcurrency--
+	remaining := f.failuresRemaining[key]
+	if remaining > 0 {
+		f.failuresRemaining[key] = remaining - 1
+	}
+	f.mu.Unlock()
+
+	if remaining > 0 {
+		return nil, errors.New("transient error")
+	}
+	return &computev1.MachineType{GuestCpus: 4, MemoryMb: 8192}, nil
+}
+
+func newTestCache(gcpClient client.Client, concurrency int) *machineTypeCache {
+	return newMachineTypeCache(gcpClient, newPopulateErrorsCounter(), concurrency, cacheTestLogger)
+}
+
+func TestMachineTypeCache_GetHitMiss(t *testing.T) {
+	cache := newTestCache(newFakeMachineTypeClient(nil), 5)
+
+	_, ok := cache.get("proj", "us-central1-a", "n1-standard-1")
+	assert.False(t, ok, "expected a miss before warming")
+
+	cache.mu.Lock()
+	cache.specs[machineTypeCacheKey("proj", "us-central1-a", "n1-standard-1")] = machineTypeSpec{VCPU: 1, MemoryGiB: 3.75}
+	cache.mu.Unlock()
+
+	spec, ok := cache.get("proj", "us-central1-a", "n1-standard-1")
+	require.True(t, ok)
+	assert.Equal(t, machineTypeSpec{VCPU: 1, MemoryGiB: 3.75}, spec)
+}
+
+func TestMachineTypeCache_Warm_PopulatesFromNodeStore(t *testing.T) {
+	instances := []*computev1.Instance{
+		{Name: "a", MachineType: "abc/n1-slim", Zone: "testing/us-central1-a", Scheduling: &computev1.Scheduling{}},
+		{Name: "b", MachineType: "abc/n2-slim", Zone: "testing/us-central1-a", Scheduling: &computev1.Scheduling{}},
+	}
+	nodeStore := newTestNodeStore(t, instances)
+	gcpClient := newFakeMachineTypeClient(nil)
+	cache := newTestCache(gcpClient, 5)
+
+	cache.warm(t.Context(), nodeStore, []string{"testing"})
+
+	spec, ok := cache.get("testing", "us-central1-a", "n1-slim")
+	require.True(t, ok)
+	assert.Equal(t, machineTypeSpec{VCPU: 4, MemoryGiB: 8}, spec)
+
+	spec, ok = cache.get("testing", "us-central1-a", "n2-slim")
+	require.True(t, ok)
+	assert.Equal(t, machineTypeSpec{VCPU: 4, MemoryGiB: 8}, spec)
+
+	select {
+	case <-cache.Done():
+	default:
+		t.Fatal("expected Done() to be closed after the first warm")
+	}
+}
+
+func TestMachineTypeCache_Warm_RetriesPreviouslyFailedKeys(t *testing.T) {
+	instances := []*computev1.Instance{
+		{Name: "a", MachineType: "abc/n1-slim", Zone: "testing/us-central1-a", Scheduling: &computev1.Scheduling{}},
+	}
+	nodeStore := newTestNodeStore(t, instances)
+	key := machineTypeCacheKey("testing", "us-central1-a", "n1-slim")
+	gcpClient := newFakeMachineTypeClient(map[string]int{key: 1}) // fails once, then succeeds
+	cache := newTestCache(gcpClient, 5)
+
+	cache.warm(t.Context(), nodeStore, []string{"testing"})
+	_, ok := cache.get("testing", "us-central1-a", "n1-slim")
+	assert.False(t, ok, "expected the key to remain uncached after a failed attempt")
+
+	cache.warm(t.Context(), nodeStore, []string{"testing"})
+	spec, ok := cache.get("testing", "us-central1-a", "n1-slim")
+	require.True(t, ok, "expected the retried key to resolve on the next warm")
+	assert.Equal(t, machineTypeSpec{VCPU: 4, MemoryGiB: 8}, spec)
+}
+
+func TestMachineTypeCache_Warm_RespectsConcurrencyLimit(t *testing.T) {
+	var instances []*computev1.Instance
+	for i := 0; i < 10; i++ {
+		instances = append(instances, &computev1.Instance{
+			Name:        "instance",
+			MachineType: "abc/machine-" + string(rune('a'+i)),
+			Zone:        "testing/us-central1-a",
+			Scheduling:  &computev1.Scheduling{},
+		})
+	}
+	nodeStore := newTestNodeStore(t, instances)
+	gcpClient := newFakeMachineTypeClient(nil)
+	const concurrency = 3
+	cache := newTestCache(gcpClient, concurrency)
+
+	cache.warm(t.Context(), nodeStore, []string{"testing"})
+
+	gcpClient.mu.Lock()
+	peak := gcpClient.peakConcurrency
+	gcpClient.mu.Unlock()
+	assert.LessOrEqual(t, peak, concurrency)
+}
+
+func TestCollector_Register(t *testing.T) {
+	c := &Collector{populateErrors: newPopulateErrorsCounter()}
+	registry := prometheus.NewRegistry()
+	require.NoError(t, c.Register(registry))
+}

--- a/pkg/google/gcp.go
+++ b/pkg/google/gcp.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	cloudcost_exporter "github.com/grafana/cloudcost-exporter"
+	"github.com/grafana/cloudcost-exporter/pkg/google/gce"
 	"github.com/grafana/cloudcost-exporter/pkg/google/gcs"
 	"github.com/grafana/cloudcost-exporter/pkg/google/gke"
 	"github.com/grafana/cloudcost-exporter/pkg/google/vertex"
@@ -35,6 +36,7 @@ const (
 	// GCP service names used by -gcp.services.
 	serviceGCS          = "GCS"
 	serviceGKE          = "GKE"
+	serviceGCE          = "GCE"
 	serviceCLB          = "CLB"
 	serviceVPC          = "VPC"
 	serviceSQL          = "SQL"
@@ -49,6 +51,7 @@ const (
 func Services() []provider.ServiceInfo {
 	return []provider.ServiceInfo{
 		{Name: serviceGKE, DisplayName: "GKE", Description: "Google Kubernetes Engine clusters"},
+		{Name: serviceGCE, DisplayName: "GCE", Description: "Standalone Google Compute Engine VMs (excludes GKE-managed nodes)"},
 		{Name: serviceGCS, DisplayName: "GCS", Description: "Google Cloud Storage buckets"},
 		{Name: serviceSQL, DisplayName: "Cloud SQL", Description: "Managed database instances"},
 		{Name: serviceManagedKafka, DisplayName: "Managed Kafka", Description: "Managed Service for Apache Kafka clusters", Aliases: []string{serviceKafkaAlias}},
@@ -99,6 +102,9 @@ type Config struct {
 	// GKEZoneConcurrency caps zone-level goroutines per project during a GKE scrape.
 	// Zero or negative values fall back to gke.DefaultZoneCollectConcurrency.
 	GKEZoneConcurrency int
+	// GCEZoneConcurrency caps zone-level goroutines per project during a GCE scrape.
+	// Zero or negative values fall back to gke.DefaultZoneCollectConcurrency.
+	GCEZoneConcurrency int
 	// VertexFamilyFilter is a regex matched against the Vertex model family label; only matching
 	// families are emitted. Mirrors --aws.bedrock.families. Empty or ".*" emits all families.
 	VertexFamilyFilter string
@@ -160,6 +166,18 @@ func New(ctx context.Context, config *Config) (*GCP, error) {
 				Projects:        config.Projects,
 				ScrapeInterval:  config.ScrapeInterval,
 				ZoneConcurrency: config.GKEZoneConcurrency,
+			}, logger, gcpClient)
+			if err != nil {
+				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",
+					slog.String("service", service),
+					slog.String("message", err.Error()))
+				continue
+			}
+		case serviceGCE:
+			collector, err = gce.New(ctx, &gce.Config{
+				Projects:        config.Projects,
+				ScrapeInterval:  config.ScrapeInterval,
+				ZoneConcurrency: config.GCEZoneConcurrency,
 			}, logger, gcpClient)
 			if err != nil {
 				logger.LogAttrs(ctx, slog.LevelError, "Error creating collector",

--- a/pkg/google/gcp_test.go
+++ b/pkg/google/gcp_test.go
@@ -246,7 +246,7 @@ func TestGCP_CollectMetrics(t *testing.T) {
 func TestServices(t *testing.T) {
 	got := Services()
 	wantNames := []string{
-		serviceGCS, serviceGKE, serviceCLB, serviceVPC,
+		serviceGCS, serviceGKE, serviceGCE, serviceCLB, serviceVPC,
 		serviceSQL, serviceManagedKafka, serviceVertex,
 	}
 	gotNames := make([]string, 0, len(got))

--- a/pkg/google/gke/gke.go
+++ b/pkg/google/gke/gke.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/grafana/cloudcost-exporter/pkg/google/client"
+	"github.com/grafana/cloudcost-exporter/pkg/google/storeutil"
 	"github.com/grafana/cloudcost-exporter/pkg/utils"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -27,16 +28,6 @@ const (
 	// Override via Config.ZoneConcurrency to trade burst rate for scrape latency.
 	DefaultZoneCollectConcurrency = 10
 )
-
-func newPopulateErrorsCounter() *prometheus.CounterVec {
-	return prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: prometheus.BuildFQName(cloudcostexporter.ExporterName, subsystem, "populate_errors_total"),
-			Help: "Total errors during background store population, by store, project, and operation.",
-		},
-		[]string{"store", "project", "operation"},
-	)
-}
 
 var (
 	gkeNodeMemoryHourlyCostDesc = utils.GenerateDesc(
@@ -178,17 +169,17 @@ func New(ctx context.Context, config *Config, logger *slog.Logger, gcpClient cli
 	projects := strings.Split(config.Projects, ",")
 	regions := client.RegionsFromZonesForProjects(gcpClient, projects, logger)
 
-	populateErrors := newPopulateErrorsCounter()
+	populateErrors := storeutil.NewPopulateErrorsCounter(subsystem)
 	nodeStore := NewNodeStore(ctx, logger, gcpClient, projects, config.ZoneConcurrency, populateErrors)
 	diskStore := NewDiskStore(ctx, logger, gcpClient, projects, config.ZoneConcurrency, populateErrors)
 
-	startRefreshTicker(ctx, PriceRefreshInterval, func() {
+	storeutil.StartRefreshTicker(ctx, PriceRefreshInterval, func() {
 		if err := pm.Populate(ctx); err != nil {
 			logger.Error(err.Error())
 		}
 	})
-	startRefreshTicker(ctx, nodeRefreshInterval, func() { nodeStore.Populate(ctx) })
-	startRefreshTicker(ctx, diskRefreshInterval, func() { diskStore.Populate(ctx) })
+	storeutil.StartRefreshTicker(ctx, nodeRefreshInterval, func() { nodeStore.Populate(ctx) })
+	storeutil.StartRefreshTicker(ctx, diskRefreshInterval, func() { diskStore.Populate(ctx) })
 
 	return &Collector{
 		projects:       projects,
@@ -199,21 +190,6 @@ func New(ctx context.Context, config *Config, logger *slog.Logger, gcpClient cli
 		diskStore:      diskStore,
 		populateErrors: populateErrors,
 	}, nil
-}
-
-func startRefreshTicker(ctx context.Context, interval time.Duration, run func()) {
-	go func() {
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				run()
-			}
-		}
-	}()
 }
 
 func (c *Collector) Regions() []string {

--- a/pkg/google/gke/gke_test.go
+++ b/pkg/google/gke/gke_test.go
@@ -19,6 +19,7 @@ import (
 	billingv1 "cloud.google.com/go/billing/apiv1"
 	"cloud.google.com/go/billing/apiv1/billingpb"
 	"github.com/grafana/cloudcost-exporter/pkg/google/client"
+	"github.com/grafana/cloudcost-exporter/pkg/google/storeutil"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
@@ -557,7 +558,7 @@ func (c *concurrentGCPClient) ListDisks(_ context.Context, _ string, _ string) (
 }
 
 func testPopulateErrorsCounter() *prometheus.CounterVec {
-	return newPopulateErrorsCounter()
+	return storeutil.NewPopulateErrorsCounter(subsystem)
 }
 
 // newSeededNodeStore returns a NodeStore without starting a populate goroutine.
@@ -573,7 +574,7 @@ func newSeededNodeStore(t *testing.T, lgr *slog.Logger, gcpClient client.Client,
 		seed = make(map[string]map[string][]*client.MachineSpec)
 	}
 	if counter == nil {
-		counter = newPopulateErrorsCounter()
+		counter = storeutil.NewPopulateErrorsCounter(subsystem)
 	}
 	return &NodeStore{
 		logger:            lgr.With("store", "nodes"),
@@ -595,7 +596,7 @@ func newSeededDiskStore(t *testing.T, lgr *slog.Logger, gcpClient client.Client,
 		seed = make(map[string]map[string][]*Disk)
 	}
 	if counter == nil {
-		counter = newPopulateErrorsCounter()
+		counter = storeutil.NewPopulateErrorsCounter(subsystem)
 	}
 	return &DiskStore{
 		logger:            lgr.With("store", "disks"),

--- a/pkg/google/gke/pricing_map.go
+++ b/pkg/google/gke/pricing_map.go
@@ -211,10 +211,15 @@ func (pm *PricingMap) GetCostOfStorage(region, storageClass string) (*StoragePri
 	if _, ok := pm.storage[region]; !ok {
 		return nil, fmt.Errorf("%w: %s", ErrRegionNotFound, region)
 	}
-	if _, ok := pm.storage[region].Storage[storageClass]; !ok {
+	sp, ok := pm.storage[region].Storage[storageClass]
+	if !ok {
 		return nil, fmt.Errorf("%w: %s", ErrFamilyTypeNotFound, storageClass)
 	}
-	return pm.storage[region].Storage[storageClass], nil
+	// Copy out while holding the lock: this pointer would otherwise alias the
+	// same *StoragePrices that ParseSkus mutates in place on the next refresh,
+	// racing with the caller's unsynchronized reads after RUnlock.
+	prices := *sp
+	return &prices, nil
 }
 
 var (

--- a/pkg/google/gke/pricing_map.go
+++ b/pkg/google/gke/pricing_map.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"cloud.google.com/go/billing/apiv1/billingpb"
@@ -101,8 +102,11 @@ func NewPriceTiers() *PriceTiers {
 	}
 }
 
-// PricingMap is a map of regions to a map of family to price tiers
+// PricingMap is a map of regions to a map of family to price tiers.
+// compute and storage are refreshed on a ticker (see Populate) while Collect
+// reads them concurrently on every scrape, so all access must go through mu.
 type PricingMap struct {
+	mu        sync.RWMutex
 	compute   map[string]*FamilyPricing
 	storage   map[string]*StoragePricing
 	gcpClient client.Client
@@ -161,6 +165,8 @@ func NewStoragePricing() *StoragePricing {
 }
 
 func (pm *PricingMap) GetCostOfInstance(instance *client.MachineSpec) (float64, float64, error) {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
 	if len(pm.compute) == 0 || instance == nil {
 		return 0, 0, ErrRegionNotFound
 	}
@@ -197,6 +203,8 @@ func computeDiskCost(d *Disk, p *StoragePrices) float64 {
 }
 
 func (pm *PricingMap) GetCostOfStorage(region, storageClass string) (*StoragePrices, error) {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
 	if len(pm.storage) == 0 {
 		return nil, ErrRegionNotFound
 	}
@@ -239,6 +247,8 @@ func (pm *PricingMap) Populate(ctx context.Context) error {
 
 // ParseSkus accepts a list of skus, parses their content, and updates the pricing map with the appropriate costs.
 func (pm *PricingMap) ParseSkus(skus []*billingpb.Sku) error {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
 	for _, sku := range skus {
 		rawData, err := getDataFromSku(sku)
 		if errors.Is(err, ErrSkuNotRelevant) {

--- a/pkg/google/gke/pricing_map_test.go
+++ b/pkg/google/gke/pricing_map_test.go
@@ -20,7 +20,7 @@ import (
 func TestStructuredPricingMap_GetCostOfInstance(t *testing.T) {
 	for _, tc := range []struct {
 		name             string
-		pm               PricingMap
+		pm               *PricingMap
 		ms               *client.MachineSpec
 		expectedCPUPrice float64
 		expectedRAMPRice float64
@@ -28,28 +28,29 @@ func TestStructuredPricingMap_GetCostOfInstance(t *testing.T) {
 	}{
 		{
 			name:          "regions is nil",
+			pm:            &PricingMap{},
 			expectedError: ErrRegionNotFound,
 		},
 		{
 			name:          "nil machine spec",
-			pm:            PricingMap{compute: map[string]*FamilyPricing{"": {}}},
+			pm:            &PricingMap{compute: map[string]*FamilyPricing{"": {}}},
 			expectedError: ErrRegionNotFound,
 		},
 		{
 			name:          "region not found",
-			pm:            PricingMap{compute: map[string]*FamilyPricing{"": {}}},
+			pm:            &PricingMap{compute: map[string]*FamilyPricing{"": {}}},
 			ms:            &client.MachineSpec{Region: "missing region"},
 			expectedError: ErrRegionNotFound,
 		},
 		{
 			name:          "family type not found",
-			pm:            PricingMap{compute: map[string]*FamilyPricing{"region": {}}},
+			pm:            &PricingMap{compute: map[string]*FamilyPricing{"region": {}}},
 			ms:            &client.MachineSpec{Region: "region"},
 			expectedError: ErrFamilyTypeNotFound,
 		},
 		{
 			name: "on-demand",
-			pm: PricingMap{
+			pm: &PricingMap{
 				compute: map[string]*FamilyPricing{
 					"region": {
 						Family: map[string]*PriceTiers{
@@ -72,7 +73,7 @@ func TestStructuredPricingMap_GetCostOfInstance(t *testing.T) {
 		},
 		{
 			name: "spot",
-			pm: PricingMap{
+			pm: &PricingMap{
 				compute: map[string]*FamilyPricing{
 					"region": {
 						Family: map[string]*PriceTiers{

--- a/pkg/google/managedkafka/managedkafka_test.go
+++ b/pkg/google/managedkafka/managedkafka_test.go
@@ -318,7 +318,7 @@ func (s *stubClient) ListInstancesInZone(string, string) ([]*client.MachineSpec,
 	return nil, nil
 }
 
-func (s *stubClient) GetMachineType(string, string, string) (*compute.MachineType, error) {
+func (s *stubClient) GetMachineType(context.Context, string, string, string) (*compute.MachineType, error) {
 	return nil, nil
 }
 

--- a/pkg/google/managedkafka/managedkafka_test.go
+++ b/pkg/google/managedkafka/managedkafka_test.go
@@ -318,6 +318,10 @@ func (s *stubClient) ListInstancesInZone(string, string) ([]*client.MachineSpec,
 	return nil, nil
 }
 
+func (s *stubClient) GetMachineType(string, string, string) (*compute.MachineType, error) {
+	return nil, nil
+}
+
 func (s *stubClient) ListDisks(context.Context, string, string) ([]*compute.Disk, error) {
 	return nil, nil
 }

--- a/pkg/google/storeutil/storeutil.go
+++ b/pkg/google/storeutil/storeutil.go
@@ -1,0 +1,41 @@
+// Package storeutil holds background-refresh helpers shared by GCP collectors
+// that maintain their own periodically-refreshed in-memory stores (gke, gce).
+package storeutil
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	cloudcostexporter "github.com/grafana/cloudcost-exporter"
+)
+
+// NewPopulateErrorsCounter returns a counter vector for tracking background
+// store population errors for the given subsystem, labeled by store,
+// project, and operation.
+func NewPopulateErrorsCounter(subsystem string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: prometheus.BuildFQName(cloudcostexporter.ExporterName, subsystem, "populate_errors_total"),
+			Help: "Total errors during background store population, by store, project, and operation.",
+		},
+		[]string{"store", "project", "operation"},
+	)
+}
+
+// StartRefreshTicker runs run on every tick of interval until ctx is done.
+func StartRefreshTicker(ctx context.Context, interval time.Duration, run func()) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				run()
+			}
+		}
+	}()
+}

--- a/pkg/google/vertex/vertex_test.go
+++ b/pkg/google/vertex/vertex_test.go
@@ -316,6 +316,10 @@ func (s *stubVertexClient) ListInstancesInZone(_ string, _ string) ([]*client.Ma
 	return nil, nil
 }
 
+func (s *stubVertexClient) GetMachineType(_, _, _ string) (*compute.MachineType, error) {
+	return nil, nil
+}
+
 func (s *stubVertexClient) ListDisks(_ context.Context, _ string, _ string) ([]*compute.Disk, error) {
 	return nil, nil
 }

--- a/pkg/google/vertex/vertex_test.go
+++ b/pkg/google/vertex/vertex_test.go
@@ -316,7 +316,7 @@ func (s *stubVertexClient) ListInstancesInZone(_ string, _ string) ([]*client.Ma
 	return nil, nil
 }
 
-func (s *stubVertexClient) GetMachineType(_, _, _ string) (*compute.MachineType, error) {
+func (s *stubVertexClient) GetMachineType(_ context.Context, _, _, _ string) (*compute.MachineType, error) {
 	return nil, nil
 }
 

--- a/pkg/google/vpc/vpc_test.go
+++ b/pkg/google/vpc/vpc_test.go
@@ -135,6 +135,10 @@ func (m *mockGCPClient) ListInstancesInZone(projectId, zone string) ([]*client.M
 	return nil, nil
 }
 
+func (m *mockGCPClient) GetMachineType(project, zone, machineType string) (*compute.MachineType, error) {
+	return nil, nil
+}
+
 func (m *mockGCPClient) ListDisks(ctx context.Context, projectId string, zone string) ([]*compute.Disk, error) {
 	return nil, nil
 }

--- a/pkg/google/vpc/vpc_test.go
+++ b/pkg/google/vpc/vpc_test.go
@@ -135,7 +135,7 @@ func (m *mockGCPClient) ListInstancesInZone(projectId, zone string) ([]*client.M
 	return nil, nil
 }
 
-func (m *mockGCPClient) GetMachineType(project, zone, machineType string) (*compute.MachineType, error) {
+func (m *mockGCPClient) GetMachineType(ctx context.Context, project, zone, machineType string) (*compute.MachineType, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
## Summary

- Adds a new `GCE` service that prices standalone Compute Engine instances (not part of a GKE cluster), reusing `pkg/google/gke`'s existing `NodeStore` and `PricingMap` rather than duplicating listing/pricing logic.
- Excludes any instance carrying the `goog-k8s-cluster-name` label, the exact complement of what `gke.go` already drops, so a node's cost is never counted by both `gcp_gke_*` and `gcp_gce_*`.
- Adds `client.Client.GetMachineType`, cached per `(project, zone, machine_type)`, to resolve vCPU/memory and compute `instance_total_usd_per_hour` alongside the existing per-core/per-GiB rate metrics.

Closes #1123.

## Test plan

- [x] `go test ./pkg/google/... -race`
- [x] `make lint`
- [x] `make generate` (no diff, `client_mock.go` is hand-written and was edited directly)
- [x] `make build-binary`
- [x] `make test`
- [x] Manual smoke test against a real GCP project (ask `@stephan-rayner` if you want the project name)

### Manual Smoke Test

Ran both `GCE` and `GKE` against the same project to check for overlap and sanity-check the numbers:

```
go run cmd/exporter/exporter.go -provider gcp -project-id=<redacted> -gcp.projects=<redacted> -gcp.services GCE
go run cmd/exporter/exporter.go -provider gcp -project-id=<redacted> -gcp.projects=<redacted> -gcp.services GKE
```

- `GCE` emitted 127 VMs across `instance_cpu_usd_per_core_hour`, `instance_memory_usd_per_gib_hour`, and `instance_total_usd_per_hour`, no populate errors.
- `GKE` emitted 571 nodes for comparison.
- No overlap: diffed the `instance` label across both scrapes and confirmed zero names appear in both, so the `goog-k8s-cluster-name` exclusion works as intended and no instance gets double-counted.
- `instance_total_usd_per_hour` lagged the cpu/memory metrics on the first scrape (40 of 127) while the machine-type cache warmed in the background, then covered all 127 on the next scrape, matching the documented tradeoff in the PR description.
